### PR TITLE
Change ToGds to return Vec<u8> and parallelize within cells

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,6 +434,7 @@ dependencies = [
  "insta",
  "quickcheck",
  "quickcheck_macros",
+ "rayon",
  "rstest",
  "tempfile",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ license = "MIT"
 [dependencies]
 bytemuck = "1.24.0"
 chrono = "0.4.42"
+rayon = "1"
 
 [dev-dependencies]
 approx = "0.5"

--- a/src/cell/io.rs
+++ b/src/cell/io.rs
@@ -9,11 +9,9 @@ use crate::utils::io::{
 };
 
 impl ToGds for Cell {
-    fn to_gds_impl(
-        &self,
-        buffer: &mut impl std::io::Write,
-        database_units: f64,
-    ) -> Result<(), GdsError> {
+    fn to_gds_impl(&self, database_units: f64) -> Result<Vec<u8>, GdsError> {
+        use rayon::prelude::*;
+
         validate_structure_name(&self.name)?;
 
         let now = Local::now();
@@ -36,24 +34,46 @@ impl ToGds for Cell {
             timestamp.second() as u16,
         ];
 
-        write_u16_array_to_file(buffer, &cell_head)?;
+        let mut buffer = Vec::new();
 
-        write_string_with_record_to_file(buffer, GDSRecord::StrName, &self.name)?;
+        write_u16_array_to_file(&mut buffer, &cell_head)?;
 
-        for path in &self.paths {
-            path.to_gds_impl(buffer, database_units)?;
+        write_string_with_record_to_file(&mut buffer, GDSRecord::StrName, &self.name)?;
+
+        let path_bufs: Result<Vec<_>, _> = self
+            .paths
+            .par_iter()
+            .map(|p| p.to_gds_impl(database_units))
+            .collect();
+        for b in path_bufs? {
+            buffer.extend_from_slice(&b);
         }
 
-        for polygon in &self.polygons {
-            polygon.to_gds_impl(buffer, database_units)?;
+        let polygon_bufs: Result<Vec<_>, _> = self
+            .polygons
+            .par_iter()
+            .map(|p| p.to_gds_impl(database_units))
+            .collect();
+        for b in polygon_bufs? {
+            buffer.extend_from_slice(&b);
         }
 
-        for text in &self.texts {
-            text.to_gds_impl(buffer, database_units)?;
+        let text_bufs: Result<Vec<_>, _> = self
+            .texts
+            .par_iter()
+            .map(|t| t.to_gds_impl(database_units))
+            .collect();
+        for b in text_bufs? {
+            buffer.extend_from_slice(&b);
         }
 
-        for reference in &self.references {
-            reference.to_gds_impl(buffer, database_units)?;
+        let ref_bufs: Result<Vec<_>, _> = self
+            .references
+            .par_iter()
+            .map(|r| r.to_gds_impl(database_units))
+            .collect();
+        for b in ref_bufs? {
+            buffer.extend_from_slice(&b);
         }
 
         let cell_tail = [
@@ -61,8 +81,8 @@ impl ToGds for Cell {
             combine_record_and_data_type(GDSRecord::EndStr, GDSDataType::NoData),
         ];
 
-        write_u16_array_to_file(buffer, &cell_tail)?;
+        write_u16_array_to_file(&mut buffer, &cell_tail)?;
 
-        Ok(())
+        Ok(buffer)
     }
 }

--- a/src/elements/element.rs
+++ b/src/elements/element.rs
@@ -115,16 +115,12 @@ impl From<Element> for Instance {
 }
 
 impl ToGds for Element {
-    fn to_gds_impl(
-        &self,
-        buffer: &mut impl std::io::Write,
-        scale: f64,
-    ) -> Result<(), crate::error::GdsError> {
+    fn to_gds_impl(&self, scale: f64) -> Result<Vec<u8>, crate::error::GdsError> {
         match self {
-            Self::Path(path) => path.to_gds_impl(buffer, scale),
-            Self::Polygon(polygon) => polygon.to_gds_impl(buffer, scale),
-            Self::Reference(reference) => reference.to_gds_impl(buffer, scale),
-            Self::Text(text) => text.to_gds_impl(buffer, scale),
+            Self::Path(path) => path.to_gds_impl(scale),
+            Self::Polygon(polygon) => polygon.to_gds_impl(scale),
+            Self::Reference(reference) => reference.to_gds_impl(scale),
+            Self::Text(text) => text.to_gds_impl(scale),
         }
     }
 }

--- a/src/elements/path/io.rs
+++ b/src/elements/path/io.rs
@@ -1,3 +1,5 @@
+use std::io::Write;
+
 use super::Path;
 use crate::config::gds_file_types::{GDSDataType, GDSRecord, combine_record_and_data_type};
 use crate::error::GdsError;
@@ -8,11 +10,7 @@ use crate::utils::io::{
 };
 
 impl ToGds for Path {
-    fn to_gds_impl(
-        &self,
-        buffer: &mut impl std::io::Write,
-        database_units: f64,
-    ) -> Result<(), GdsError> {
+    fn to_gds_impl(&self, database_units: f64) -> Result<Vec<u8>, GdsError> {
         validate_layer(self.layer())?;
         validate_data_type(self.data_type())?;
 
@@ -21,6 +19,8 @@ impl ToGds for Path {
                 message: "Path must have at least 2 points".to_string(),
             });
         }
+
+        let mut buffer = Vec::new();
 
         let path_head = [
             4,
@@ -33,7 +33,7 @@ impl ToGds for Path {
             self.data_type(),
         ];
 
-        write_u16_array_to_file(buffer, &path_head)?;
+        write_u16_array_to_file(&mut buffer, &path_head)?;
 
         if let Some(path_type) = self.path_type() {
             let path_type_value = path_type.value();
@@ -47,7 +47,7 @@ impl ToGds for Path {
                 path_type_value,
             ];
 
-            write_u16_array_to_file(buffer, &path_type_head)?;
+            write_u16_array_to_file(&mut buffer, &path_type_head)?;
         }
 
         if let Some(width) = self.width() {
@@ -59,15 +59,17 @@ impl ToGds for Path {
                 combine_record_and_data_type(GDSRecord::Width, GDSDataType::FourByteSignedInteger),
             ];
 
-            write_u16_array_to_file(buffer, &width_head)?;
+            write_u16_array_to_file(&mut buffer, &width_head)?;
 
             let bytes = width_value.to_be_bytes();
 
             buffer.write_all(&bytes)?;
         }
 
-        write_points_to_file(buffer, self.points(), database_units)?;
+        write_points_to_file(&mut buffer, self.points(), database_units)?;
 
-        write_element_tail_to_file(buffer)
+        write_element_tail_to_file(&mut buffer)?;
+
+        Ok(buffer)
     }
 }

--- a/src/elements/polygon/io.rs
+++ b/src/elements/polygon/io.rs
@@ -8,11 +8,7 @@ use crate::utils::io::{
 };
 
 impl ToGds for Polygon {
-    fn to_gds_impl(
-        &self,
-        buffer: &mut impl std::io::Write,
-        database_units: f64,
-    ) -> Result<(), GdsError> {
+    fn to_gds_impl(&self, database_units: f64) -> Result<Vec<u8>, GdsError> {
         if self.points().len() > MAX_POINTS {
             return Err(GdsError::ValidationError {
                 message: format!(
@@ -35,6 +31,8 @@ impl ToGds for Polygon {
             });
         }
 
+        let mut buffer = Vec::new();
+
         let polygon_head = [
             4,
             combine_record_and_data_type(GDSRecord::Boundary, GDSDataType::NoData),
@@ -46,10 +44,12 @@ impl ToGds for Polygon {
             self.data_type(),
         ];
 
-        write_u16_array_to_file(buffer, &polygon_head)?;
+        write_u16_array_to_file(&mut buffer, &polygon_head)?;
 
-        write_points_to_file(buffer, self.points(), database_units)?;
+        write_points_to_file(&mut buffer, self.points(), database_units)?;
 
-        write_element_tail_to_file(buffer)
+        write_element_tail_to_file(&mut buffer)?;
+
+        Ok(buffer)
     }
 }

--- a/src/elements/reference/io.rs
+++ b/src/elements/reference/io.rs
@@ -2,24 +2,18 @@ use super::{Instance, Reference};
 use crate::config::gds_file_types::{GDSDataType, GDSRecord, combine_record_and_data_type};
 use crate::elements::Element;
 use crate::error::GdsError;
-use crate::traits::ToGds;
+use crate::traits::{Movable, ToGds, Transformable};
 use crate::utils::io::{
     validate_col_row, write_element_tail_to_file, write_points_to_file,
     write_string_with_record_to_file, write_transformation_to_file, write_u16_array_to_file,
 };
 
 impl ToGds for Reference {
-    fn to_gds_impl(
-        &self,
-        buffer: &mut impl std::io::Write,
-        database_units: f64,
-    ) -> Result<(), GdsError> {
+    fn to_gds_impl(&self, database_units: f64) -> Result<Vec<u8>, GdsError> {
         match &self.instance {
-            Instance::Cell(cell_name) => {
-                self.to_gds_impl_with_cell(buffer, database_units, cell_name)
-            }
+            Instance::Cell(cell_name) => self.to_gds_impl_with_cell(database_units, cell_name),
             Instance::Element(element) => {
-                self.to_gds_impl_with_element(buffer, database_units, element.as_ref().as_ref())
+                self.to_gds_impl_with_element(database_units, element.as_ref().as_ref())
             }
         }
     }
@@ -28,23 +22,40 @@ impl ToGds for Reference {
 impl Reference {
     fn to_gds_impl_with_element(
         &self,
-        buffer: &mut impl std::io::Write,
         database_units: f64,
         element: &Element,
-    ) -> Result<(), GdsError> {
-        for element in self.get_elements_in_grid(element) {
-            element.to_gds_impl(buffer, database_units)?;
-        }
+    ) -> Result<Vec<u8>, GdsError> {
+        let grid = self.grid();
+        let spacing_x = grid.spacing_x().unwrap_or_default();
+        let spacing_y = grid.spacing_y().unwrap_or_default();
 
-        Ok(())
+        let mut buf = Vec::new();
+        for column_index in 0..grid.columns() {
+            for row_index in 0..grid.rows() {
+                let offset = (spacing_x * column_index) + (spacing_y * row_index);
+                let rotated_offset =
+                    offset.rotate_around_point(grid.angle(), &crate::Point::default());
+                let final_position = grid.origin() + rotated_offset;
+
+                let mut new_element = element.clone();
+                if grid.x_reflection() {
+                    new_element = new_element.reflect(0.0, grid.origin());
+                }
+                new_element = new_element.rotate(grid.angle(), grid.origin());
+                new_element = new_element.scale(grid.magnification(), grid.origin());
+                new_element = new_element.move_by(final_position - grid.origin());
+
+                buf.extend_from_slice(&new_element.to_gds_impl(database_units)?);
+            }
+        }
+        Ok(buf)
     }
 
     fn to_gds_impl_with_cell(
         &self,
-        buffer: &mut impl std::io::Write,
         database_units: f64,
         cell_name: &str,
-    ) -> Result<(), GdsError> {
+    ) -> Result<Vec<u8>, GdsError> {
         validate_col_row(self.grid().columns(), self.grid().rows())?;
 
         let is_single_instance = self.grid().columns() == 1 && self.grid().rows() == 1;
@@ -55,22 +66,24 @@ impl Reference {
             GDSRecord::ARef
         };
 
+        let mut buffer = Vec::new();
+
         let buffer_start = [4, combine_record_and_data_type(record, GDSDataType::NoData)];
 
-        write_u16_array_to_file(buffer, &buffer_start)?;
+        write_u16_array_to_file(&mut buffer, &buffer_start)?;
 
-        write_string_with_record_to_file(buffer, GDSRecord::SName, cell_name)?;
+        write_string_with_record_to_file(&mut buffer, GDSRecord::SName, cell_name)?;
 
         let angle = self.grid().angle();
         let magnification = self.grid().magnification();
         let x_reflection = self.grid().x_reflection();
 
-        write_transformation_to_file(buffer, angle, magnification, x_reflection)?;
+        write_transformation_to_file(&mut buffer, angle, magnification, x_reflection)?;
 
         if is_single_instance {
             let origin = self.grid().origin();
             let reference_points = [origin];
-            write_points_to_file(buffer, &reference_points, database_units)?;
+            write_points_to_file(&mut buffer, &reference_points, database_units)?;
         } else {
             let buffer_array = [
                 8,
@@ -79,7 +92,7 @@ impl Reference {
                 self.grid().rows() as u16,
             ];
 
-            write_u16_array_to_file(buffer, &buffer_array)?;
+            write_u16_array_to_file(&mut buffer, &buffer_array)?;
 
             let origin = self
                 .grid()
@@ -95,27 +108,29 @@ impl Reference {
                         .rotate_around_point(self.grid().angle(), &origin);
 
                     let reference_points = [origin, point2, point3];
-                    write_points_to_file(buffer, &reference_points, database_units)?;
+                    write_points_to_file(&mut buffer, &reference_points, database_units)?;
                 }
                 (Some(spacing_x), None) => {
                     let point2 = ((origin + spacing_x) * self.grid().columns())
                         .rotate_around_point(self.grid().angle(), &origin);
                     let reference_points = [origin, point2, origin];
-                    write_points_to_file(buffer, &reference_points, database_units)?;
+                    write_points_to_file(&mut buffer, &reference_points, database_units)?;
                 }
                 (None, Some(spacing_y)) => {
                     let point3 = ((origin + spacing_y) * self.grid().rows())
                         .rotate_around_point(self.grid().angle(), &origin);
                     let reference_points = [origin, origin, point3];
-                    write_points_to_file(buffer, &reference_points, database_units)?;
+                    write_points_to_file(&mut buffer, &reference_points, database_units)?;
                 }
                 _ => {
                     let reference_points = [origin];
-                    write_points_to_file(buffer, &reference_points, database_units)?;
+                    write_points_to_file(&mut buffer, &reference_points, database_units)?;
                 }
             }
         }
 
-        write_element_tail_to_file(buffer)
+        write_element_tail_to_file(&mut buffer)?;
+
+        Ok(buffer)
     }
 }

--- a/src/elements/text/io.rs
+++ b/src/elements/text/io.rs
@@ -9,15 +9,13 @@ use crate::utils::io::{
 };
 
 impl ToGds for Text {
-    fn to_gds_impl(
-        &self,
-        buffer: &mut impl std::io::Write,
-        database_units: f64,
-    ) -> Result<(), GdsError> {
+    fn to_gds_impl(&self, database_units: f64) -> Result<Vec<u8>, GdsError> {
         validate_layer(self.layer())?;
         validate_string_length(self.text())?;
 
-        let buffer_start = vec![
+        let mut buffer = Vec::new();
+
+        let buffer_start = [
             4,
             combine_record_and_data_type(GDSRecord::Text, GDSDataType::NoData),
             6,
@@ -34,18 +32,20 @@ impl ToGds for Text {
             ),
         ];
 
-        write_u16_array_to_file(buffer, &buffer_start)?;
+        write_u16_array_to_file(&mut buffer, &buffer_start)?;
 
         let angle = self.angle();
         let magnification = self.magnification();
         let x_reflection = self.x_reflection();
 
-        write_transformation_to_file(buffer, angle, magnification, x_reflection)?;
+        write_transformation_to_file(&mut buffer, angle, magnification, x_reflection)?;
 
-        write_points_to_file(buffer, &[*self.origin()], database_units)?;
+        write_points_to_file(&mut buffer, &[*self.origin()], database_units)?;
 
-        write_string_with_record_to_file(buffer, GDSRecord::String, self.text())?;
+        write_string_with_record_to_file(&mut buffer, GDSRecord::String, self.text())?;
 
-        write_element_tail_to_file(buffer)
+        write_element_tail_to_file(&mut buffer)?;
+
+        Ok(buffer)
     }
 }

--- a/src/library/mod.rs
+++ b/src/library/mod.rs
@@ -72,13 +72,8 @@ impl Library {
         user_units: f64,
         database_units: f64,
     ) -> Result<(), GdsError> {
-        write_gds(
-            file_name,
-            &self.name,
-            user_units,
-            database_units,
-            self.cells.values(),
-        )
+        let cells: Vec<&Cell> = self.cells.values().collect();
+        write_gds(file_name, &self.name, user_units, database_units, &cells)
     }
 
     /// Read a library from a GDS file.

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -4,8 +4,8 @@ use crate::{AngleInRadians, Point};
 
 /// Trait for types that can be serialized to the GDSII binary format.
 pub trait ToGds {
-    /// Writes the GDSII binary representation to the given buffer.
-    fn to_gds_impl(&self, buffer: &mut impl std::io::Write, scale: f64) -> Result<(), GdsError>;
+    /// Returns the GDSII binary representation as a byte vector.
+    fn to_gds_impl(&self, scale: f64) -> Result<Vec<u8>, GdsError>;
 }
 
 /// Trait for types that can be geometrically transformed (rotated, scaled, reflected, translated).

--- a/src/utils/gds_format.rs
+++ b/src/utils/gds_format.rs
@@ -40,12 +40,14 @@ pub fn eight_byte_real(value: f64) -> [u8; 8] {
     result
 }
 
-pub fn u16_array_to_big_endian(array: &[u16]) -> Vec<u16> {
-    let mut result = Vec::with_capacity(array.len());
+pub fn write_u16_array_as_big_endian(
+    buffer: &mut impl std::io::Write,
+    array: &[u16],
+) -> std::io::Result<()> {
     for value in array {
-        result.push(value.to_be());
+        buffer.write_all(&value.to_be_bytes())?;
     }
-    result
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/utils/io.rs
+++ b/src/utils/io.rs
@@ -2,7 +2,6 @@ use std::convert::TryFrom;
 use std::fs::File;
 use std::io::{self, BufReader, Read, Write};
 
-use bytemuck::cast_slice;
 use chrono::{Datelike, Local, Timelike};
 
 use crate::cell::Cell;
@@ -14,7 +13,7 @@ use crate::elements::{Path, PathType, Polygon, Reference, Text};
 use crate::error::GdsError;
 use crate::geometry::round_to_decimals;
 use crate::library::Library;
-use crate::utils::gds_format::{eight_byte_real, u16_array_to_big_endian};
+use crate::utils::gds_format::{eight_byte_real, write_u16_array_as_big_endian};
 use crate::{DEFAULT_INTEGER_UNITS, DataType, Instance, Layer, Point, ToGds, Unit};
 
 pub fn write_gds_head_to_file(
@@ -72,8 +71,7 @@ pub fn write_u16_array_to_file(
     buffer: &mut impl std::io::Write,
     array: &[u16],
 ) -> Result<(), GdsError> {
-    let u16_array_to_big_endian = u16_array_to_big_endian(array);
-    Ok(buffer.write_all(cast_slice(&u16_array_to_big_endian))?)
+    Ok(write_u16_array_as_big_endian(buffer, array)?)
 }
 
 pub fn write_float_to_eight_byte_real_to_file(
@@ -167,11 +165,9 @@ pub fn write_points_to_file(
     points: &[Point],
     database_units: f64,
 ) -> Result<(), GdsError> {
-    let integer_points: Vec<Point> = points.iter().map(Point::to_integer_unit).collect();
+    let num_points = points.len().min(MAX_POINTS);
 
-    let points_to_write = integer_points.get(..MAX_POINTS).unwrap_or(&integer_points);
-
-    let record_size = 4 + (points_to_write.len() * 8) as u16;
+    let record_size = 4 + (num_points * 8) as u16;
     let xy_header_buffer = [
         record_size,
         combine_record_and_data_type(GDSRecord::XY, GDSDataType::FourByteSignedInteger),
@@ -179,7 +175,8 @@ pub fn write_points_to_file(
 
     write_u16_array_to_file(buffer, &xy_header_buffer)?;
 
-    for point in points_to_write {
+    for point in points.iter().take(num_points) {
+        let point = point.to_integer_unit();
         let x_real = point.x().absolute_value();
         let y_real = point.y().absolute_value();
 
@@ -206,44 +203,45 @@ pub fn write_string_with_record_to_file(
     record: GDSRecord,
     string: &str,
 ) -> Result<(), GdsError> {
-    let mut len = string.len();
-    if len % 2 != 0 {
-        len += 1;
-    }
-
-    let mut lib_name_bytes = string.as_bytes().to_vec();
-
-    if string.len() % 2 != 0 {
-        lib_name_bytes.push(0);
-    }
+    let byte_len = string.len();
+    let padded_len = byte_len + (byte_len % 2);
 
     let string_start = [
-        (4 + len) as u16,
+        (4 + padded_len) as u16,
         combine_record_and_data_type(record, GDSDataType::AsciiString),
     ];
 
     write_u16_array_to_file(buffer, &string_start)?;
 
-    Ok(buffer.write_all(&lib_name_bytes)?)
+    buffer.write_all(string.as_bytes())?;
+    if byte_len % 2 != 0 {
+        buffer.write_all(&[0])?;
+    }
+
+    Ok(())
 }
 
-pub fn write_gds<'a, P: AsRef<std::path::Path>>(
+pub fn write_gds<P: AsRef<std::path::Path>>(
     file_name: P,
     library_name: &str,
     user_units: f64,
     database_units: f64,
-    cells: impl Iterator<Item = &'a Cell>,
+    cells: &[&Cell],
 ) -> Result<(), GdsError> {
+    use rayon::prelude::*;
+
+    let cell_buffers: Result<Vec<Vec<u8>>, GdsError> = cells
+        .par_iter()
+        .map(|cell| cell.to_gds_impl(database_units))
+        .collect();
+    let cell_buffers = cell_buffers?;
+
     let mut file = File::create(file_name)?;
-
     write_gds_head_to_file(library_name, user_units, database_units, &mut file)?;
-
-    for cell in cells {
-        cell.to_gds_impl(&mut file, database_units)?;
+    for buf in &cell_buffers {
+        file.write_all(buf)?;
     }
-
     write_gds_tail_to_file(&mut file)?;
-
     Ok(file.flush()?)
 }
 


### PR DESCRIPTION
## Summary

- Change `ToGds::to_gds_impl` from `(&self, &mut impl Write, f64) -> Result<(), GdsError>` to `(&self, f64) -> Result<Vec<u8>, GdsError>`, enabling parallel element serialization within cells via rayon
- Reduce allocations in the write path: eliminate intermediate `Vec<u16>` in `u16_array_to_big_endian`, intermediate `Vec<Point>` in `write_points_to_file`, `.to_vec()` in `write_string_with_record_to_file`, and heap-allocated `vec![]` in text header
- Inline grid expansion in reference serialization to avoid collecting all cloned elements into a `Vec<Element>` before serializing

## Test plan

- [x] All 542 tests pass via `cargo nextest run`
- [x] All pre-commit checks pass via `uvx prek run -a`