### PR TITLE
Add quickcheck property tests for Point

### DIFF
--- a/crates/gdsr/src/point/mod.rs
+++ b/crates/gdsr/src/point/mod.rs
@@ -291,6 +291,39 @@ mod tests {
 
     use super::*;
 
+    use quickcheck::{Arbitrary, Gen};
+
+    const MAX_VALUE: i32 = 10_000;
+
+    impl Arbitrary for Point {
+        fn arbitrary(g: &mut Gen) -> Self {
+            let units_options = [1e-9, 1e-8, 1e-7, 1e-6];
+            let units = units_options[usize::arbitrary(g) % units_options.len()];
+
+            if bool::arbitrary(g) {
+                let x = (i32::arbitrary(g) % MAX_VALUE).clamp(-MAX_VALUE, MAX_VALUE);
+                let y = (i32::arbitrary(g) % MAX_VALUE).clamp(-MAX_VALUE, MAX_VALUE);
+                Self::integer(x, y, units)
+            } else {
+                let raw_x = f64::arbitrary(g);
+                let raw_y = f64::arbitrary(g);
+                let x = if raw_x.is_finite() {
+                    (raw_x % f64::from(MAX_VALUE))
+                        .clamp(f64::from(-MAX_VALUE), f64::from(MAX_VALUE))
+                } else {
+                    0.0
+                };
+                let y = if raw_y.is_finite() {
+                    (raw_y % f64::from(MAX_VALUE))
+                        .clamp(f64::from(-MAX_VALUE), f64::from(MAX_VALUE))
+                } else {
+                    0.0
+                };
+                Self::float(x, y, units)
+            }
+        }
+    }
+
     mod creation {
         use super::*;
 
@@ -643,6 +676,87 @@ mod tests {
 
             assert_eq!(result.x(), Unit::float(-5.0, 1e-6));
             assert_eq!(result.y(), Unit::float(-10.0, 1e-6));
+        }
+    }
+
+    mod property_tests {
+        use std::f64::consts::TAU;
+
+        use super::*;
+        use quickcheck_macros::quickcheck;
+
+        #[quickcheck]
+        fn addition_commutativity(a: Point, b: Point) -> bool {
+            let a = a.to_float_unit();
+            let b = b.to_float_unit().scale_units(a.units().0);
+
+            (a + b) == (b + a)
+        }
+
+        #[quickcheck]
+        fn addition_associativity(a: Point, b: Point, c: Point) -> bool {
+            let units = a.units().0;
+            let a = a.to_float_unit();
+            let b = b.to_float_unit().scale_units(units);
+            let c = c.to_float_unit().scale_units(units);
+
+            ((a + b) + c) == (a + (b + c))
+        }
+
+        #[quickcheck]
+        fn additive_identity(a: Point) -> bool {
+            let zero = Point::float(0.0, 0.0, a.units().0);
+            let a = a.to_float_unit();
+
+            let a_plus_zero = a + zero;
+            let zero_plus_a = zero + a;
+            a_plus_zero == a && zero_plus_a == a
+        }
+
+        /// Verifies that a + (-a) produces a zero point.
+        #[quickcheck]
+        fn additive_inverse(a: Point) -> bool {
+            let units = a.units().0;
+            let neg_a = Point::new(
+                Unit::float(-a.x().float_value(), units),
+                Unit::float(-a.y().float_value(), units),
+            );
+            let a = a.to_float_unit();
+
+            let result = a + neg_a;
+            result.x().absolute_value().abs() < 1e-9 && result.y().absolute_value().abs() < 1e-9
+        }
+
+        /// Verifies scalar multiplication distributes over point addition.
+        /// Uses float points with matching units and approximate comparison
+        /// to account for floating point rounding in different evaluation orders.
+        #[quickcheck]
+        fn scalar_multiplication_distributivity(a: Point, b: Point, s: i32) -> bool {
+            let units = a.units().0;
+            let a = Point::float(a.x().float_value(), a.y().float_value(), units);
+            let b = Point::float(b.x().float_value(), b.y().float_value(), units);
+            let s = (s % MAX_VALUE).clamp(-MAX_VALUE, MAX_VALUE);
+
+            let lhs = (a + b) * s;
+            let rhs = (a * s) + (b * s);
+
+            let dx = (lhs.x().absolute_value() - rhs.x().absolute_value()).abs();
+            let dy = (lhs.y().absolute_value() - rhs.y().absolute_value()).abs();
+
+            dx < units && dy < units
+        }
+
+        /// Verifies that rotation by 2*pi returns approximately the original point.
+        #[quickcheck]
+        fn rotation_by_2pi_is_identity(a: Point) -> bool {
+            let a = a.to_float_unit();
+            let origin = Point::float(0.0, 0.0, a.units().0);
+            let rotated = a.rotate(TAU, origin);
+
+            let dx = (rotated.x().absolute_value() - a.x().absolute_value()).abs();
+            let dy = (rotated.y().absolute_value() - a.y().absolute_value()).abs();
+
+            dx < 1e-9 && dy < 1e-9
         }
     }
 }


### PR DESCRIPTION
## Summary
- Implement `Arbitrary` for `Point` following the existing pattern in `units.rs`
- Add 6 quickcheck property tests for `Point` arithmetic and rotation:
  - Addition commutativity: `a + b == b + a`
  - Addition associativity: `(a + b) + c == a + (b + c)`
  - Additive identity: `a + zero == a` and `zero + a == a`
  - Additive inverse: `a + (-a) ≈ zero`
  - Scalar multiplication distributivity: `(a + b) * s ≈ a * s + b * s`
  - Rotation by 2π ≈ identity (within floating point tolerance)

Closes #80

## Test plan
- [x] All 6 new property tests pass (`cargo test -p gdsr point::tests::property_tests`)
- [x] Full test suite passes (368 tests)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean
- [x] All pre-commit checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)