### PR TITLE
Add documentation to public types and methods

### DIFF
--- a/crates/gdsr/src/cell/mod.rs
+++ b/crates/gdsr/src/cell/mod.rs
@@ -4,6 +4,7 @@ use crate::{
 
 mod io;
 
+/// A named cell containing polygons, paths, texts, and references to other cells or elements.
 #[derive(Clone, Debug, PartialEq, Default)]
 pub struct Cell {
     name: String,
@@ -14,6 +15,7 @@ pub struct Cell {
 }
 
 impl Cell {
+    /// Creates a new empty cell with the given name.
     pub fn new(name: &str) -> Self {
         Self {
             name: name.to_string(),
@@ -24,6 +26,7 @@ impl Cell {
         }
     }
 
+    /// Returns the cell name.
     pub fn name(&self) -> &str {
         &self.name
     }
@@ -32,22 +35,27 @@ impl Cell {
         self.name = name.to_string();
     }
 
+    /// Returns the polygons in this cell.
     pub const fn polygons(&self) -> &Vec<Polygon> {
         &self.polygons
     }
 
+    /// Returns the paths in this cell.
     pub const fn paths(&self) -> &Vec<Path> {
         &self.paths
     }
 
+    /// Returns the texts in this cell.
     pub const fn texts(&self) -> &Vec<Text> {
         &self.texts
     }
 
+    /// Returns the references in this cell.
     pub const fn references(&self) -> &Vec<Reference> {
         &self.references
     }
 
+    /// Adds an element (polygon, path, text, or reference) to the cell.
     pub fn add(&mut self, element: impl Into<Element>) {
         match element.into() {
             Element::Path(path) => self.paths.push(path),
@@ -57,6 +65,7 @@ impl Cell {
         }
     }
 
+    /// Returns all elements in this cell, recursively flattening references up to the given depth.
     pub fn get_elements(&self, depth: Option<usize>, library: &Library) -> Vec<Element> {
         let depth = depth.unwrap_or(usize::MAX);
         let mut elements: Vec<Element> = Vec::new();

--- a/crates/gdsr/src/elements/element.rs
+++ b/crates/gdsr/src/elements/element.rs
@@ -4,15 +4,21 @@ use crate::elements::{Path, Polygon, Reference, Text};
 use crate::traits::ToGds;
 use crate::{Instance, Movable, Point, Transformable, Transformation};
 
+/// A GDSII element: one of [`Path`], [`Polygon`], [`Text`], or [`Reference`].
 #[derive(Clone, Debug, PartialEq)]
 pub enum Element {
+    /// A path element.
     Path(Path),
+    /// A polygon element.
     Polygon(Polygon),
+    /// A text annotation element.
     Text(Text),
+    /// A reference to another cell or element.
     Reference(Reference),
 }
 
 impl Element {
+    /// Returns the inner [`Path`] if this is a `Path` variant, or `None`.
     pub fn as_path(&self) -> Option<&Path> {
         if let Self::Path(v) = self {
             Some(v)
@@ -21,6 +27,7 @@ impl Element {
         }
     }
 
+    /// Returns the inner [`Polygon`] if this is a `Polygon` variant, or `None`.
     pub fn as_polygon(&self) -> Option<&Polygon> {
         if let Self::Polygon(v) = self {
             Some(v)
@@ -29,6 +36,7 @@ impl Element {
         }
     }
 
+    /// Returns the inner [`Text`] if this is a `Text` variant, or `None`.
     pub fn as_text(&self) -> Option<&Text> {
         if let Self::Text(v) = self {
             Some(v)
@@ -37,6 +45,7 @@ impl Element {
         }
     }
 
+    /// Returns the inner [`Reference`] if this is a `Reference` variant, or `None`.
     pub fn as_reference(&self) -> Option<&Reference> {
         if let Self::Reference(v) = self {
             Some(v)

--- a/crates/gdsr/src/elements/path/mod.rs
+++ b/crates/gdsr/src/elements/path/mod.rs
@@ -5,6 +5,7 @@ mod path_type;
 
 pub use path_type::PathType;
 
+/// An open path defined by a sequence of points, with optional width and end cap type.
 #[derive(Clone, Debug, PartialEq, Default)]
 pub struct Path {
     pub(crate) points: Vec<Point>,
@@ -15,6 +16,7 @@ pub struct Path {
 }
 
 impl Path {
+    /// Creates a new path from the given points, layer, data type, optional end cap type, and optional width.
     pub fn new(
         points: impl IntoIterator<Item = Point>,
         layer: Layer,
@@ -31,22 +33,27 @@ impl Path {
         }
     }
 
+    /// Returns the path's points.
     pub fn points(&self) -> &[Point] {
         &self.points
     }
 
+    /// Returns the layer number.
     pub const fn layer(&self) -> Layer {
         self.layer
     }
 
+    /// Returns the data type.
     pub const fn data_type(&self) -> DataType {
         self.data_type
     }
 
+    /// Returns the end cap type, if set.
     pub const fn path_type(&self) -> &Option<PathType> {
         &self.r#type
     }
 
+    /// Returns the path width, if set.
     pub const fn width(&self) -> Option<Unit> {
         self.width
     }

--- a/crates/gdsr/src/elements/polygon/mod.rs
+++ b/crates/gdsr/src/elements/polygon/mod.rs
@@ -5,6 +5,7 @@ mod utils;
 
 pub use utils::get_correct_polygon_points_format;
 
+/// A closed polygon defined by a sequence of points on a specific layer.
 #[derive(Clone, Debug, PartialEq, Default)]
 pub struct Polygon {
     pub(crate) points: Vec<Point>,
@@ -13,6 +14,8 @@ pub struct Polygon {
 }
 
 impl Polygon {
+    /// Creates a new polygon from the given points, layer, and data type.
+    /// The polygon is automatically closed if needed.
     pub fn new(points: impl IntoIterator<Item = Point>, layer: Layer, data_type: DataType) -> Self {
         Self {
             points: utils::get_correct_polygon_points_format(points),
@@ -21,22 +24,27 @@ impl Polygon {
         }
     }
 
+    /// Returns the polygon's points (including the closing point).
     pub fn points(&self) -> &[Point] {
         &self.points
     }
 
+    /// Returns the layer number.
     pub const fn layer(&self) -> Layer {
         self.layer
     }
 
+    /// Returns the data type.
     pub const fn data_type(&self) -> DataType {
         self.data_type
     }
 
+    /// Computes the area of the polygon using the shoelace formula.
     pub fn area(&self) -> Unit {
         crate::utils::geometry::area(&self.points)
     }
 
+    /// Computes the perimeter of the polygon.
     pub fn perimeter(&self) -> Unit {
         crate::utils::geometry::perimeter(&self.points)
     }

--- a/crates/gdsr/src/elements/reference/instance/mod.rs
+++ b/crates/gdsr/src/elements/reference/instance/mod.rs
@@ -4,13 +4,17 @@ use crate::Cell;
 use crate::elements::Element;
 // Note: Reference is defined in parent module, so we can't import it here to avoid circular dependency
 
+/// The target of a [`Reference`](crate::Reference): either a cell name or an inline element.
 #[derive(Clone, Debug, PartialEq)]
 pub enum Instance {
+    /// A reference to a named cell in the library.
     Cell(String),
+    /// An inline element stored directly in the reference.
     Element(Arc<Box<Element>>),
 }
 
 impl Instance {
+    /// Returns the cell name if this is a `Cell` instance, or `None`.
     pub fn as_cell(&self) -> Option<&String> {
         if let Self::Cell(v) = self {
             Some(v)
@@ -19,6 +23,7 @@ impl Instance {
         }
     }
 
+    /// Returns the element if this is an `Element` instance, or `None`.
     pub fn as_element(&self) -> Option<&Arc<Box<Element>>> {
         if let Self::Element(v) = self {
             Some(v)

--- a/crates/gdsr/src/elements/reference/mod.rs
+++ b/crates/gdsr/src/elements/reference/mod.rs
@@ -5,6 +5,7 @@ mod io;
 
 pub use instance::Instance;
 
+/// A reference to an instance (cell or element) placed with a grid layout.
 #[derive(Clone, Debug, PartialEq, Default)]
 pub struct Reference {
     pub(crate) instance: Instance,
@@ -12,6 +13,7 @@ pub struct Reference {
 }
 
 impl Reference {
+    /// Creates a new reference to the given instance with a default grid.
     pub fn new(instance: impl Into<Instance>) -> Self {
         Self {
             instance: instance.into(),
@@ -19,20 +21,24 @@ impl Reference {
         }
     }
 
+    /// Returns the referenced instance.
     pub const fn instance(&self) -> &Instance {
         &self.instance
     }
 
+    /// Returns the grid layout configuration.
     pub const fn grid(&self) -> &Grid {
         &self.grid
     }
 
+    /// Sets the grid layout and returns the modified reference.
     #[must_use]
     pub const fn with_grid(mut self, grid: Grid) -> Self {
         self.grid = grid;
         self
     }
 
+    /// Expands a single element across the grid, returning one element per grid position.
     pub fn get_elements_in_grid(&self, element: &Element) -> Vec<Element> {
         let grid = self.grid();
 
@@ -73,6 +79,8 @@ impl Reference {
         elements
     }
 
+    /// Recursively flattens this reference into concrete elements, resolving cell references
+    /// up to the given depth (or fully if `None`).
     pub fn flatten(self, depth: Option<usize>, library: &Library) -> Vec<Element> {
         let depth = depth.unwrap_or(usize::MAX);
         let mut elements: Vec<Element> = Vec::new();

--- a/crates/gdsr/src/elements/text/mod.rs
+++ b/crates/gdsr/src/elements/text/mod.rs
@@ -4,6 +4,7 @@ pub mod io;
 pub mod presentation;
 pub mod utils;
 
+/// A text annotation placed at a specific point with configurable presentation.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Text {
     pub(crate) value: String,
@@ -34,6 +35,7 @@ impl Default for Text {
 }
 
 impl Text {
+    /// Creates a new text element with the given properties.
     pub fn new(
         text: &str,
         origin: Point,
@@ -58,70 +60,84 @@ impl Text {
         }
     }
 
+    /// Returns the text string.
     pub const fn text(&self) -> &String {
         &self.value
     }
 
+    /// Sets the text string and returns the modified value.
     #[must_use]
     pub fn set_text(mut self, text: String) -> Self {
         self.value = text;
         self
     }
 
+    /// Returns the origin point.
     pub const fn origin(&self) -> &Point {
         &self.origin
     }
 
+    /// Sets the origin point and returns the modified value.
     #[must_use]
     pub fn set_origin(mut self, origin: Point) -> Self {
         self.origin = origin;
         self
     }
 
+    /// Returns the layer number.
     pub const fn layer(&self) -> Layer {
         self.layer
     }
 
+    /// Sets the layer number and returns the modified value.
     #[must_use]
     pub fn set_layer(mut self, layer: Layer) -> Self {
         self.layer = layer;
         self
     }
 
+    /// Returns the magnification factor.
     pub const fn magnification(&self) -> f64 {
         self.magnification
     }
 
+    /// Sets the magnification factor and returns the modified value.
     #[must_use]
     pub fn set_magnification(mut self, magnification: f64) -> Self {
         self.magnification = magnification;
         self
     }
 
+    /// Returns the rotation angle in radians.
     pub const fn angle(&self) -> f64 {
         self.angle
     }
 
+    /// Sets the rotation angle and returns the modified value.
     #[must_use]
     pub fn set_angle(mut self, angle: f64) -> Self {
         self.angle = angle;
         self
     }
 
+    /// Returns whether x-axis reflection is enabled.
     pub const fn x_reflection(&self) -> bool {
         self.x_reflection
     }
 
+    /// Sets x-axis reflection and returns the modified value.
     #[must_use]
     pub fn set_x_reflection(mut self, x_reflection: bool) -> Self {
         self.x_reflection = x_reflection;
         self
     }
 
+    /// Returns the vertical text presentation alignment.
     pub const fn vertical_presentation(&self) -> &presentation::VerticalPresentation {
         &self.vertical_presentation
     }
 
+    /// Sets the vertical presentation alignment and returns the modified value.
     #[must_use]
     pub fn set_vertical_presentation(
         mut self,
@@ -131,10 +147,12 @@ impl Text {
         self
     }
 
+    /// Returns the horizontal text presentation alignment.
     pub const fn horizontal_presentation(&self) -> &presentation::HorizontalPresentation {
         &self.horizontal_presentation
     }
 
+    /// Sets the horizontal presentation alignment and returns the modified value.
     #[must_use]
     pub fn set_horizontal_presentation(
         mut self,

--- a/crates/gdsr/src/grid/mod.rs
+++ b/crates/gdsr/src/grid/mod.rs
@@ -2,6 +2,7 @@ use std::f64::consts::PI;
 
 use crate::{AngleInRadians, Movable, Point, Transformable, Transformation};
 
+/// A grid layout that repeats elements in rows and columns with optional transformations.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Grid {
     origin: Point,
@@ -15,6 +16,7 @@ pub struct Grid {
 }
 
 impl Grid {
+    /// Creates a new grid with the given parameters.
     #[allow(clippy::too_many_arguments)]
     pub const fn new(
         origin: Point,
@@ -38,112 +40,136 @@ impl Grid {
         }
     }
 
+    /// Returns the origin point of the grid.
     pub const fn origin(&self) -> Point {
         self.origin
     }
 
+    /// Returns the number of columns.
     pub const fn columns(&self) -> u32 {
         self.columns
     }
 
+    /// Returns the number of rows.
     pub const fn rows(&self) -> u32 {
         self.rows
     }
 
+    /// Returns the column spacing vector, if set.
     pub const fn spacing_x(&self) -> Option<Point> {
         self.spacing_x
     }
 
+    /// Returns the row spacing vector, if set.
     pub const fn spacing_y(&self) -> Option<Point> {
         self.spacing_y
     }
 
+    /// Returns the magnification factor.
     pub const fn magnification(&self) -> f64 {
         self.magnification
     }
 
+    /// Returns the rotation angle in radians.
     pub const fn angle(&self) -> f64 {
         self.angle
     }
 
+    /// Returns whether x-axis reflection is enabled.
     pub const fn x_reflection(&self) -> bool {
         self.x_reflection
     }
 
+    /// Sets the origin point.
     pub const fn set_origin(&mut self, origin: Point) {
         self.origin = origin;
     }
 
+    /// Returns a new grid with the given origin.
     #[must_use]
     pub const fn with_origin(mut self, origin: Point) -> Self {
         self.origin = origin;
         self
     }
 
+    /// Sets the number of columns.
     pub const fn set_columns(&mut self, columns: u32) {
         self.columns = columns;
     }
 
+    /// Returns a new grid with the given number of columns.
     #[must_use]
     pub const fn with_columns(mut self, columns: u32) -> Self {
         self.columns = columns;
         self
     }
 
+    /// Sets the number of rows.
     pub const fn set_rows(&mut self, rows: u32) {
         self.rows = rows;
     }
 
+    /// Returns a new grid with the given number of rows.
     #[must_use]
     pub const fn with_rows(mut self, rows: u32) -> Self {
         self.rows = rows;
         self
     }
 
+    /// Sets the column spacing vector.
     pub const fn set_spacing_x(&mut self, spacing_x: Option<Point>) {
         self.spacing_x = spacing_x;
     }
 
+    /// Returns a new grid with the given column spacing vector.
     #[must_use]
     pub const fn with_spacing_x(mut self, spacing_x: Option<Point>) -> Self {
         self.spacing_x = spacing_x;
         self
     }
 
+    /// Sets the row spacing vector.
     pub const fn set_spacing_y(&mut self, spacing_y: Option<Point>) {
         self.spacing_y = spacing_y;
     }
 
+    /// Returns a new grid with the given row spacing vector.
     #[must_use]
     pub const fn with_spacing_y(mut self, spacing_y: Option<Point>) -> Self {
         self.spacing_y = spacing_y;
         self
     }
 
+    /// Sets the magnification factor.
     pub const fn set_magnification(&mut self, magnification: f64) {
         self.magnification = magnification;
     }
 
+    /// Returns a new grid with the given magnification factor.
     #[must_use]
     pub const fn with_magnification(mut self, magnification: f64) -> Self {
         self.magnification = magnification;
         self
     }
 
+    /// Sets the rotation angle in radians.
     pub const fn set_angle(&mut self, angle: AngleInRadians) {
         self.angle = angle;
     }
 
+    /// Returns a new grid with the given rotation angle.
     #[must_use]
     pub const fn with_angle(mut self, angle: AngleInRadians) -> Self {
         self.angle = angle;
         self
     }
 
+    /// Sets whether x-axis reflection is enabled.
     pub const fn set_x_reflection(&mut self, x_reflection: bool) {
         self.x_reflection = x_reflection;
     }
 
+    /// Returns a new grid with the given x-axis reflection setting.
     #[must_use]
     pub const fn with_x_reflection(mut self, x_reflection: bool) -> Self {
         self.x_reflection = x_reflection;

--- a/crates/gdsr/src/library/mod.rs
+++ b/crates/gdsr/src/library/mod.rs
@@ -4,6 +4,7 @@ use std::io;
 use crate::cell::Cell;
 use crate::utils::io::{from_gds, write_gds};
 
+/// A GDSII library containing named cells. This is the top-level container for a GDSII design.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Library {
     pub(crate) name: String,
@@ -11,6 +12,7 @@ pub struct Library {
 }
 
 impl Library {
+    /// Creates a new empty library with the given name.
     pub fn new(name: &str) -> Self {
         Self {
             name: name.to_string(),
@@ -18,32 +20,39 @@ impl Library {
         }
     }
 
+    /// Returns the library name.
     pub fn name(&self) -> &str {
         &self.name
     }
 
+    /// Returns the map of cell names to cells.
     pub fn cells(&self) -> &HashMap<String, Cell> {
         &self.cells
     }
 
+    /// Sets the library name.
     pub fn set_name(&mut self, name: &str) {
         self.name = name.to_string();
     }
 
+    /// Adds a cell to the library. If a cell with the same name exists, it is replaced.
     pub fn add_cell(&mut self, cell: Cell) {
         self.cells.insert(cell.name().to_string(), cell);
     }
 
+    /// Removes the given cells from the library by name.
     pub fn remove_cell(&mut self, cells: Vec<Cell>) {
         for cell in cells {
             self.cells.remove(cell.name());
         }
     }
 
+    /// Returns a reference to the cell with the given name, if it exists.
     pub fn get_cell(&self, name: &str) -> Option<&Cell> {
         self.cells.get(name)
     }
 
+    /// Returns `true` if the library contains a cell with the same name.
     pub fn contains_cell(&self, cell: &Cell) -> bool {
         self.cells.contains_key(cell.name())
     }

--- a/crates/gdsr/src/point/mod.rs
+++ b/crates/gdsr/src/point/mod.rs
@@ -3,6 +3,7 @@ use std::ops::{Add, Div, Mul, Sub};
 use crate::units::Unit;
 use crate::{AngleInRadians, Movable, Transformable, Transformation};
 
+/// A 2D point with x and y coordinates, each carrying their own unit of measurement.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub struct Point {
     x: Unit,
@@ -10,6 +11,7 @@ pub struct Point {
 }
 
 impl Point {
+    /// Creates a point with integer coordinates and the given units.
     pub const fn integer(x: i32, y: i32, units: f64) -> Self {
         Self {
             x: Unit::integer(x, units),
@@ -17,6 +19,7 @@ impl Point {
         }
     }
 
+    /// Creates a point with float coordinates and the given units.
     pub const fn float(x: f64, y: f64, units: f64) -> Self {
         Self {
             x: Unit::float(x, units),
@@ -24,6 +27,7 @@ impl Point {
         }
     }
 
+    /// Creates a point at the origin (0, 0) with default integer units.
     pub fn origin() -> Self {
         Self {
             x: Unit::zero(),
@@ -31,6 +35,7 @@ impl Point {
         }
     }
 
+    /// Creates a point with integer coordinates and default integer units (1e-9).
     pub const fn default_integer(x: i32, y: i32) -> Self {
         Self {
             x: Unit::default_integer(x),
@@ -38,6 +43,7 @@ impl Point {
         }
     }
 
+    /// Creates a point with float coordinates and default float units (1e-6).
     pub const fn default_float(x: f64, y: f64) -> Self {
         Self {
             x: Unit::default_float(x),
@@ -53,10 +59,12 @@ impl Point {
         Self { x, y }
     }
 
+    /// Returns the units for both coordinates as `(x_units, y_units)`.
     pub const fn units(&self) -> (f64, f64) {
         (self.x.units(), self.y.units())
     }
 
+    /// Returns a copy of this point with both coordinates set to the given units (without scaling).
     #[must_use]
     pub const fn set_units(&self, units: f64) -> Self {
         Self {
@@ -65,6 +73,7 @@ impl Point {
         }
     }
 
+    /// Returns a copy of this point with both coordinates scaled to the given units.
     #[must_use]
     pub fn scale_units(&self, new_units: f64) -> Self {
         Self {

--- a/crates/gdsr/src/traits/mod.rs
+++ b/crates/gdsr/src/traits/mod.rs
@@ -1,19 +1,25 @@
 use crate::transformation::{Reflection, Rotation, Scale, Transformation, Translation};
 use crate::{AngleInRadians, Point};
 
+/// Trait for types that can be serialized to the GDSII binary format.
 pub trait ToGds {
+    /// Writes the GDSII binary representation to the given buffer.
     fn to_gds_impl(&self, buffer: &mut impl std::io::Write, scale: f64) -> std::io::Result<()>;
 }
 
+/// Trait for types that can be geometrically transformed (rotated, scaled, reflected, translated).
 pub trait Transformable: Sized {
+    /// Applies a transformation and returns the transformed value.
     #[must_use]
     fn transform(self, transformation: impl Into<Transformation>) -> Self {
         self.transform_impl(&transformation.into())
     }
 
+    /// Applies a transformation reference and returns the transformed value.
     #[must_use]
     fn transform_impl(self, transformation: &Transformation) -> Self;
 
+    /// Rotates by the given angle (in radians) around the centre point.
     #[must_use]
     fn rotate(self, angle: AngleInRadians, centre: Point) -> Self {
         self.transform_impl(
@@ -21,11 +27,13 @@ pub trait Transformable: Sized {
         )
     }
 
+    /// Scales by the given factor around the centre point.
     #[must_use]
     fn scale(self, factor: f64, centre: Point) -> Self {
         self.transform_impl(Transformation::default().with_scale(Some(Scale::new(factor, centre))))
     }
 
+    /// Reflects across the axis defined by the given angle (in radians) through the centre point.
     #[must_use]
     fn reflect(self, angle: f64, centre: Point) -> Self {
         self.transform_impl(
@@ -33,6 +41,7 @@ pub trait Transformable: Sized {
         )
     }
 
+    /// Translates by the given delta point.
     #[must_use]
     fn translate(self, delta: Point) -> Self {
         self.transform_impl(
@@ -41,7 +50,9 @@ pub trait Transformable: Sized {
     }
 }
 
+/// Trait for types that can be repositioned by moving to an absolute target or by a relative delta.
 pub trait Movable: Transformable {
+    /// Moves the value by the given delta (relative translation).
     #[must_use]
     fn move_by(self, delta: Point) -> Self {
         self.transform_impl(
@@ -49,10 +60,13 @@ pub trait Movable: Transformable {
         )
     }
 
+    /// Moves the value to the given absolute target point.
     #[must_use]
     fn move_to(self, target: Point) -> Self;
 }
 
+/// Trait for types that have spatial dimensions and a bounding box.
 pub trait Dimensions {
+    /// Returns the axis-aligned bounding box as `(min_point, max_point)`.
     fn bounding_box(&self) -> (Point, Point);
 }

--- a/crates/gdsr/src/transformation/mod.rs
+++ b/crates/gdsr/src/transformation/mod.rs
@@ -10,6 +10,7 @@ pub use rotation::Rotation;
 pub use scale::Scale;
 pub use translation::Translation;
 
+/// A composite transformation that applies reflection, rotation, scale, and translation in order.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Transformation {
     pub reflection: Option<Reflection>,
@@ -19,26 +20,32 @@ pub struct Transformation {
 }
 
 impl Transformation {
+    /// Sets the reflection component and returns `&mut Self` for chaining.
     pub const fn with_reflection(&mut self, reflection: Option<Reflection>) -> &mut Self {
         self.reflection = reflection;
         self
     }
 
+    /// Sets the rotation component and returns `&mut Self` for chaining.
     pub const fn with_rotation(&mut self, rotation: Option<Rotation>) -> &mut Self {
         self.rotation = rotation;
         self
     }
 
+    /// Sets the scale component and returns `&mut Self` for chaining.
     pub const fn with_scale(&mut self, scale: Option<Scale>) -> &mut Self {
         self.scale = scale;
         self
     }
 
+    /// Sets the translation component and returns `&mut Self` for chaining.
     pub const fn with_translation(&mut self, translation: Option<Translation>) -> &mut Self {
         self.translation = translation;
         self
     }
 
+    /// Applies all transformation components to a point in order:
+    /// reflection, rotation, scale, then translation.
     pub fn apply_to_point(&self, point: &Point) -> Point {
         let mut new_point = *point;
 

--- a/crates/gdsr/src/transformation/reflection.rs
+++ b/crates/gdsr/src/transformation/reflection.rs
@@ -1,5 +1,6 @@
 use crate::{AngleInRadians, Point};
 
+/// A reflection transformation defined by an axis angle and centre point.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Reflection {
     angle: AngleInRadians,
@@ -17,14 +18,17 @@ impl std::fmt::Display for Reflection {
 }
 
 impl Reflection {
+    /// Creates a new reflection with the given axis angle (in radians) and centre point.
     pub const fn new(angle: AngleInRadians, centre: Point) -> Self {
         Self { angle, centre }
     }
 
+    /// Creates a horizontal reflection (angle = 0) about the x-axis.
     pub const fn new_horizontal() -> Self {
         Self::new(0.0, Point::integer(0, 1, 1e-9))
     }
 
+    /// Creates a reflection from a line defined by two points.
     pub fn from_line(point1: &Point, point2: &Point) -> Self {
         let dx = (point2.x() - point1.x()).absolute_value();
         let dy = (point2.y() - point1.y()).absolute_value();
@@ -36,6 +40,7 @@ impl Reflection {
         Self { angle, centre }
     }
 
+    /// Reflects a point across this reflection's axis and returns the new point.
     pub fn apply_to_point(&self, point: &Point) -> Point {
         let cos_2angle = (2.0 * self.angle).cos();
         let sin_2angle = (2.0 * self.angle).sin();

--- a/crates/gdsr/src/transformation/rotation.rs
+++ b/crates/gdsr/src/transformation/rotation.rs
@@ -1,5 +1,6 @@
 use crate::{AngleInRadians, Point};
 
+/// A rotation transformation defined by an angle (in radians) and a centre point.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Rotation {
     angle: AngleInRadians,
@@ -13,18 +14,22 @@ impl std::fmt::Display for Rotation {
 }
 
 impl Rotation {
+    /// Creates a new rotation with the given angle (in radians) and centre point.
     pub const fn new(angle: AngleInRadians, centre: Point) -> Self {
         Self { angle, centre }
     }
 
+    /// Returns the rotation angle in radians.
     pub const fn angle(&self) -> AngleInRadians {
         self.angle
     }
 
+    /// Returns the centre point of the rotation.
     pub const fn centre(&self) -> &Point {
         &self.centre
     }
 
+    /// Rotates a point around this rotation's centre and returns the new point.
     pub fn apply_to_point(&self, point: &Point) -> Point {
         let cos_angle = self.angle.cos();
         let sin_angle = self.angle.sin();

--- a/crates/gdsr/src/transformation/scale.rs
+++ b/crates/gdsr/src/transformation/scale.rs
@@ -1,5 +1,6 @@
 use crate::Point;
 
+/// A scale transformation defined by a factor and a centre point.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Scale {
     factor: f64,
@@ -13,18 +14,22 @@ impl std::fmt::Display for Scale {
 }
 
 impl Scale {
+    /// Creates a new scale with the given factor and centre point.
     pub const fn new(factor: f64, centre: Point) -> Self {
         Self { factor, centre }
     }
 
+    /// Returns the scale factor.
     pub const fn factor(&self) -> f64 {
         self.factor
     }
 
+    /// Returns the centre point of the scale.
     pub const fn centre(&self) -> &Point {
         &self.centre
     }
 
+    /// Scales a point relative to this scale's centre and returns the new point.
     pub fn apply_to_point(&self, point: &Point) -> Point {
         let self_center_x = self.centre.x();
         let self_center_y = self.centre.y();

--- a/crates/gdsr/src/transformation/translation.rs
+++ b/crates/gdsr/src/transformation/translation.rs
@@ -1,5 +1,6 @@
 use crate::Point;
 
+/// A translation transformation defined by a delta point.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Translation {
     delta: Point,
@@ -12,10 +13,12 @@ impl std::fmt::Display for Translation {
 }
 
 impl Translation {
+    /// Creates a new translation with the given delta.
     pub const fn new(delta: Point) -> Self {
         Self { delta }
     }
 
+    /// Translates a point by this translation's delta and returns the new point.
     pub fn apply_to_point(&self, point: &Point) -> Point {
         point + self.delta
     }

--- a/crates/gdsr/src/units.rs
+++ b/crates/gdsr/src/units.rs
@@ -4,12 +4,14 @@ type IntegerType = i32;
 type FloatType = f64;
 type UnitsType = f64;
 
+/// A unit value backed by a 32-bit integer.
 #[derive(Clone, Copy, Debug)]
 pub struct IntegerUnit {
     pub value: IntegerType,
     pub units: UnitsType,
 }
 
+/// A unit value backed by a 64-bit float.
 #[derive(Clone, Copy, Debug)]
 pub struct FloatUnit {
     pub value: FloatType,
@@ -30,7 +32,9 @@ pub enum Unit {
     Float(FloatUnit),
 }
 
+/// Default units for integer values (1e-9, i.e. nanometers).
 pub const DEFAULT_INTEGER_UNITS: UnitsType = 1e-9;
+/// Default units for float values (1e-6, i.e. micrometers).
 pub const DEFAULT_FLOAT_UNITS: UnitsType = 1e-6;
 
 impl Unit {
@@ -60,6 +64,7 @@ impl Unit {
         })
     }
 
+    /// Returns a zero-valued unit with default integer units.
     pub fn zero() -> Self {
         Self::default()
     }


### PR DESCRIPTION
## Summary
- Add doc comments to all public types and methods across 17 source files
- Covers units, transformations, elements, grid, cell, library, traits, and point types

Closes #48

## Test plan
- [x] `cargo test -p gdsr` passes
- [x] `uvx prek run -a` passes