### PR TITLE
Add unit tests for Translation type

### DIFF
--- a/crates/gdsr/src/transformation/translation.rs
+++ b/crates/gdsr/src/transformation/translation.rs
@@ -32,4 +32,50 @@ mod tests {
         assert!(display_str.contains("Translation by"));
         assert!(display_str.contains("Point("));
     }
+
+    #[test]
+    fn test_translation_new() {
+        let delta = Point::integer(10, 20, 1e-9);
+        let translation = Translation::new(delta);
+        assert_eq!(translation.delta, delta);
+    }
+
+    #[test]
+    fn test_translation_apply_positive_delta() {
+        let translation = Translation::new(Point::integer(3, 7, 1e-9));
+        let point = Point::integer(10, 20, 1e-9);
+        let result = translation.apply_to_point(&point);
+        assert_eq!(result, Point::integer(13, 27, 1e-9));
+    }
+
+    #[test]
+    fn test_translation_apply_negative_delta() {
+        let translation = Translation::new(Point::integer(-5, -10, 1e-9));
+        let point = Point::integer(10, 20, 1e-9);
+        let result = translation.apply_to_point(&point);
+        assert_eq!(result, Point::integer(5, 10, 1e-9));
+    }
+
+    #[test]
+    fn test_translation_zero_delta() {
+        let translation = Translation::new(Point::integer(0, 0, 1e-9));
+        let point = Point::integer(10, 20, 1e-9);
+        let result = translation.apply_to_point(&point);
+        assert_eq!(result, point);
+    }
+
+    #[test]
+    fn test_translation_large_values() {
+        let translation = Translation::new(Point::integer(1_000_000, -1_000_000, 1e-9));
+        let point = Point::integer(500_000, 500_000, 1e-9);
+        let result = translation.apply_to_point(&point);
+        assert_eq!(result, Point::integer(1_500_000, -500_000, 1e-9));
+    }
+
+    #[test]
+    fn test_translation_clone() {
+        let translation = Translation::new(Point::integer(5, 5, 1e-9));
+        let cloned = translation.clone();
+        assert_eq!(translation, cloned);
+    }
 }


### PR DESCRIPTION
## Summary
- Add 6 unit tests for the `Translation` type covering construction, apply_to_point, zero/negative/large deltas, and clone

Closes #49

## Test plan
- [x] `cargo test -p gdsr` passes
- [x] `uvx prek run -a` passes