### PR TITLE
Add validation for transformation scale factors

### DIFF
--- a/crates/gdsr/src/elements/element.rs
+++ b/crates/gdsr/src/elements/element.rs
@@ -238,7 +238,7 @@ mod tests {
         let element: Element = path.into();
 
         let centre = Point::integer(0, 0, 1e-9);
-        let transformed = element.clone().scale(2.0, centre);
+        let transformed = element.clone().scale(2.0, centre).unwrap();
 
         assert!(transformed.as_path().is_some());
     }

--- a/crates/gdsr/src/elements/reference/mod.rs
+++ b/crates/gdsr/src/elements/reference/mod.rs
@@ -61,7 +61,9 @@ impl Reference {
                 }
 
                 new_element = new_element.rotate(grid.angle(), grid.origin());
-                new_element = new_element.scale(grid.magnification(), grid.origin());
+                new_element = new_element
+                    .scale(grid.magnification(), grid.origin())
+                    .expect("grid magnification must be a valid scale factor");
 
                 // Move element to final position
                 new_element = new_element.move_by(final_position - grid.origin());

--- a/crates/gdsr/src/elements/text/mod.rs
+++ b/crates/gdsr/src/elements/text/mod.rs
@@ -390,7 +390,7 @@ mod tests {
             .set_magnification(1.5);
 
         let centre = Point::integer(0, 0, 1e-9);
-        let scaled = text.scale(2.0, centre);
+        let scaled = text.scale(2.0, centre).unwrap();
 
         assert_eq!(scaled.magnification(), 3.0);
         assert_eq!(scaled.origin(), &Point::integer(20, 40, 1e-9));
@@ -406,6 +406,7 @@ mod tests {
         let transformed = text
             .reflect(0.0, Point::origin())
             .scale(2.0, Point::origin())
+            .unwrap()
             .rotate(PI / 2.0, Point::origin());
 
         assert!(transformed.x_reflection());

--- a/crates/gdsr/src/grid/mod.rs
+++ b/crates/gdsr/src/grid/mod.rs
@@ -380,7 +380,7 @@ mod tests {
         );
 
         let centre = Point::integer(0, 0, 1e-9);
-        let transformed = grid.scale(2.0, centre);
+        let transformed = grid.scale(2.0, centre).unwrap();
 
         assert_eq!(transformed.magnification, 2.0);
     }

--- a/crates/gdsr/src/lib.rs
+++ b/crates/gdsr/src/lib.rs
@@ -17,6 +17,6 @@ pub use grid::Grid;
 pub use library::Library;
 pub use point::Point;
 pub use traits::{Dimensions, Movable, ToGds, Transformable};
-pub use transformation::{Reflection, Rotation, Scale, Transformation, Translation};
+pub use transformation::{Reflection, Rotation, Scale, ScaleError, Transformation, Translation};
 pub use types::{AngleInRadians, DataType, Layer};
 pub use units::{DEFAULT_FLOAT_UNITS, DEFAULT_INTEGER_UNITS, FloatUnit, IntegerUnit, Unit};

--- a/crates/gdsr/src/traits/mod.rs
+++ b/crates/gdsr/src/traits/mod.rs
@@ -1,4 +1,4 @@
-use crate::transformation::{Reflection, Rotation, Scale, Transformation, Translation};
+use crate::transformation::{Reflection, Rotation, Scale, ScaleError, Transformation, Translation};
 use crate::{AngleInRadians, Point};
 
 pub trait ToGds {
@@ -21,9 +21,10 @@ pub trait Transformable: Sized {
         )
     }
 
-    #[must_use]
-    fn scale(self, factor: f64, centre: Point) -> Self {
-        self.transform_impl(Transformation::default().with_scale(Some(Scale::new(factor, centre))))
+    fn scale(self, factor: f64, centre: Point) -> Result<Self, ScaleError> {
+        Ok(self.transform_impl(
+            Transformation::default().with_scale(Some(Scale::new(factor, centre)?)),
+        ))
     }
 
     #[must_use]

--- a/crates/gdsr/src/transformation/mod.rs
+++ b/crates/gdsr/src/transformation/mod.rs
@@ -7,7 +7,7 @@ mod translation;
 
 pub use reflection::Reflection;
 pub use rotation::Rotation;
-pub use scale::Scale;
+pub use scale::{Scale, ScaleError};
 pub use translation::Translation;
 
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -135,7 +135,7 @@ mod tests {
 
     #[test]
     fn test_transformation_with_scale() {
-        let scale = Scale::new(2.0, Point::integer(0, 0, 1e-9));
+        let scale = Scale::new(2.0, Point::integer(0, 0, 1e-9)).unwrap();
         let mut transformation = Transformation::default();
         transformation.with_scale(Some(scale.clone()));
 
@@ -174,7 +174,7 @@ mod tests {
 
     #[test]
     fn test_apply_to_point_scale() {
-        let scale = Scale::new(2.0, Point::integer(0, 0, 1e-9));
+        let scale = Scale::new(2.0, Point::integer(0, 0, 1e-9)).unwrap();
         let mut transformation = Transformation::default();
         transformation.with_scale(Some(scale));
 
@@ -209,7 +209,7 @@ mod tests {
 
     #[test]
     fn test_from_scale() {
-        let scale = Scale::new(2.0, Point::integer(0, 0, 1e-9));
+        let scale = Scale::new(2.0, Point::integer(0, 0, 1e-9)).unwrap();
         let transformation: Transformation = scale.clone().into();
 
         assert!(transformation.scale.is_some());

--- a/crates/gdsr/src/transformation/scale.rs
+++ b/crates/gdsr/src/transformation/scale.rs
@@ -1,6 +1,27 @@
 use crate::Point;
 
 #[derive(Clone, Debug, PartialEq)]
+pub enum ScaleError {
+    Zero,
+    Negative(f64),
+    NaN,
+    Infinite,
+}
+
+impl std::fmt::Display for ScaleError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::Zero => write!(f, "Scale factor must not be zero"),
+            Self::Negative(v) => write!(f, "Scale factor must be positive, got {v}"),
+            Self::NaN => write!(f, "Scale factor must not be NaN"),
+            Self::Infinite => write!(f, "Scale factor must be finite"),
+        }
+    }
+}
+
+impl std::error::Error for ScaleError {}
+
+#[derive(Clone, Debug, PartialEq)]
 pub struct Scale {
     factor: f64,
     centre: Point,
@@ -13,8 +34,20 @@ impl std::fmt::Display for Scale {
 }
 
 impl Scale {
-    pub const fn new(factor: f64, centre: Point) -> Self {
-        Self { factor, centre }
+    pub fn new(factor: f64, centre: Point) -> Result<Self, ScaleError> {
+        if factor.is_nan() {
+            return Err(ScaleError::NaN);
+        }
+        if factor.is_infinite() {
+            return Err(ScaleError::Infinite);
+        }
+        if factor == 0.0 {
+            return Err(ScaleError::Zero);
+        }
+        if factor < 0.0 {
+            return Err(ScaleError::Negative(factor));
+        }
+        Ok(Self { factor, centre })
     }
 
     pub const fn factor(&self) -> f64 {
@@ -45,7 +78,7 @@ mod tests {
 
     #[test]
     fn test_scale_new() {
-        let scale = Scale::new(2.0, Point::integer(10, 20, 1e-9));
+        let scale = Scale::new(2.0, Point::integer(10, 20, 1e-9)).unwrap();
         assert_eq!(scale.factor(), 2.0);
         assert_eq!(scale.centre(), &Point::integer(10, 20, 1e-9));
     }
@@ -53,14 +86,14 @@ mod tests {
     #[test]
     fn test_scale_getters() {
         let centre = Point::integer(5, 10, 1e-9);
-        let scale = Scale::new(1.5, centre);
+        let scale = Scale::new(1.5, centre).unwrap();
         assert_eq!(scale.factor(), 1.5);
         assert_eq!(scale.centre(), &centre);
     }
 
     #[test]
     fn test_scale_clone() {
-        let scale = Scale::new(3.0, Point::integer(5, 5, 1e-9));
+        let scale = Scale::new(3.0, Point::integer(5, 5, 1e-9)).unwrap();
         let cloned = scale.clone();
         assert_eq!(scale, cloned);
     }
@@ -68,7 +101,7 @@ mod tests {
     #[test]
     fn test_scale_apply_at_centre() {
         let centre = Point::integer(10, 10, 1e-9);
-        let scale = Scale::new(2.0, centre);
+        let scale = Scale::new(2.0, centre).unwrap();
         let scaled = scale.apply_to_point(&centre);
 
         // Point at centre should remain unchanged
@@ -77,11 +110,10 @@ mod tests {
 
     #[test]
     fn test_scale_double() {
-        let scale = Scale::new(2.0, Point::integer(0, 0, 1e-9));
+        let scale = Scale::new(2.0, Point::integer(0, 0, 1e-9)).unwrap();
         let point = Point::integer(10, 5, 1e-9);
         let scaled = scale.apply_to_point(&point);
 
-        // Point should be twice as far from origin
         let expected = Point::integer(20, 10, 1e-9);
         assert_eq!(scaled.x(), expected.x());
         assert_eq!(scaled.y(), expected.y());
@@ -89,7 +121,7 @@ mod tests {
 
     #[test]
     fn test_scale_display() {
-        let scale = Scale::new(2.5, Point::integer(10, 20, 1e-9));
+        let scale = Scale::new(2.5, Point::integer(10, 20, 1e-9)).unwrap();
         let display_str = format!("{scale}");
         assert!(display_str.contains("Scale by 2.5 about"));
         assert!(display_str.contains("Point("));
@@ -97,13 +129,63 @@ mod tests {
 
     #[test]
     fn test_scale_half() {
-        let scale = Scale::new(0.5, Point::integer(0, 0, 1e-9));
+        let scale = Scale::new(0.5, Point::integer(0, 0, 1e-9)).unwrap();
         let point = Point::integer(20, 10, 1e-9);
         let scaled = scale.apply_to_point(&point);
 
-        // Point should be half as far from origin
         let expected = Point::integer(10, 5, 1e-9);
         assert_eq!(scaled.x(), expected.x());
         assert_eq!(scaled.y(), expected.y());
+    }
+
+    #[test]
+    fn test_scale_valid_factor() {
+        assert!(Scale::new(1.0, Point::integer(0, 0, 1e-9)).is_ok());
+        assert!(Scale::new(0.5, Point::integer(0, 0, 1e-9)).is_ok());
+        assert!(Scale::new(100.0, Point::integer(0, 0, 1e-9)).is_ok());
+    }
+
+    #[test]
+    fn test_scale_zero_factor() {
+        let result = Scale::new(0.0, Point::integer(0, 0, 1e-9));
+        assert_eq!(result, Err(ScaleError::Zero));
+    }
+
+    #[test]
+    fn test_scale_negative_factor() {
+        let result = Scale::new(-1.0, Point::integer(0, 0, 1e-9));
+        assert_eq!(result, Err(ScaleError::Negative(-1.0)));
+    }
+
+    #[test]
+    fn test_scale_nan_factor() {
+        let result = Scale::new(f64::NAN, Point::integer(0, 0, 1e-9));
+        assert_eq!(result, Err(ScaleError::NaN));
+    }
+
+    #[test]
+    fn test_scale_infinity_factor() {
+        let result = Scale::new(f64::INFINITY, Point::integer(0, 0, 1e-9));
+        assert_eq!(result, Err(ScaleError::Infinite));
+
+        let result = Scale::new(f64::NEG_INFINITY, Point::integer(0, 0, 1e-9));
+        assert_eq!(result, Err(ScaleError::Infinite));
+    }
+
+    #[test]
+    fn test_scale_error_display() {
+        assert_eq!(
+            ScaleError::Zero.to_string(),
+            "Scale factor must not be zero"
+        );
+        assert_eq!(
+            ScaleError::Negative(-2.0).to_string(),
+            "Scale factor must be positive, got -2"
+        );
+        assert_eq!(ScaleError::NaN.to_string(), "Scale factor must not be NaN");
+        assert_eq!(
+            ScaleError::Infinite.to_string(),
+            "Scale factor must be finite"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- `Scale::new()` now returns `Result<Self, ScaleError>`, rejecting zero, negative, NaN, and infinite values
- Add `ScaleError` enum with `Display` and `Error` implementations
- Update all callers to handle the `Result`
- `Transformable::scale()` now returns `Result<Self, ScaleError>`

Closes #47

## Test plan
- [x] `cargo test -p gdsr` passes
- [x] `uvx prek run -a` passes