### PR TITLE
Add edge case tests for Grid calculations

### DIFF
--- a/crates/gdsr/src/elements/reference/mod.rs
+++ b/crates/gdsr/src/elements/reference/mod.rs
@@ -422,4 +422,200 @@ mod tests {
         let flattened = reference.flatten(None, &library);
         assert_eq!(flattened.len(), 4); // 2x2 grid
     }
+
+    #[test]
+    fn test_reference_1x1_grid_expansion() {
+        let polygon = Polygon::new(
+            [
+                Point::integer(0, 0, 1e-9),
+                Point::integer(10, 0, 1e-9),
+                Point::integer(10, 10, 1e-9),
+            ],
+            1,
+            0,
+        );
+        let grid = Grid::default()
+            .with_columns(1)
+            .with_rows(1)
+            .with_spacing_x(Some(Point::integer(20, 0, 1e-9)))
+            .with_spacing_y(Some(Point::integer(0, 20, 1e-9)));
+
+        let reference = Reference::new(polygon.clone()).with_grid(grid);
+
+        let element = Element::Polygon(polygon.clone());
+        let elements = reference.get_elements_in_grid(&element);
+
+        assert_eq!(elements.len(), 1);
+        let result = elements[0].as_polygon().unwrap();
+        assert_eq!(result.points(), polygon.points());
+    }
+
+    #[test]
+    fn test_reference_asymmetric_1x5_grid_expansion() {
+        let polygon = Polygon::new(
+            [
+                Point::integer(0, 0, 1e-9),
+                Point::integer(10, 0, 1e-9),
+                Point::integer(10, 10, 1e-9),
+            ],
+            1,
+            0,
+        );
+        let grid = Grid::default()
+            .with_columns(1)
+            .with_rows(5)
+            .with_spacing_x(Some(Point::integer(20, 0, 1e-9)))
+            .with_spacing_y(Some(Point::integer(0, 20, 1e-9)));
+
+        let reference = Reference::new(polygon.clone()).with_grid(grid);
+
+        let element = Element::Polygon(polygon);
+        let elements = reference.get_elements_in_grid(&element);
+
+        assert_eq!(elements.len(), 5);
+        for (i, el) in elements.iter().enumerate() {
+            let p = el.as_polygon().unwrap();
+            let expected_y_offset = (i as i32) * 20;
+            assert_eq!(p.points()[0], Point::integer(0, expected_y_offset, 1e-9));
+        }
+    }
+
+    #[test]
+    fn test_reference_asymmetric_5x1_grid_expansion() {
+        let polygon = Polygon::new(
+            [
+                Point::integer(0, 0, 1e-9),
+                Point::integer(10, 0, 1e-9),
+                Point::integer(10, 10, 1e-9),
+            ],
+            1,
+            0,
+        );
+        let grid = Grid::default()
+            .with_columns(5)
+            .with_rows(1)
+            .with_spacing_x(Some(Point::integer(20, 0, 1e-9)))
+            .with_spacing_y(Some(Point::integer(0, 20, 1e-9)));
+
+        let reference = Reference::new(polygon.clone()).with_grid(grid);
+
+        let element = Element::Polygon(polygon);
+        let elements = reference.get_elements_in_grid(&element);
+
+        assert_eq!(elements.len(), 5);
+        for (i, el) in elements.iter().enumerate() {
+            let p = el.as_polygon().unwrap();
+            let expected_x_offset = (i as i32) * 20;
+            assert_eq!(p.points()[0], Point::integer(expected_x_offset, 0, 1e-9));
+        }
+    }
+
+    #[test]
+    fn test_reference_none_spacing_grid_expansion() {
+        let polygon = Polygon::new(
+            [
+                Point::integer(0, 0, 1e-9),
+                Point::integer(10, 0, 1e-9),
+                Point::integer(10, 10, 1e-9),
+            ],
+            1,
+            0,
+        );
+        let grid = Grid::default().with_columns(3).with_rows(3);
+
+        let reference = Reference::new(polygon.clone()).with_grid(grid);
+
+        let element = Element::Polygon(polygon.clone());
+        let elements = reference.get_elements_in_grid(&element);
+
+        assert_eq!(elements.len(), 9);
+        for el in &elements {
+            let p = el.as_polygon().unwrap();
+            assert_eq!(p.points(), polygon.points());
+        }
+    }
+
+    #[test]
+    fn test_reference_zero_spacing_grid_expansion() {
+        let polygon = Polygon::new(
+            [
+                Point::integer(0, 0, 1e-9),
+                Point::integer(10, 0, 1e-9),
+                Point::integer(10, 10, 1e-9),
+            ],
+            1,
+            0,
+        );
+        let grid = Grid::default()
+            .with_columns(3)
+            .with_rows(3)
+            .with_spacing_x(Some(Point::integer(0, 0, 1e-9)))
+            .with_spacing_y(Some(Point::integer(0, 0, 1e-9)));
+
+        let reference = Reference::new(polygon.clone()).with_grid(grid);
+
+        let element = Element::Polygon(polygon.clone());
+        let elements = reference.get_elements_in_grid(&element);
+
+        assert_eq!(elements.len(), 9);
+        for el in &elements {
+            let p = el.as_polygon().unwrap();
+            assert_eq!(p.points(), polygon.points());
+        }
+    }
+
+    #[test]
+    fn test_reference_negative_spacing_grid_expansion() {
+        let polygon = Polygon::new(
+            [
+                Point::integer(0, 0, 1e-9),
+                Point::integer(10, 0, 1e-9),
+                Point::integer(10, 10, 1e-9),
+            ],
+            1,
+            0,
+        );
+        let grid = Grid::default()
+            .with_columns(3)
+            .with_rows(1)
+            .with_spacing_x(Some(Point::integer(-20, 0, 1e-9)))
+            .with_spacing_y(Some(Point::integer(0, -20, 1e-9)));
+
+        let reference = Reference::new(polygon.clone()).with_grid(grid);
+
+        let element = Element::Polygon(polygon);
+        let elements = reference.get_elements_in_grid(&element);
+
+        assert_eq!(elements.len(), 3);
+        for (i, el) in elements.iter().enumerate() {
+            let p = el.as_polygon().unwrap();
+            let expected_x_offset = (i as i32) * -20;
+            assert_eq!(p.points()[0], Point::integer(expected_x_offset, 0, 1e-9));
+        }
+    }
+
+    #[test]
+    fn test_reference_large_grid_expansion() {
+        let polygon = Polygon::new(
+            [
+                Point::integer(0, 0, 1e-9),
+                Point::integer(1, 0, 1e-9),
+                Point::integer(1, 1, 1e-9),
+            ],
+            1,
+            0,
+        );
+        let grid = Grid::default()
+            .with_columns(10)
+            .with_rows(10)
+            .with_spacing_x(Some(Point::integer(5, 0, 1e-9)))
+            .with_spacing_y(Some(Point::integer(0, 5, 1e-9)));
+
+        let reference = Reference::new(polygon.clone()).with_grid(grid);
+
+        let element = Element::Polygon(polygon);
+        let elements = reference.get_elements_in_grid(&element);
+
+        assert_eq!(elements.len(), 100);
+    }
 }

--- a/crates/gdsr/src/grid/mod.rs
+++ b/crates/gdsr/src/grid/mod.rs
@@ -565,4 +565,163 @@ mod tests {
         assert_eq!(grid.angle, 90.0);
         assert!(grid.x_reflection);
     }
+
+    #[test]
+    fn test_grid_1x1() {
+        let grid = Grid::new(
+            Point::integer(5, 10, 1e-9),
+            1,
+            1,
+            Some(Point::integer(10, 0, 1e-9)),
+            Some(Point::integer(0, 10, 1e-9)),
+            1.0,
+            0.0,
+            false,
+        );
+
+        assert_eq!(grid.columns(), 1);
+        assert_eq!(grid.rows(), 1);
+        assert_eq!(grid.origin(), Point::integer(5, 10, 1e-9));
+    }
+
+    #[test]
+    fn test_grid_asymmetric_1x5() {
+        let grid = Grid::new(
+            Point::integer(0, 0, 1e-9),
+            1,
+            5,
+            Some(Point::integer(10, 0, 1e-9)),
+            Some(Point::integer(0, 10, 1e-9)),
+            1.0,
+            0.0,
+            false,
+        );
+
+        assert_eq!(grid.columns(), 1);
+        assert_eq!(grid.rows(), 5);
+    }
+
+    #[test]
+    fn test_grid_asymmetric_5x1() {
+        let grid = Grid::new(
+            Point::integer(0, 0, 1e-9),
+            5,
+            1,
+            Some(Point::integer(10, 0, 1e-9)),
+            Some(Point::integer(0, 10, 1e-9)),
+            1.0,
+            0.0,
+            false,
+        );
+
+        assert_eq!(grid.columns(), 5);
+        assert_eq!(grid.rows(), 1);
+    }
+
+    #[test]
+    fn test_grid_none_spacing() {
+        let grid = Grid::new(
+            Point::integer(0, 0, 1e-9),
+            3,
+            3,
+            None,
+            None,
+            1.0,
+            0.0,
+            false,
+        );
+
+        assert_eq!(grid.spacing_x(), None);
+        assert_eq!(grid.spacing_y(), None);
+    }
+
+    #[test]
+    fn test_grid_zero_spacing() {
+        let grid = Grid::new(
+            Point::integer(0, 0, 1e-9),
+            3,
+            3,
+            Some(Point::integer(0, 0, 1e-9)),
+            Some(Point::integer(0, 0, 1e-9)),
+            1.0,
+            0.0,
+            false,
+        );
+
+        assert_eq!(grid.spacing_x(), Some(Point::integer(0, 0, 1e-9)));
+        assert_eq!(grid.spacing_y(), Some(Point::integer(0, 0, 1e-9)));
+    }
+
+    #[test]
+    fn test_grid_negative_spacing() {
+        let grid = Grid::new(
+            Point::integer(0, 0, 1e-9),
+            3,
+            3,
+            Some(Point::integer(-10, 0, 1e-9)),
+            Some(Point::integer(0, -10, 1e-9)),
+            1.0,
+            0.0,
+            false,
+        );
+
+        assert_eq!(grid.spacing_x(), Some(Point::integer(-10, 0, 1e-9)));
+        assert_eq!(grid.spacing_y(), Some(Point::integer(0, -10, 1e-9)));
+    }
+
+    #[test]
+    fn test_grid_transform_rotation_then_reflection() {
+        let grid = Grid::new(
+            Point::integer(10, 20, 1e-9),
+            2,
+            2,
+            Some(Point::integer(5, 0, 1e-9)),
+            Some(Point::integer(0, 5, 1e-9)),
+            1.0,
+            0.0,
+            false,
+        );
+
+        let centre = Point::integer(0, 0, 1e-9);
+        let transformed = grid.rotate(FRAC_PI_2, centre).reflect(0.0, centre);
+
+        assert!((transformed.angle() - FRAC_PI_2).abs() < 0.001);
+        assert!(transformed.x_reflection());
+    }
+
+    #[test]
+    fn test_grid_transform_double_reflection_cancels() {
+        let grid = Grid::new(
+            Point::integer(10, 20, 1e-9),
+            2,
+            2,
+            Some(Point::integer(5, 0, 1e-9)),
+            Some(Point::integer(0, 5, 1e-9)),
+            1.0,
+            0.0,
+            false,
+        );
+
+        let centre = Point::integer(0, 0, 1e-9);
+        let transformed = grid.reflect(0.0, centre).reflect(0.0, centre);
+
+        assert!(!transformed.x_reflection());
+    }
+
+    #[test]
+    fn test_grid_large() {
+        let grid = Grid::new(
+            Point::integer(0, 0, 1e-9),
+            100,
+            100,
+            Some(Point::integer(1, 0, 1e-9)),
+            Some(Point::integer(0, 1, 1e-9)),
+            1.0,
+            0.0,
+            false,
+        );
+
+        assert_eq!(grid.columns(), 100);
+        assert_eq!(grid.rows(), 100);
+    }
 }


### PR DESCRIPTION
## Summary
- Add 9 grid unit tests: 1x1, asymmetric, None/zero/negative spacing, chained transformations, large grids
- Add 7 reference grid expansion tests: 1x1, asymmetric, None/zero/negative spacing, large grids

Closes #52

## Test plan
- [x] `cargo test -p gdsr` passes
- [x] `uvx prek run -a` passes