### PR TITLE
Add Display implementations for transformation types

### DIFF
--- a/crates/gdsr/src/transformation/reflection.rs
+++ b/crates/gdsr/src/transformation/reflection.rs
@@ -6,6 +6,16 @@ pub struct Reflection {
     centre: Point,
 }
 
+impl std::fmt::Display for Reflection {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "Reflection with angle {} rad about {}",
+            self.angle, self.centre
+        )
+    }
+}
+
 impl Reflection {
     pub const fn new(angle: AngleInRadians, centre: Point) -> Self {
         Self { angle, centre }
@@ -127,6 +137,14 @@ mod tests {
         assert!((reflection.angle - expected_angle).abs() < 1e-10);
         // Centre should be midpoint
         assert_eq!(reflection.centre, Point::integer(5, 5, 1e-9));
+    }
+
+    #[test]
+    fn test_reflection_display() {
+        let reflection = Reflection::new(0.5, Point::integer(10, 20, 1e-9));
+        let display_str = format!("{reflection}");
+        assert!(display_str.contains("Reflection with angle 0.5 rad about"));
+        assert!(display_str.contains("Point("));
     }
 
     #[test]

--- a/crates/gdsr/src/transformation/rotation.rs
+++ b/crates/gdsr/src/transformation/rotation.rs
@@ -6,6 +6,12 @@ pub struct Rotation {
     centre: Point,
 }
 
+impl std::fmt::Display for Rotation {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "Rotation of {} rad about {}", self.angle, self.centre)
+    }
+}
+
 impl Rotation {
     pub const fn new(angle: AngleInRadians, centre: Point) -> Self {
         Self { angle, centre }
@@ -72,6 +78,14 @@ mod tests {
 
         // Point at centre should remain unchanged
         assert_eq!(rotated, centre);
+    }
+
+    #[test]
+    fn test_rotation_display() {
+        let rotation = Rotation::new(FRAC_PI_2, Point::integer(10, 20, 1e-9));
+        let display_str = format!("{rotation}");
+        assert!(display_str.contains(&format!("Rotation of {FRAC_PI_2} rad about")));
+        assert!(display_str.contains("Point("));
     }
 
     #[test]

--- a/crates/gdsr/src/transformation/scale.rs
+++ b/crates/gdsr/src/transformation/scale.rs
@@ -6,6 +6,12 @@ pub struct Scale {
     centre: Point,
 }
 
+impl std::fmt::Display for Scale {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "Scale by {} about {}", self.factor, self.centre)
+    }
+}
+
 impl Scale {
     pub const fn new(factor: f64, centre: Point) -> Self {
         Self { factor, centre }
@@ -79,6 +85,14 @@ mod tests {
         let expected = Point::integer(20, 10, 1e-9);
         assert_eq!(scaled.x(), expected.x());
         assert_eq!(scaled.y(), expected.y());
+    }
+
+    #[test]
+    fn test_scale_display() {
+        let scale = Scale::new(2.5, Point::integer(10, 20, 1e-9));
+        let display_str = format!("{scale}");
+        assert!(display_str.contains("Scale by 2.5 about"));
+        assert!(display_str.contains("Point("));
     }
 
     #[test]

--- a/crates/gdsr/src/transformation/translation.rs
+++ b/crates/gdsr/src/transformation/translation.rs
@@ -5,6 +5,12 @@ pub struct Translation {
     delta: Point,
 }
 
+impl std::fmt::Display for Translation {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "Translation by {}", self.delta)
+    }
+}
+
 impl Translation {
     pub const fn new(delta: Point) -> Self {
         Self { delta }
@@ -12,5 +18,18 @@ impl Translation {
 
     pub fn apply_to_point(&self, point: &Point) -> Point {
         point + self.delta
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_translation_display() {
+        let translation = Translation::new(Point::integer(5, -3, 1e-9));
+        let display_str = format!("{translation}");
+        assert!(display_str.contains("Translation by"));
+        assert!(display_str.contains("Point("));
     }
 }


### PR DESCRIPTION
## Summary
- Add `Display` implementations for `Reflection`, `Rotation`, `Scale`, and `Translation`
- Add display tests for each type

Closes #54

## Test plan
- [x] `cargo test -p gdsr` passes
- [x] `uvx prek run -a` passes