### PR TITLE
Add .claude/worktrees to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 
 node_modules/
+
+.claude/worktrees/


### PR DESCRIPTION
## Summary
- Ignore Claude Code agent worktree directories to prevent accidental commits