### PR TITLE
Add edge-case tests for Grid, Transformation, and Reference

### DIFF
--- a/crates/gdsr/src/elements/reference/mod.rs
+++ b/crates/gdsr/src/elements/reference/mod.rs
@@ -698,4 +698,215 @@ mod tests {
 
         assert_eq!(elements.len(), 100);
     }
+
+    #[test]
+    fn test_reference_flatten_nonexistent_cell() {
+        let library = Library::new("main");
+        let reference = Reference::new("nonexistent_cell");
+
+        let flattened = reference.flatten(None, &library);
+        assert!(flattened.is_empty());
+    }
+
+    #[test]
+    fn test_reference_flatten_nonexistent_cell_with_grid() {
+        let library = Library::new("main");
+        let grid = Grid::default()
+            .with_columns(3)
+            .with_rows(3)
+            .with_spacing_x(Some(Point::integer(10, 0, 1e-9)))
+            .with_spacing_y(Some(Point::integer(0, 10, 1e-9)));
+
+        let reference = Reference::new("missing_cell").with_grid(grid);
+
+        let flattened = reference.flatten(None, &library);
+        assert!(flattened.is_empty());
+    }
+
+    #[test]
+    fn test_reference_flatten_empty_cell() {
+        let mut library = Library::new("main");
+        let cell = crate::Cell::new("empty_cell");
+        library.add_cell(cell);
+
+        let reference = Reference::new("empty_cell");
+
+        let flattened = reference.flatten(None, &library);
+        assert!(flattened.is_empty());
+    }
+
+    #[test]
+    fn test_reference_flatten_empty_cell_with_grid() {
+        let mut library = Library::new("main");
+        let cell = crate::Cell::new("empty_cell");
+        library.add_cell(cell);
+
+        let grid = Grid::default()
+            .with_columns(2)
+            .with_rows(2)
+            .with_spacing_x(Some(Point::integer(10, 0, 1e-9)))
+            .with_spacing_y(Some(Point::integer(0, 10, 1e-9)));
+
+        let reference = Reference::new("empty_cell").with_grid(grid);
+
+        let flattened = reference.flatten(None, &library);
+        assert!(flattened.is_empty());
+    }
+
+    #[test]
+    fn test_reference_depth_limited_flatten_nested() {
+        let mut library = Library::new("main");
+
+        let polygon = Polygon::new(
+            [
+                Point::integer(0, 0, 1e-9),
+                Point::integer(10, 0, 1e-9),
+                Point::integer(10, 10, 1e-9),
+            ],
+            1,
+            0,
+        );
+
+        let mut inner_cell = crate::Cell::new("inner");
+        inner_cell.add(polygon);
+        library.add_cell(inner_cell);
+
+        let mut outer_cell = crate::Cell::new("outer");
+        outer_cell.add(Reference::new("inner"));
+        library.add_cell(outer_cell);
+
+        // depth=1 should resolve outer_cell but leave inner references unresolved
+        let reference = Reference::new("outer");
+        let flattened_depth_1 = reference.clone().flatten(Some(1), &library);
+        assert_eq!(flattened_depth_1.len(), 1);
+        assert!(flattened_depth_1[0].as_reference().is_some());
+
+        // depth=2 should fully resolve to the polygon
+        let flattened_depth_2 = reference.flatten(Some(2), &library);
+        assert_eq!(flattened_depth_2.len(), 1);
+        assert!(flattened_depth_2[0].as_polygon().is_some());
+    }
+
+    #[test]
+    fn test_reference_depth_limited_flatten_triple_nested() {
+        let mut library = Library::new("main");
+
+        let polygon = Polygon::new(
+            [
+                Point::integer(0, 0, 1e-9),
+                Point::integer(5, 0, 1e-9),
+                Point::integer(5, 5, 1e-9),
+            ],
+            1,
+            0,
+        );
+
+        let mut cell_a = crate::Cell::new("a");
+        cell_a.add(polygon);
+        library.add_cell(cell_a);
+
+        let mut cell_b = crate::Cell::new("b");
+        cell_b.add(Reference::new("a"));
+        library.add_cell(cell_b);
+
+        let mut cell_c = crate::Cell::new("c");
+        cell_c.add(Reference::new("b"));
+        library.add_cell(cell_c);
+
+        let reference = Reference::new("c");
+
+        // depth=0 returns the reference itself
+        let d0 = reference.clone().flatten(Some(0), &library);
+        assert_eq!(d0.len(), 1);
+        assert!(d0[0].as_reference().is_some());
+
+        // depth=1 resolves c -> ref(b), still a reference
+        let d1 = reference.clone().flatten(Some(1), &library);
+        assert_eq!(d1.len(), 1);
+        assert!(d1[0].as_reference().is_some());
+
+        // depth=2 resolves c -> b -> ref(a), still a reference
+        let d2 = reference.clone().flatten(Some(2), &library);
+        assert_eq!(d2.len(), 1);
+        assert!(d2[0].as_reference().is_some());
+
+        // depth=3 fully resolves to the polygon
+        let d3 = reference.flatten(Some(3), &library);
+        assert_eq!(d3.len(), 1);
+        assert!(d3[0].as_polygon().is_some());
+    }
+
+    #[test]
+    fn test_reference_zero_column_grid_expansion() {
+        let polygon = Polygon::new(
+            [
+                Point::integer(0, 0, 1e-9),
+                Point::integer(10, 0, 1e-9),
+                Point::integer(10, 10, 1e-9),
+            ],
+            1,
+            0,
+        );
+        let grid = Grid::default()
+            .with_columns(0)
+            .with_rows(3)
+            .with_spacing_x(Some(Point::integer(10, 0, 1e-9)))
+            .with_spacing_y(Some(Point::integer(0, 10, 1e-9)));
+
+        let reference = Reference::new(polygon.clone()).with_grid(grid);
+
+        let element = Element::Polygon(polygon);
+        let elements = reference.get_elements_in_grid(&element);
+
+        assert!(elements.is_empty());
+    }
+
+    #[test]
+    fn test_reference_zero_row_grid_expansion() {
+        let polygon = Polygon::new(
+            [
+                Point::integer(0, 0, 1e-9),
+                Point::integer(10, 0, 1e-9),
+                Point::integer(10, 10, 1e-9),
+            ],
+            1,
+            0,
+        );
+        let grid = Grid::default()
+            .with_columns(3)
+            .with_rows(0)
+            .with_spacing_x(Some(Point::integer(10, 0, 1e-9)))
+            .with_spacing_y(Some(Point::integer(0, 10, 1e-9)));
+
+        let reference = Reference::new(polygon.clone()).with_grid(grid);
+
+        let element = Element::Polygon(polygon);
+        let elements = reference.get_elements_in_grid(&element);
+
+        assert!(elements.is_empty());
+    }
+
+    #[test]
+    fn test_reference_flatten_with_zero_column_grid() {
+        let library = Library::new("main");
+        let polygon = Polygon::new(
+            [
+                Point::integer(0, 0, 1e-9),
+                Point::integer(10, 0, 1e-9),
+                Point::integer(10, 10, 1e-9),
+            ],
+            1,
+            0,
+        );
+        let grid = Grid::default()
+            .with_columns(0)
+            .with_rows(2)
+            .with_spacing_x(Some(Point::integer(10, 0, 1e-9)))
+            .with_spacing_y(Some(Point::integer(0, 10, 1e-9)));
+
+        let reference = Reference::new(polygon).with_grid(grid);
+
+        let flattened = reference.flatten(None, &library);
+        assert!(flattened.is_empty());
+    }
 }

--- a/crates/gdsr/src/grid/mod.rs
+++ b/crates/gdsr/src/grid/mod.rs
@@ -851,4 +851,125 @@ mod tests {
         assert_eq!(grid.columns(), 100);
         assert_eq!(grid.rows(), 100);
     }
+
+    #[test]
+    fn test_grid_zero_columns() {
+        let grid = Grid::new(
+            Point::integer(0, 0, 1e-9),
+            0,
+            3,
+            Some(Point::integer(10, 0, 1e-9)),
+            Some(Point::integer(0, 10, 1e-9)),
+            1.0,
+            0.0,
+            false,
+        );
+
+        assert_eq!(grid.columns(), 0);
+        assert_eq!(grid.rows(), 3);
+    }
+
+    #[test]
+    fn test_grid_zero_rows() {
+        let grid = Grid::new(
+            Point::integer(0, 0, 1e-9),
+            3,
+            0,
+            Some(Point::integer(10, 0, 1e-9)),
+            Some(Point::integer(0, 10, 1e-9)),
+            1.0,
+            0.0,
+            false,
+        );
+
+        assert_eq!(grid.columns(), 3);
+        assert_eq!(grid.rows(), 0);
+    }
+
+    #[test]
+    fn test_grid_zero_columns_and_rows() {
+        let grid = Grid::new(
+            Point::integer(0, 0, 1e-9),
+            0,
+            0,
+            Some(Point::integer(10, 0, 1e-9)),
+            Some(Point::integer(0, 10, 1e-9)),
+            1.0,
+            0.0,
+            false,
+        );
+
+        assert_eq!(grid.columns(), 0);
+        assert_eq!(grid.rows(), 0);
+    }
+
+    #[test]
+    fn test_grid_zero_magnification() {
+        let grid = Grid::new(
+            Point::integer(0, 0, 1e-9),
+            2,
+            2,
+            Some(Point::integer(10, 0, 1e-9)),
+            Some(Point::integer(0, 10, 1e-9)),
+            0.0,
+            0.0,
+            false,
+        );
+
+        assert_eq!(grid.magnification(), 0.0);
+    }
+
+    #[test]
+    fn test_grid_negative_magnification() {
+        let grid = Grid::new(
+            Point::integer(0, 0, 1e-9),
+            2,
+            2,
+            Some(Point::integer(10, 0, 1e-9)),
+            Some(Point::integer(0, 10, 1e-9)),
+            -2.0,
+            0.0,
+            false,
+        );
+
+        assert_eq!(grid.magnification(), -2.0);
+    }
+
+    #[test]
+    fn test_grid_transform_zero_magnification_with_scale() {
+        let grid = Grid::new(
+            Point::integer(10, 20, 1e-9),
+            2,
+            2,
+            Some(Point::integer(5, 0, 1e-9)),
+            Some(Point::integer(0, 5, 1e-9)),
+            0.0,
+            0.0,
+            false,
+        );
+
+        let centre = Point::integer(0, 0, 1e-9);
+        let transformed = grid.scale(2.0, centre);
+
+        assert_eq!(transformed.magnification(), 0.0);
+    }
+
+    #[test]
+    fn test_grid_transform_negative_magnification_with_scale() {
+        let grid = Grid::new(
+            Point::integer(10, 20, 1e-9),
+            2,
+            2,
+            Some(Point::integer(5, 0, 1e-9)),
+            Some(Point::integer(0, 5, 1e-9)),
+            -1.0,
+            0.0,
+            false,
+        );
+
+        let centre = Point::integer(0, 0, 1e-9);
+        let transformed = grid.scale(3.0, centre);
+
+        assert_eq!(transformed.magnification(), -3.0);
+    }
 }

--- a/crates/gdsr/src/transformation/mod.rs
+++ b/crates/gdsr/src/transformation/mod.rs
@@ -638,4 +638,136 @@ mod tests {
             point_approx_eq(&result, &point, 1e-6)
         }
     }
+
+    #[test]
+    fn test_scale_by_zero() {
+        let origin = Point::integer(0, 0, 1e-9);
+        let scale = Scale::new(0.0, origin);
+        let mut transformation = Transformation::default();
+        transformation.with_scale(Some(scale));
+
+        let point = Point::integer(5, 10, 1e-9);
+        let result = transformation.apply_to_point(&point);
+
+        assert_point_approx_eq(&result, &Point::integer(0, 0, 1e-9));
+    }
+
+    #[test]
+    fn test_scale_by_zero_nonorigin_centre() {
+        let centre = Point::integer(10, 10, 1e-9);
+        let scale = Scale::new(0.0, centre);
+        let mut transformation = Transformation::default();
+        transformation.with_scale(Some(scale));
+
+        let point = Point::integer(5, 20, 1e-9);
+        let result = transformation.apply_to_point(&point);
+
+        assert_point_approx_eq(&result, &centre);
+    }
+
+    #[test]
+    fn test_negative_scale() {
+        let origin = Point::integer(0, 0, 1e-9);
+        let scale = Scale::new(-1.0, origin);
+        let mut transformation = Transformation::default();
+        transformation.with_scale(Some(scale));
+
+        let point = Point::integer(5, 10, 1e-9);
+        let result = transformation.apply_to_point(&point);
+
+        assert_point_approx_eq(&result, &Point::integer(-5, -10, 1e-9));
+    }
+
+    #[test]
+    fn test_negative_scale_with_nonorigin_centre() {
+        let centre = Point::integer(10, 10, 1e-9);
+        let scale = Scale::new(-1.0, centre);
+        let mut transformation = Transformation::default();
+        transformation.with_scale(Some(scale));
+
+        let point = Point::integer(15, 20, 1e-9);
+        let result = transformation.apply_to_point(&point);
+
+        assert_point_approx_eq(&result, &Point::integer(5, 0, 1e-9));
+    }
+
+    #[test]
+    fn test_rotation_greater_than_2pi() {
+        let origin = Point::integer(0, 0, 1e-9);
+        let angle = std::f64::consts::TAU + std::f64::consts::FRAC_PI_2;
+        let rotation = Rotation::new(angle, origin);
+        let mut transformation = Transformation::default();
+        transformation.with_rotation(Some(rotation));
+
+        let point = Point::integer(10, 0, 1e-9);
+        let result = transformation.apply_to_point(&point);
+
+        let just_90 = Rotation::new(std::f64::consts::FRAC_PI_2, origin);
+        let expected = just_90.apply_to_point(&point);
+        assert_point_approx_eq(&result, &expected);
+    }
+
+    #[test]
+    fn test_rotation_negative_angle() {
+        let origin = Point::integer(0, 0, 1e-9);
+        let rotation = Rotation::new(-std::f64::consts::FRAC_PI_2, origin);
+        let mut transformation = Transformation::default();
+        transformation.with_rotation(Some(rotation));
+
+        let point = Point::integer(10, 0, 1e-9);
+        let result = transformation.apply_to_point(&point);
+
+        assert_point_approx_eq(&result, &Point::integer(0, -10, 1e-9));
+    }
+
+    #[test]
+    fn test_all_transformations_simultaneously() {
+        let origin = Point::integer(0, 0, 1e-9);
+        let reflection = Reflection::new(0.0, origin);
+        let rotation = Rotation::new(std::f64::consts::FRAC_PI_4, origin);
+        let scale = Scale::new(3.0, origin);
+        let translation = Translation::new(Point::integer(100, 200, 1e-9));
+
+        let mut transformation = Transformation::default();
+        transformation.with_reflection(Some(reflection.clone()));
+        transformation.with_rotation(Some(rotation.clone()));
+        transformation.with_scale(Some(scale.clone()));
+        transformation.with_translation(Some(translation.clone()));
+
+        let point = Point::integer(10, 5, 1e-9);
+        let result = transformation.apply_to_point(&point);
+
+        let step1 = reflection.apply_to_point(&point);
+        let step2 = rotation.apply_to_point(&step1);
+        let step3 = scale.apply_to_point(&step2);
+        let expected = translation.apply_to_point(&step3);
+
+        assert_point_approx_eq(&result, &expected);
+    }
+
+    #[test]
+    fn test_scale_by_zero_then_translate() {
+        let origin = Point::integer(0, 0, 1e-9);
+        let scale = Scale::new(0.0, origin);
+        let translation = Translation::new(Point::integer(10, 20, 1e-9));
+
+        let mut transformation = Transformation::default();
+        transformation.with_scale(Some(scale));
+        transformation.with_translation(Some(translation));
+
+        let point = Point::integer(99, 99, 1e-9);
+        let result = transformation.apply_to_point(&point);
+
+        assert_point_approx_eq(&result, &Point::integer(10, 20, 1e-9));
+    }
+
+    #[test]
+    fn test_from_self_reference() {
+        let translation = Translation::new(Point::integer(5, 10, 1e-9));
+        let mut original = Transformation::default();
+        original.with_translation(Some(translation));
+
+        let cloned: Transformation = Transformation::from(&original);
+        assert_eq!(cloned, original);
+    }
 }

--- a/crates/gdsr/src/transformation/rotation.rs
+++ b/crates/gdsr/src/transformation/rotation.rs
@@ -103,4 +103,42 @@ mod tests {
         assert!((rotated.x() - expected.x()).absolute_value().abs() < 1e-6);
         assert!((rotated.y() - expected.y()).absolute_value().abs() < 1e-6);
     }
+
+    /// Rotation by 2pi + pi/2 should produce the same result as pi/2 alone.
+    #[test]
+    fn test_rotation_greater_than_2pi() {
+        let origin = Point::integer(0, 0, 1e-9);
+        let point = Point::integer(10, 0, 1e-9);
+
+        let rotation_large = Rotation::new(std::f64::consts::TAU + FRAC_PI_2, origin);
+        let rotation_normal = Rotation::new(FRAC_PI_2, origin);
+
+        let result_large = rotation_large.apply_to_point(&point);
+        let result_normal = rotation_normal.apply_to_point(&point);
+
+        assert!(
+            (result_large.x() - result_normal.x())
+                .absolute_value()
+                .abs()
+                < 1e-6
+        );
+        assert!(
+            (result_large.y() - result_normal.y())
+                .absolute_value()
+                .abs()
+                < 1e-6
+        );
+    }
+
+    #[test]
+    fn test_rotation_negative_angle() {
+        let origin = Point::integer(0, 0, 1e-9);
+        let rotation = Rotation::new(-FRAC_PI_2, origin);
+        let point = Point::integer(10, 0, 1e-9);
+        let rotated = rotation.apply_to_point(&point);
+
+        let expected = Point::integer(0, -10, 1e-9);
+        assert!((rotated.x() - expected.x()).absolute_value().abs() < 1e-6);
+        assert!((rotated.y() - expected.y()).absolute_value().abs() < 1e-6);
+    }
 }

--- a/crates/gdsr/src/transformation/scale.rs
+++ b/crates/gdsr/src/transformation/scale.rs
@@ -109,4 +109,49 @@ mod tests {
         assert_eq!(scaled.x(), expected.x());
         assert_eq!(scaled.y(), expected.y());
     }
+
+    #[test]
+    fn test_scale_by_zero() {
+        let scale = Scale::new(0.0, Point::integer(0, 0, 1e-9));
+        let point = Point::integer(10, 20, 1e-9);
+        let scaled = scale.apply_to_point(&point);
+
+        assert_eq!(scaled.x().absolute_value(), 0.0);
+        assert_eq!(scaled.y().absolute_value(), 0.0);
+    }
+
+    #[test]
+    fn test_scale_by_zero_nonorigin_centre() {
+        let centre = Point::integer(5, 5, 1e-9);
+        let scale = Scale::new(0.0, centre);
+        let point = Point::integer(10, 20, 1e-9);
+        let scaled = scale.apply_to_point(&point);
+
+        assert_eq!(scaled.x(), centre.x());
+        assert_eq!(scaled.y(), centre.y());
+    }
+
+    #[test]
+    fn test_scale_negative() {
+        let scale = Scale::new(-1.0, Point::integer(0, 0, 1e-9));
+        let point = Point::integer(10, 5, 1e-9);
+        let scaled = scale.apply_to_point(&point);
+
+        let expected = Point::integer(-10, -5, 1e-9);
+        assert_eq!(scaled.x(), expected.x());
+        assert_eq!(scaled.y(), expected.y());
+    }
+
+    #[test]
+    fn test_scale_negative_with_centre() {
+        let centre = Point::integer(10, 10, 1e-9);
+        let scale = Scale::new(-2.0, centre);
+        let point = Point::integer(15, 20, 1e-9);
+        let scaled = scale.apply_to_point(&point);
+
+        // (15-10)*-2 + 10 = 0, (20-10)*-2 + 10 = -10
+        let expected = Point::integer(0, -10, 1e-9);
+        assert_eq!(scaled.x(), expected.x());
+        assert_eq!(scaled.y(), expected.y());
+    }
 }


### PR DESCRIPTION
## Summary
- Add edge-case tests for `Grid` with 0 columns/rows, 0 magnification, and negative magnification, including behavior when scaling is applied
- Add edge-case tests for `Transformation` covering scale by 0, negative scale, rotation greater than 2pi, negative rotation, combining all transformation types simultaneously, and scale-by-zero-then-translate
- Add edge-case tests for `Reference` flatten with nonexistent cells, empty cells, depth-limited flatten with nested (2-level) and triple-nested (3-level) cell references, and grid expansion with 0 columns/rows

## Test plan
- [x] All 394 tests pass with `cargo test`
- [x] No warnings from `cargo clippy`
- [x] All pre-commit checks pass via `uvx prek run -a`

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)