### PR TITLE
Add Dimensions trait for Path, Text, Element, and Cell

### DIFF
--- a/crates/gdsr/src/cell/mod.rs
+++ b/crates/gdsr/src/cell/mod.rs
@@ -1,5 +1,6 @@
 use crate::{
-    Element, Library, Movable, Path, Polygon, Reference, Text, Transformable, Transformation,
+    Dimensions, Element, Library, Movable, Path, Point, Polygon, Reference, Text, Transformable,
+    Transformation,
 };
 
 mod io;
@@ -127,6 +128,29 @@ impl Transformable for Cell {
     }
 }
 
+impl Dimensions for Cell {
+    fn bounding_box(&self) -> (Point, Point) {
+        let all_points: Vec<Point> = self
+            .polygons
+            .iter()
+            .flat_map(|p| {
+                let (min, max) = p.bounding_box();
+                vec![min, max]
+            })
+            .chain(self.paths.iter().flat_map(|p| {
+                let (min, max) = p.bounding_box();
+                vec![min, max]
+            }))
+            .chain(self.texts.iter().flat_map(|t| {
+                let (min, max) = t.bounding_box();
+                vec![min, max]
+            }))
+            .collect();
+
+        crate::utils::geometry::bounding_box(&all_points)
+    }
+}
+
 impl Movable for Cell {
     fn move_to(mut self, target: crate::Point) -> Self {
         self.polygons = self
@@ -160,7 +184,6 @@ impl Movable for Cell {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Point;
 
     #[test]
     fn test_cell_new() {
@@ -255,5 +278,66 @@ mod tests {
         let rotated_elements = rotated_cell.get_elements(None, &library);
 
         insta::assert_debug_snapshot!(rotated_elements);
+    }
+
+    #[test]
+    fn test_cell_bounding_box() {
+        let mut cell = Cell::new("test");
+        cell.add(Polygon::new(
+            [
+                Point::integer(0, 0, 1e-9),
+                Point::integer(10, 0, 1e-9),
+                Point::integer(10, 10, 1e-9),
+            ],
+            1,
+            0,
+        ));
+        cell.add(Path::new(
+            vec![Point::integer(-5, 5, 1e-9), Point::integer(15, 20, 1e-9)],
+            1,
+            0,
+            None,
+            None,
+        ));
+        cell.add(Text::default().set_origin(Point::integer(3, -2, 1e-9)));
+
+        let (min, max) = cell.bounding_box();
+        assert_eq!(min, Point::integer(-5, -2, 1e-9));
+        assert_eq!(max, Point::integer(15, 20, 1e-9));
+    }
+
+    #[test]
+    fn test_cell_bounding_box_empty() {
+        let cell = Cell::new("empty");
+        let (min, max) = cell.bounding_box();
+        assert_eq!(min, Point::default());
+        assert_eq!(max, Point::default());
+    }
+
+    #[test]
+    fn test_cell_bounding_box_polygons_only() {
+        let mut cell = Cell::new("test");
+        cell.add(Polygon::new(
+            [
+                Point::integer(0, 0, 1e-9),
+                Point::integer(5, 0, 1e-9),
+                Point::integer(5, 5, 1e-9),
+            ],
+            1,
+            0,
+        ));
+        cell.add(Polygon::new(
+            [
+                Point::integer(10, 10, 1e-9),
+                Point::integer(20, 10, 1e-9),
+                Point::integer(20, 20, 1e-9),
+            ],
+            1,
+            0,
+        ));
+
+        let (min, max) = cell.bounding_box();
+        assert_eq!(min, Point::integer(0, 0, 1e-9));
+        assert_eq!(max, Point::integer(20, 20, 1e-9));
     }
 }

--- a/crates/gdsr/src/elements/element.rs
+++ b/crates/gdsr/src/elements/element.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::elements::{Path, Polygon, Reference, Text};
 use crate::traits::ToGds;
-use crate::{Instance, Movable, Point, Transformable, Transformation};
+use crate::{Dimensions, Instance, Movable, Point, Transformable, Transformation};
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Element {
@@ -112,6 +112,17 @@ impl Movable for Element {
             Self::Polygon(polygon) => Self::Polygon(polygon.move_to(target)),
             Self::Reference(reference) => Self::Reference(reference.move_to(target)),
             Self::Text(text) => Self::Text(text.move_to(target)),
+        }
+    }
+}
+
+impl Dimensions for Element {
+    fn bounding_box(&self) -> (Point, Point) {
+        match self {
+            Self::Path(path) => path.bounding_box(),
+            Self::Polygon(polygon) => polygon.bounding_box(),
+            Self::Text(text) => text.bounding_box(),
+            Self::Reference(_) => (Point::default(), Point::default()),
         }
     }
 }
@@ -315,5 +326,64 @@ mod tests {
         let moved = element.move_by(delta);
 
         assert!(moved.as_path().is_some());
+    }
+
+    #[test]
+    fn test_element_bounding_box_polygon() {
+        let polygon = Polygon::new(
+            [
+                Point::integer(0, 0, 1e-9),
+                Point::integer(10, 0, 1e-9),
+                Point::integer(10, 10, 1e-9),
+            ],
+            1,
+            0,
+        );
+        let element: Element = polygon.into();
+        let (min, max) = element.bounding_box();
+        assert_eq!(min, Point::integer(0, 0, 1e-9));
+        assert_eq!(max, Point::integer(10, 10, 1e-9));
+    }
+
+    #[test]
+    fn test_element_bounding_box_path() {
+        let path = Path::new(
+            vec![Point::integer(-5, 3, 1e-9), Point::integer(10, 7, 1e-9)],
+            1,
+            0,
+            None,
+            None,
+        );
+        let element: Element = path.into();
+        let (min, max) = element.bounding_box();
+        assert_eq!(min, Point::integer(-5, 3, 1e-9));
+        assert_eq!(max, Point::integer(10, 7, 1e-9));
+    }
+
+    #[test]
+    fn test_element_bounding_box_text() {
+        let text = Text::default().set_origin(Point::integer(5, 10, 1e-9));
+        let element: Element = text.into();
+        let (min, max) = element.bounding_box();
+        assert_eq!(min, Point::integer(5, 10, 1e-9));
+        assert_eq!(max, Point::integer(5, 10, 1e-9));
+    }
+
+    #[test]
+    fn test_element_bounding_box_reference() {
+        let polygon = Polygon::new(
+            [
+                Point::integer(0, 0, 1e-9),
+                Point::integer(10, 0, 1e-9),
+                Point::integer(10, 10, 1e-9),
+            ],
+            1,
+            0,
+        );
+        let reference = Reference::new(polygon);
+        let element: Element = reference.into();
+        let (min, max) = element.bounding_box();
+        assert_eq!(min, Point::default());
+        assert_eq!(max, Point::default());
     }
 }

--- a/crates/gdsr/src/elements/path/mod.rs
+++ b/crates/gdsr/src/elements/path/mod.rs
@@ -1,4 +1,4 @@
-use crate::{DataType, Layer, Movable, Point, Transformable, Unit};
+use crate::{DataType, Dimensions, Layer, Movable, Point, Transformable, Unit};
 
 mod io;
 mod path_type;
@@ -88,6 +88,12 @@ impl Movable for Path {
     }
 }
 
+impl Dimensions for Path {
+    fn bounding_box(&self) -> (Point, Point) {
+        crate::utils::geometry::bounding_box(&self.points)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -164,5 +170,35 @@ mod tests {
         let points = vec![Point::integer(0, 0, 1e-9), Point::float(100.0, 100.0, 1e-6)];
         let path = Path::new(points, 0, 0, None, None);
         assert_eq!(path.points().len(), 2);
+    }
+
+    #[test]
+    fn test_path_bounding_box() {
+        let points = vec![
+            Point::integer(0, 0, 1e-9),
+            Point::integer(10, 5, 1e-9),
+            Point::integer(20, -3, 1e-9),
+        ];
+        let path = Path::new(points, 1, 0, None, None);
+        let (min, max) = path.bounding_box();
+        assert_eq!(min, Point::integer(0, -3, 1e-9));
+        assert_eq!(max, Point::integer(20, 5, 1e-9));
+    }
+
+    #[test]
+    fn test_path_bounding_box_empty() {
+        let path = Path::default();
+        let (min, max) = path.bounding_box();
+        assert_eq!(min, Point::default());
+        assert_eq!(max, Point::default());
+    }
+
+    #[test]
+    fn test_path_bounding_box_single_point() {
+        let points = vec![Point::integer(5, 10, 1e-9)];
+        let path = Path::new(points, 1, 0, None, None);
+        let (min, max) = path.bounding_box();
+        assert_eq!(min, Point::integer(5, 10, 1e-9));
+        assert_eq!(max, Point::integer(5, 10, 1e-9));
     }
 }

--- a/crates/gdsr/src/elements/text/mod.rs
+++ b/crates/gdsr/src/elements/text/mod.rs
@@ -1,4 +1,4 @@
-use crate::{DataType, Layer, Movable, Point, Transformable};
+use crate::{DataType, Dimensions, Layer, Movable, Point, Transformable};
 
 pub mod io;
 pub mod presentation;
@@ -182,6 +182,12 @@ impl Movable for Text {
     fn move_to(mut self, target: Point) -> Self {
         self.origin = target;
         self
+    }
+}
+
+impl Dimensions for Text {
+    fn bounding_box(&self) -> (Point, Point) {
+        (self.origin, self.origin)
     }
 }
 
@@ -391,6 +397,23 @@ mod tests {
 
         assert_eq!(scaled.magnification(), 3.0);
         assert_eq!(scaled.origin(), &Point::integer(20, 40, 1e-9));
+    }
+
+    #[test]
+    fn test_text_bounding_box() {
+        let origin = Point::integer(10, 20, 1e-9);
+        let text = Text::default().set_origin(origin);
+        let (min, max) = text.bounding_box();
+        assert_eq!(min, origin);
+        assert_eq!(max, origin);
+    }
+
+    #[test]
+    fn test_text_bounding_box_default() {
+        let text = Text::default();
+        let (min, max) = text.bounding_box();
+        assert_eq!(min, Point::integer(0, 0, 1e-9));
+        assert_eq!(max, Point::integer(0, 0, 1e-9));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Implement `Dimensions` trait (`bounding_box()`) for Path, Text, Element, and Cell
- Path: bounding box of points (width not accounted for)
- Text: bounding box is origin point
- Element: dispatches to inner type (Reference returns default)
- Cell: combines bounding boxes of all polygons, paths, and texts
- 12 new tests

Closes #46

## Test plan
- [x] `cargo test -p gdsr` passes
- [x] `uvx prek run -a` passes