### PR TITLE
Write SREF for single-instance cell references

### DIFF
--- a/crates/gdsr/src/elements/reference/io.rs
+++ b/crates/gdsr/src/elements/reference/io.rs
@@ -45,10 +45,15 @@ impl Reference {
         database_units: f64,
         cell_name: &str,
     ) -> Result<(), GdsError> {
-        let buffer_start = [
-            4,
-            combine_record_and_data_type(GDSRecord::ARef, GDSDataType::NoData),
-        ];
+        let is_single_instance = self.grid().columns() == 1 && self.grid().rows() == 1;
+
+        let record = if is_single_instance {
+            GDSRecord::SRef
+        } else {
+            GDSRecord::ARef
+        };
+
+        let buffer_start = [4, combine_record_and_data_type(record, GDSDataType::NoData)];
 
         write_u16_array_to_file(buffer, &buffer_start)?;
 
@@ -60,46 +65,52 @@ impl Reference {
 
         write_transformation_to_file(buffer, angle, magnification, x_reflection)?;
 
-        let buffer_array = [
-            8,
-            combine_record_and_data_type(GDSRecord::ColRow, GDSDataType::TwoByteSignedInteger),
-            self.grid().columns() as u16,
-            self.grid().rows() as u16,
-        ];
+        if is_single_instance {
+            let origin = self.grid().origin();
+            let reference_points = [origin];
+            write_points_to_file(buffer, &reference_points, database_units)?;
+        } else {
+            let buffer_array = [
+                8,
+                combine_record_and_data_type(GDSRecord::ColRow, GDSDataType::TwoByteSignedInteger),
+                self.grid().columns() as u16,
+                self.grid().rows() as u16,
+            ];
 
-        write_u16_array_to_file(buffer, &buffer_array)?;
+            write_u16_array_to_file(buffer, &buffer_array)?;
 
-        let origin = self
-            .grid()
-            .origin()
-            .rotate_around_point(self.grid().angle(), &self.grid().origin());
+            let origin = self
+                .grid()
+                .origin()
+                .rotate_around_point(self.grid().angle(), &self.grid().origin());
 
-        match (self.grid.spacing_x(), self.grid.spacing_y()) {
-            (Some(spacing_x), Some(spacing_y)) => {
-                let point2 = ((origin + spacing_x) * self.grid().columns())
-                    .rotate_around_point(self.grid().angle(), &origin);
+            match (self.grid.spacing_x(), self.grid.spacing_y()) {
+                (Some(spacing_x), Some(spacing_y)) => {
+                    let point2 = ((origin + spacing_x) * self.grid().columns())
+                        .rotate_around_point(self.grid().angle(), &origin);
 
-                let point3 = ((origin + spacing_y) * self.grid().rows())
-                    .rotate_around_point(self.grid().angle(), &origin);
+                    let point3 = ((origin + spacing_y) * self.grid().rows())
+                        .rotate_around_point(self.grid().angle(), &origin);
 
-                let reference_points = [origin, point2, point3];
-                write_points_to_file(buffer, &reference_points, database_units)?;
-            }
-            (Some(spacing_x), None) => {
-                let point2 = ((origin + spacing_x) * self.grid().columns())
-                    .rotate_around_point(self.grid().angle(), &origin);
-                let reference_points = [origin, point2, origin];
-                write_points_to_file(buffer, &reference_points, database_units)?;
-            }
-            (None, Some(spacing_y)) => {
-                let point3 = ((origin + spacing_y) * self.grid().rows())
-                    .rotate_around_point(self.grid().angle(), &origin);
-                let reference_points = [origin, origin, point3];
-                write_points_to_file(buffer, &reference_points, database_units)?;
-            }
-            _ => {
-                let reference_points = [origin];
-                write_points_to_file(buffer, &reference_points, database_units)?;
+                    let reference_points = [origin, point2, point3];
+                    write_points_to_file(buffer, &reference_points, database_units)?;
+                }
+                (Some(spacing_x), None) => {
+                    let point2 = ((origin + spacing_x) * self.grid().columns())
+                        .rotate_around_point(self.grid().angle(), &origin);
+                    let reference_points = [origin, point2, origin];
+                    write_points_to_file(buffer, &reference_points, database_units)?;
+                }
+                (None, Some(spacing_y)) => {
+                    let point3 = ((origin + spacing_y) * self.grid().rows())
+                        .rotate_around_point(self.grid().angle(), &origin);
+                    let reference_points = [origin, origin, point3];
+                    write_points_to_file(buffer, &reference_points, database_units)?;
+                }
+                _ => {
+                    let reference_points = [origin];
+                    write_points_to_file(buffer, &reference_points, database_units)?;
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- Fix the GDS write path to emit SREF (instead of AREF) for single-instance (1x1) cell references, per the GDS2 specification
- When `columns == 1 && rows == 1`, writes SREF header with a single XY point and no COLROW record
- Multi-instance references continue to use AREF with COLROW and 3 XY points as before

Closes #75

## Test plan
- [x] All 387 existing tests pass, including roundtrip tests for 1x1 references (`test_nested_references`, `test_single_cell_with_all_element_types`, `test_multiple_cells_referencing_same_cell`)
- [x] `cargo clippy` reports no warnings
- [x] `cargo fmt` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)