### PR TITLE
Add GDS2 spec validation for element fields

### DIFF
--- a/crates/gdsr/src/cell/io.rs
+++ b/crates/gdsr/src/cell/io.rs
@@ -4,7 +4,9 @@ use crate::Cell;
 use crate::config::gds_file_types::{GDSDataType, GDSRecord, combine_record_and_data_type};
 use crate::error::GdsError;
 use crate::traits::ToGds;
-use crate::utils::io::{write_string_with_record_to_file, write_u16_array_to_file};
+use crate::utils::io::{
+    validate_structure_name, write_string_with_record_to_file, write_u16_array_to_file,
+};
 
 impl ToGds for Cell {
     fn to_gds_impl(
@@ -12,6 +14,8 @@ impl ToGds for Cell {
         buffer: &mut impl std::io::Write,
         database_units: f64,
     ) -> Result<(), GdsError> {
+        validate_structure_name(&self.name)?;
+
         let now = Local::now();
         let timestamp = now.naive_utc();
 

--- a/crates/gdsr/src/elements/path/io.rs
+++ b/crates/gdsr/src/elements/path/io.rs
@@ -2,7 +2,10 @@ use super::Path;
 use crate::config::gds_file_types::{GDSDataType, GDSRecord, combine_record_and_data_type};
 use crate::error::GdsError;
 use crate::traits::ToGds;
-use crate::utils::io::{write_element_tail_to_file, write_points_to_file, write_u16_array_to_file};
+use crate::utils::io::{
+    validate_data_type, validate_layer, write_element_tail_to_file, write_points_to_file,
+    write_u16_array_to_file,
+};
 
 impl ToGds for Path {
     fn to_gds_impl(
@@ -10,6 +13,9 @@ impl ToGds for Path {
         buffer: &mut impl std::io::Write,
         database_units: f64,
     ) -> Result<(), GdsError> {
+        validate_layer(self.layer())?;
+        validate_data_type(self.data_type())?;
+
         if self.points().len() < 2 {
             return Err(GdsError::ValidationError {
                 message: "Path must have at least 2 points".to_string(),

--- a/crates/gdsr/src/elements/polygon/io.rs
+++ b/crates/gdsr/src/elements/polygon/io.rs
@@ -3,7 +3,8 @@ use crate::config::gds_file_types::{GDSDataType, GDSRecord, combine_record_and_d
 use crate::error::GdsError;
 use crate::traits::ToGds;
 use crate::utils::io::{
-    MAX_POINTS, write_element_tail_to_file, write_points_to_file, write_u16_array_to_file,
+    MAX_POINTS, MIN_POLYGON_POINTS, validate_data_type, validate_layer, write_element_tail_to_file,
+    write_points_to_file, write_u16_array_to_file,
 };
 
 impl ToGds for Polygon {
@@ -18,6 +19,18 @@ impl ToGds for Polygon {
                     "Polygon has {} points, which exceeds the maximum of {}",
                     self.points().len(),
                     MAX_POINTS
+                ),
+            });
+        }
+
+        validate_layer(self.layer())?;
+        validate_data_type(self.data_type())?;
+
+        if self.points().len() < MIN_POLYGON_POINTS {
+            return Err(GdsError::ValidationError {
+                message: format!(
+                    "Polygon must have at least {MIN_POLYGON_POINTS} points (3 vertices + closing point), got {}",
+                    self.points().len()
                 ),
             });
         }

--- a/crates/gdsr/src/elements/reference/io.rs
+++ b/crates/gdsr/src/elements/reference/io.rs
@@ -4,8 +4,8 @@ use crate::elements::Element;
 use crate::error::GdsError;
 use crate::traits::ToGds;
 use crate::utils::io::{
-    write_element_tail_to_file, write_points_to_file, write_string_with_record_to_file,
-    write_transformation_to_file, write_u16_array_to_file,
+    validate_col_row, write_element_tail_to_file, write_points_to_file,
+    write_string_with_record_to_file, write_transformation_to_file, write_u16_array_to_file,
 };
 
 impl ToGds for Reference {
@@ -45,6 +45,8 @@ impl Reference {
         database_units: f64,
         cell_name: &str,
     ) -> Result<(), GdsError> {
+        validate_col_row(self.grid().columns(), self.grid().rows())?;
+
         let is_single_instance = self.grid().columns() == 1 && self.grid().rows() == 1;
 
         let record = if is_single_instance {

--- a/crates/gdsr/src/elements/text/io.rs
+++ b/crates/gdsr/src/elements/text/io.rs
@@ -4,8 +4,8 @@ use crate::config::gds_file_types::{GDSDataType, GDSRecord, combine_record_and_d
 use crate::error::GdsError;
 use crate::traits::ToGds;
 use crate::utils::io::{
-    write_element_tail_to_file, write_points_to_file, write_string_with_record_to_file,
-    write_transformation_to_file, write_u16_array_to_file,
+    validate_layer, validate_string_length, write_element_tail_to_file, write_points_to_file,
+    write_string_with_record_to_file, write_transformation_to_file, write_u16_array_to_file,
 };
 
 impl ToGds for Text {
@@ -14,6 +14,9 @@ impl ToGds for Text {
         buffer: &mut impl std::io::Write,
         database_units: f64,
     ) -> Result<(), GdsError> {
+        validate_layer(self.layer())?;
+        validate_string_length(self.text())?;
+
         let buffer_start = vec![
             4,
             combine_record_and_data_type(GDSRecord::Text, GDSDataType::NoData),

--- a/crates/gdsr/src/utils/io.rs
+++ b/crates/gdsr/src/utils/io.rs
@@ -85,6 +85,89 @@ pub fn write_float_to_eight_byte_real_to_file(
 }
 
 pub const MAX_POINTS: usize = 8191;
+pub const MAX_LAYER: u16 = 255;
+pub const MAX_DATA_TYPE: u16 = 255;
+pub const MAX_STRING_LENGTH: usize = 512;
+pub const MAX_STRUCTURE_NAME_LENGTH: usize = 32;
+pub const MAX_COL_ROW: u32 = 32767;
+pub const MIN_POLYGON_POINTS: usize = 4;
+
+/// Returns an `InvalidInput` error if the layer is out of the GDS2 spec range (0-255).
+pub fn validate_layer(layer: u16) -> io::Result<()> {
+    if layer > MAX_LAYER {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("Layer {layer} exceeds maximum value of {MAX_LAYER}"),
+        ));
+    }
+    Ok(())
+}
+
+/// Returns an `InvalidInput` error if the data type is out of the GDS2 spec range (0-255).
+pub fn validate_data_type(data_type: u16) -> io::Result<()> {
+    if data_type > MAX_DATA_TYPE {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("Data type {data_type} exceeds maximum value of {MAX_DATA_TYPE}"),
+        ));
+    }
+    Ok(())
+}
+
+/// Returns an `InvalidInput` error if the string exceeds 512 characters.
+pub fn validate_string_length(s: &str) -> io::Result<()> {
+    if s.len() > MAX_STRING_LENGTH {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "String length {} exceeds maximum of {MAX_STRING_LENGTH} characters",
+                s.len()
+            ),
+        ));
+    }
+    Ok(())
+}
+
+/// Returns an `InvalidInput` error if the structure name exceeds 32 characters or contains
+/// invalid characters (only alphanumeric, `_`, `?`, `$` are allowed).
+pub fn validate_structure_name(name: &str) -> io::Result<()> {
+    if name.len() > MAX_STRUCTURE_NAME_LENGTH {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "Structure name length {} exceeds maximum of {MAX_STRUCTURE_NAME_LENGTH} characters",
+                name.len()
+            ),
+        ));
+    }
+    if let Some(c) = name
+        .chars()
+        .find(|c| !c.is_ascii_alphanumeric() && *c != '_' && *c != '?' && *c != '$')
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("Structure name contains invalid character: '{c}'"),
+        ));
+    }
+    Ok(())
+}
+
+/// Returns an `InvalidInput` error if columns or rows exceed 32767.
+pub fn validate_col_row(columns: u32, rows: u32) -> io::Result<()> {
+    if columns > MAX_COL_ROW {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("Column count {columns} exceeds maximum value of {MAX_COL_ROW}"),
+        ));
+    }
+    if rows > MAX_COL_ROW {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("Row count {rows} exceeds maximum value of {MAX_COL_ROW}"),
+        ));
+    }
+    Ok(())
+}
 
 pub fn write_points_to_file(
     buffer: &mut impl std::io::Write,

--- a/crates/gdsr/tests/read_write.rs
+++ b/crates/gdsr/tests/read_write.rs
@@ -1116,3 +1116,293 @@ fn test_multiple_cells_referencing_same_cell() {
 
     assert_eq!(library, new_library);
 }
+
+fn assert_write_validation_error(library: &Library) {
+    let temp_dir = tempdir().unwrap();
+    let gds_path = temp_dir.path().join("validation.gds");
+    let err = library.write_file(&gds_path, 1e-9, 1e-9).unwrap_err();
+    let is_validation = match &err {
+        GdsError::ValidationError { .. } => true,
+        GdsError::Io(e) => e.kind() == std::io::ErrorKind::InvalidInput,
+        GdsError::InvalidData { .. } => false,
+    };
+    assert!(is_validation, "expected validation error, got: {err}");
+}
+
+#[test]
+fn test_polygon_invalid_layer() {
+    let units = 1e-9;
+    let mut library = Library::new("lib");
+    let mut cell = Cell::new("cell");
+    cell.add(Polygon::new(
+        [
+            Point::integer(0, 0, units),
+            Point::integer(10, 0, units),
+            Point::integer(10, 10, units),
+        ],
+        256,
+        0,
+    ));
+    library.add_cell(cell);
+    assert_write_validation_error(&library);
+}
+
+#[test]
+fn test_polygon_invalid_data_type() {
+    let units = 1e-9;
+    let mut library = Library::new("lib");
+    let mut cell = Cell::new("cell");
+    cell.add(Polygon::new(
+        [
+            Point::integer(0, 0, units),
+            Point::integer(10, 0, units),
+            Point::integer(10, 10, units),
+        ],
+        0,
+        256,
+    ));
+    library.add_cell(cell);
+    assert_write_validation_error(&library);
+}
+
+#[test]
+fn test_polygon_too_few_points() {
+    let units = 1e-9;
+    let mut library = Library::new("lib");
+    let mut cell = Cell::new("cell");
+    cell.add(Polygon::new(
+        [Point::integer(0, 0, units), Point::integer(10, 0, units)],
+        0,
+        0,
+    ));
+    library.add_cell(cell);
+    assert_write_validation_error(&library);
+}
+
+#[test]
+fn test_path_invalid_layer() {
+    let units = 1e-9;
+    let mut library = Library::new("lib");
+    let mut cell = Cell::new("cell");
+    cell.add(Path::new(
+        vec![Point::integer(0, 0, units), Point::integer(10, 0, units)],
+        256,
+        0,
+        None,
+        None,
+    ));
+    library.add_cell(cell);
+    assert_write_validation_error(&library);
+}
+
+#[test]
+fn test_path_invalid_data_type() {
+    let units = 1e-9;
+    let mut library = Library::new("lib");
+    let mut cell = Cell::new("cell");
+    cell.add(Path::new(
+        vec![Point::integer(0, 0, units), Point::integer(10, 0, units)],
+        0,
+        256,
+        None,
+        None,
+    ));
+    library.add_cell(cell);
+    assert_write_validation_error(&library);
+}
+
+#[test]
+fn test_text_invalid_layer() {
+    let units = 1e-9;
+    let mut library = Library::new("lib");
+    let mut cell = Cell::new("cell");
+    cell.add(Text::new(
+        "hello",
+        Point::integer(0, 0, units),
+        256,
+        0,
+        1.0,
+        0.0,
+        false,
+        VerticalPresentation::default(),
+        HorizontalPresentation::default(),
+    ));
+    library.add_cell(cell);
+    assert_write_validation_error(&library);
+}
+
+#[test]
+fn test_text_string_too_long() {
+    let units = 1e-9;
+    let mut library = Library::new("lib");
+    let mut cell = Cell::new("cell");
+    let long_string = "a".repeat(513);
+    cell.add(Text::new(
+        &long_string,
+        Point::integer(0, 0, units),
+        0,
+        0,
+        1.0,
+        0.0,
+        false,
+        VerticalPresentation::default(),
+        HorizontalPresentation::default(),
+    ));
+    library.add_cell(cell);
+    assert_write_validation_error(&library);
+}
+
+#[test]
+fn test_text_string_at_max_length() {
+    let units = 1e-9;
+    let mut library = Library::new("lib");
+    let mut cell = Cell::new("cell");
+    let max_string = "a".repeat(512);
+    cell.add(Text::new(
+        &max_string,
+        Point::integer(0, 0, units),
+        0,
+        0,
+        1.0,
+        0.0,
+        false,
+        VerticalPresentation::default(),
+        HorizontalPresentation::default(),
+    ));
+    library.add_cell(cell);
+    let temp_dir = tempdir().unwrap();
+    let gds_path = temp_dir.path().join("valid.gds");
+    assert!(library.write_file(&gds_path, 1e-9, 1e-9).is_ok());
+}
+
+#[test]
+fn test_cell_name_too_long() {
+    let mut library = Library::new("lib");
+    let long_name = "a".repeat(33);
+    let cell = Cell::new(&long_name);
+    library.add_cell(cell);
+    assert_write_validation_error(&library);
+}
+
+#[test]
+fn test_cell_name_invalid_characters() {
+    let mut library = Library::new("lib");
+    let cell = Cell::new("cell with spaces");
+    library.add_cell(cell);
+    assert_write_validation_error(&library);
+}
+
+#[test]
+fn test_cell_name_valid_special_characters() {
+    let mut library = Library::new("lib");
+    let cell = Cell::new("CELL_with$valid?chars");
+    library.add_cell(cell);
+    let temp_dir = tempdir().unwrap();
+    let gds_path = temp_dir.path().join("valid.gds");
+    assert!(library.write_file(&gds_path, 1e-9, 1e-9).is_ok());
+}
+
+#[test]
+fn test_cell_name_at_max_length() {
+    let mut library = Library::new("lib");
+    let max_name = "a".repeat(32);
+    let cell = Cell::new(&max_name);
+    library.add_cell(cell);
+    let temp_dir = tempdir().unwrap();
+    let gds_path = temp_dir.path().join("valid.gds");
+    assert!(library.write_file(&gds_path, 1e-9, 1e-9).is_ok());
+}
+
+#[test]
+fn test_reference_columns_exceed_max() {
+    let units = 1e-9;
+    let mut library = Library::new("lib");
+    let mut base_cell = Cell::new("base");
+    base_cell.add(Polygon::new(
+        [
+            Point::integer(0, 0, units),
+            Point::integer(10, 0, units),
+            Point::integer(10, 10, units),
+            Point::integer(0, 10, units),
+        ],
+        0,
+        0,
+    ));
+    library.add_cell(base_cell);
+
+    let mut cell = Cell::new("cell");
+    cell.add(Reference::new("base").with_grid(Grid::default().with_columns(32768).with_rows(1)));
+    library.add_cell(cell);
+    assert_write_validation_error(&library);
+}
+
+#[test]
+fn test_reference_rows_exceed_max() {
+    let units = 1e-9;
+    let mut library = Library::new("lib");
+    let mut base_cell = Cell::new("base");
+    base_cell.add(Polygon::new(
+        [
+            Point::integer(0, 0, units),
+            Point::integer(10, 0, units),
+            Point::integer(10, 10, units),
+            Point::integer(0, 10, units),
+        ],
+        0,
+        0,
+    ));
+    library.add_cell(base_cell);
+
+    let mut cell = Cell::new("cell");
+    cell.add(Reference::new("base").with_grid(Grid::default().with_columns(1).with_rows(32768)));
+    library.add_cell(cell);
+    assert_write_validation_error(&library);
+}
+
+#[test]
+fn test_reference_col_row_at_max() {
+    let units = 1e-9;
+    let mut library = Library::new("lib");
+    let mut base_cell = Cell::new("base");
+    base_cell.add(Polygon::new(
+        [
+            Point::integer(0, 0, units),
+            Point::integer(10, 0, units),
+            Point::integer(10, 10, units),
+            Point::integer(0, 10, units),
+        ],
+        0,
+        0,
+    ));
+    library.add_cell(base_cell);
+
+    let mut cell = Cell::new("cell");
+    cell.add(
+        Reference::new("base").with_grid(Grid::default().with_columns(32767).with_rows(32767)),
+    );
+    library.add_cell(cell);
+    let temp_dir = tempdir().unwrap();
+    let gds_path = temp_dir.path().join("valid.gds");
+    assert!(library.write_file(&gds_path, 1e-9, 1e-9).is_ok());
+}
+
+#[test]
+fn test_polygon_layer_and_data_type_at_boundary() {
+    let units = 1e-9;
+    let mut library = Library::new("lib");
+    let mut cell = Cell::new("cell");
+    cell.add(Polygon::new(
+        [
+            Point::integer(0, 0, units),
+            Point::integer(10, 0, units),
+            Point::integer(10, 10, units),
+            Point::integer(0, 10, units),
+        ],
+        255,
+        255,
+    ));
+    library.add_cell(cell);
+    let temp_dir = tempdir().unwrap();
+    let gds_path = temp_dir.path().join("valid.gds");
+    assert!(library.write_file(&gds_path, 1e-9, 1e-9).is_ok());
+}


### PR DESCRIPTION
## Summary
- Add GDS2 spec validation during write (`to_gds_impl`) to prevent producing files that standard GDS tools reject
- Validate layer (0-255), data type (0-255), string length (max 512), structure name (max 32 chars, alphanumeric/`_`/`?`/`$` only), COLROW (max 32767), and polygon minimum points (4)
- Return `io::Error` with `ErrorKind::InvalidInput` on constraint violations

## Test plan
- [x] Added 16 new integration tests covering each validation rule (invalid values and boundary values)
- [x] All 403 tests pass (362 unit + 41 integration)
- [x] `cargo clippy` reports no warnings
- [x] All pre-commit hooks pass

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)