### PR TITLE
Add quickcheck property tests for Polygon

### DIFF
--- a/crates/gdsr/src/elements/polygon/mod.rs
+++ b/crates/gdsr/src/elements/polygon/mod.rs
@@ -133,6 +133,31 @@ impl Dimensions for Polygon {
 mod tests {
     use super::*;
 
+    use quickcheck::{Arbitrary, Gen};
+
+    const MAX_VALUE: i32 = 10_000;
+    const MIN_POLYGON_VERTICES: usize = 3;
+    const MAX_EXTRA_VERTICES: usize = 20;
+
+    impl Arbitrary for Polygon {
+        fn arbitrary(g: &mut Gen) -> Self {
+            let units_options = [1e-9, 1e-8, 1e-7, 1e-6];
+            let units = units_options[usize::arbitrary(g) % units_options.len()];
+            let num_vertices =
+                MIN_POLYGON_VERTICES + (usize::arbitrary(g) % (MAX_EXTRA_VERTICES + 1));
+            let points: Vec<Point> = (0..num_vertices)
+                .map(|_| {
+                    let x = (i32::arbitrary(g) % MAX_VALUE).clamp(-MAX_VALUE, MAX_VALUE);
+                    let y = (i32::arbitrary(g) % MAX_VALUE).clamp(-MAX_VALUE, MAX_VALUE);
+                    Point::integer(x, y, units)
+                })
+                .collect();
+            let layer = u16::arbitrary(g);
+            let data_type = u16::arbitrary(g);
+            Self::new(points, layer, data_type)
+        }
+    }
+
     #[test]
     fn test_polygon_creation() {
         let points = vec![
@@ -331,5 +356,55 @@ mod tests {
         let polygon = Polygon::new(vec![], 1, 0);
         let moved = polygon.move_to(Point::integer(5, 5, 1e-9));
         assert_eq!(moved.points().len(), 0);
+    }
+
+    #[allow(clippy::needless_pass_by_value)]
+    mod property_tests {
+        use super::*;
+        use quickcheck_macros::quickcheck;
+
+        #[quickcheck]
+        fn area_is_non_negative(polygon: Polygon) -> bool {
+            polygon.area().float_value() >= 0.0
+        }
+
+        #[quickcheck]
+        fn perimeter_is_non_negative(polygon: Polygon) -> bool {
+            polygon.perimeter().float_value() >= 0.0
+        }
+
+        #[quickcheck]
+        fn translation_preserves_area(polygon: Polygon) -> bool {
+            let units = polygon.points()[0].units().0;
+            let delta = Point::integer(42, -17, units);
+            let translated = polygon.clone().translate(delta);
+            polygon.area() == translated.area()
+        }
+
+        #[quickcheck]
+        fn translation_preserves_perimeter(polygon: Polygon) -> bool {
+            let units = polygon.points()[0].units().0;
+            let delta = Point::integer(42, -17, units);
+            let translated = polygon.clone().translate(delta);
+            polygon.perimeter() == translated.perimeter()
+        }
+
+        #[quickcheck]
+        fn bounding_box_contains_all_points(polygon: Polygon) -> bool {
+            let (min, max) = polygon.bounding_box();
+            polygon.points().iter().all(|p| {
+                p.x().float_value() >= min.x().float_value()
+                    && p.x().float_value() <= max.x().float_value()
+                    && p.y().float_value() >= min.y().float_value()
+                    && p.y().float_value() <= max.y().float_value()
+            })
+        }
+
+        #[quickcheck]
+        fn close_points_is_idempotent(polygon: Polygon) -> bool {
+            let once = utils::close_points(polygon.points().to_vec());
+            let twice = utils::close_points(once.clone());
+            once == twice
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Implement `Arbitrary` for `Polygon` to generate valid polygons with 3-23 vertices and randomized layers, data types, and units
- Add 6 quickcheck property tests verifying geometric invariants: non-negative area/perimeter, translation preservation of area/perimeter, bounding box containment of all points, and idempotency of `close_points()`

## Test plan
- [x] `cargo test` passes (all 369 tests including 6 new property tests)
- [x] `cargo clippy` passes with no warnings
- [x] `uvx prek run -a` passes all pre-commit checks

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)