### PR TITLE
Return error for oversized polygons (#74)

### DIFF
--- a/crates/gdsr/src/elements/polygon/io.rs
+++ b/crates/gdsr/src/elements/polygon/io.rs
@@ -10,7 +10,14 @@ use crate::utils::io::{
 impl ToGds for Polygon {
     fn to_gds_impl(&self, buffer: &mut impl std::io::Write, database_units: f64) -> io::Result<()> {
         if self.points().len() > MAX_POINTS {
-            return Ok(());
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "Polygon has {} points, which exceeds the maximum of {}",
+                    self.points().len(),
+                    MAX_POINTS
+                ),
+            ));
         }
 
         let polygon_head = [

--- a/crates/gdsr/tests/read_write.rs
+++ b/crates/gdsr/tests/read_write.rs
@@ -907,17 +907,9 @@ fn test_invalid_polygon() {
 
     library.add_cell(cell);
 
-    let _res = library.write_file(&gds_path, 1e-9, 1e-9);
+    let res = library.write_file(&gds_path, 1e-9, 1e-9);
 
-    let new_library = Library::read_file(&gds_path, Some(DEFAULT_INTEGER_UNITS)).unwrap();
-
-    let mut expected_library = Library::new("reference_test");
-
-    let cell = Cell::new("cell");
-
-    expected_library.add_cell(cell);
-
-    assert_eq!(expected_library, new_library);
+    assert!(res.is_err());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Return an `io::Error` with `ErrorKind::InvalidInput` when a polygon exceeds `MAX_POINTS` (8191), instead of silently returning `Ok(())` and discarding the data
- Update `test_invalid_polygon` to assert the write returns an error

Closes #74

## Test plan
- [x] `cargo test` passes (all 387 tests)
- [x] `cargo clippy` clean
- [x] Pre-commit checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)