### PR TITLE
Add KLayout vs gdsr benchmark comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 GDSII manipulation, written in rust.
 
+<div align="center">
+  <img src="https://raw.githubusercontent.com/MatthewMckee4/gdsr/main/scripts/benchmark/results/benchmark.svg" alt="GDS I/O Benchmark" width="70%">
+</div>
+
 > [!WARNING]
 > This is a work in progress and is not yet ready for production use.
 

--- a/scripts/benchmark/.gitignore
+++ b/scripts/benchmark/.gitignore
@@ -1,0 +1,3 @@
+.venv/
+target/
+Cargo.lock

--- a/scripts/benchmark/Cargo.toml
+++ b/scripts/benchmark/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "benchmark-gdsr"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[[bin]]
+name = "benchmark_gdsr"
+path = "benchmark_gdsr.rs"
+
+[dependencies]
+gdsr = { path = "../.." }

--- a/scripts/benchmark/README.md
+++ b/scripts/benchmark/README.md
@@ -1,0 +1,30 @@
+# Benchmark: gdsr vs KLayout
+
+Compares GDS read/write performance between gdsr and KLayout using [hyperfine](https://github.com/sharkdp/hyperfine).
+
+## Prerequisites
+
+- Rust toolchain
+- [hyperfine](https://github.com/sharkdp/hyperfine): `brew install hyperfine`
+- Python 3.13+ with klayout:
+
+```bash
+python3 -m venv .venv
+.venv/bin/pip install klayout
+```
+
+## Run benchmarks
+
+```bash
+./benchmark_comparison.sh
+```
+
+This builds the gdsr benchmark binary, runs hyperfine for both read and write operations, and saves results to `results/write.json` and `results/read.json`.
+
+## Generate plot
+
+```bash
+uv run plot.py
+```
+
+Outputs `results/benchmark.svg`.

--- a/scripts/benchmark/benchmark_comparison.sh
+++ b/scripts/benchmark/benchmark_comparison.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Benchmark comparison: KLayout vs gdsr using hyperfine.
+#
+# Prerequisites:
+#   brew install hyperfine
+#   cargo (Rust toolchain)
+#   scripts/benchmark/.venv with klayout installed
+#
+# Usage:
+#   ./scripts/benchmark/benchmark_comparison.sh
+#
+# Outputs:
+#   scripts/benchmark/results/write.json
+#   scripts/benchmark/results/read.json
+#
+# Then run plot.py to visualize:
+#   ./scripts/benchmark/.venv/bin/python3 scripts/benchmark/plot.py
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+if [[ -x "$SCRIPT_DIR/.venv/bin/python3" ]]; then
+    PYTHON="${PYTHON:-$SCRIPT_DIR/.venv/bin/python3}"
+else
+    PYTHON="${PYTHON:-python3}"
+fi
+
+WARMUP=3
+RUNS=20
+RESULTS_DIR="$SCRIPT_DIR/results"
+mkdir -p "$RESULTS_DIR"
+
+# Build gdsr benchmark
+echo "Building gdsr benchmark (release)..."
+cargo build --release --manifest-path "$SCRIPT_DIR/Cargo.toml" 2>&1
+GDSR_BIN="$SCRIPT_DIR/target/release/benchmark_gdsr"
+
+# Verify dependencies
+if ! "$PYTHON" -c "import klayout.db" 2>/dev/null; then
+    echo "Error: klayout not found. Run: $SCRIPT_DIR/.venv/bin/pip install klayout"
+    exit 1
+fi
+
+if ! command -v hyperfine &>/dev/null; then
+    echo "Error: hyperfine not found. Install with: brew install hyperfine"
+    exit 1
+fi
+
+# Seed read benchmark files
+echo "Preparing read benchmark files..."
+"$GDSR_BIN" write
+"$PYTHON" "$SCRIPT_DIR/benchmark_klayout.py" write
+
+# Run benchmarks
+echo ""
+echo "=== Write ==="
+hyperfine \
+    --warmup "$WARMUP" \
+    --runs "$RUNS" \
+    --shell=none \
+    --export-json "$RESULTS_DIR/write.json" \
+    --command-name "gdsr"    "$GDSR_BIN write" \
+    --command-name "klayout" "$PYTHON $SCRIPT_DIR/benchmark_klayout.py write"
+
+echo ""
+echo "=== Read ==="
+hyperfine \
+    --warmup "$WARMUP" \
+    --runs "$RUNS" \
+    --shell=none \
+    --export-json "$RESULTS_DIR/read.json" \
+    --command-name "gdsr"    "$GDSR_BIN read" \
+    --command-name "klayout" "$PYTHON $SCRIPT_DIR/benchmark_klayout.py read"
+
+echo ""
+echo "Results saved to $RESULTS_DIR/"
+echo "Run plot.py to visualize: $PYTHON $SCRIPT_DIR/plot.py"

--- a/scripts/benchmark/benchmark_gdsr.rs
+++ b/scripts/benchmark/benchmark_gdsr.rs
@@ -1,0 +1,181 @@
+use gdsr::{
+    Cell, Grid, HorizontalPresentation, Library, Path, PathType, Point, Polygon, Reference, Text,
+    Unit, VerticalPresentation,
+};
+
+const DB_UNITS: f64 = 1e-9;
+const USER_UNITS: f64 = 1e-9;
+
+fn point(x: i32, y: i32) -> Point {
+    Point::integer(x, y, DB_UNITS)
+}
+
+const PATH_TYPES: [PathType; 3] = [PathType::Square, PathType::Round, PathType::Overlap];
+const VERT_PRES: [VerticalPresentation; 3] = [
+    VerticalPresentation::Top,
+    VerticalPresentation::Middle,
+    VerticalPresentation::Bottom,
+];
+const HORIZ_PRES: [HorizontalPresentation; 3] = [
+    HorizontalPresentation::Left,
+    HorizontalPresentation::Centre,
+    HorizontalPresentation::Right,
+];
+
+fn build_library() -> Library {
+    let mut library = Library::new("bench_complex");
+
+    for c in 0_i32..20 {
+        let mut cell = Cell::new(&format!("leaf_{c}"));
+
+        for i in 0_i32..500 {
+            let offset = i * 50;
+            let layer = ((c * 3 + i) % 64) as u16;
+            let npoints = 4 + (i as usize % 5);
+            let points: Vec<Point> = (0..npoints)
+                .map(|p| {
+                    let angle = std::f64::consts::TAU * p as f64 / npoints as f64;
+                    let r = 20 + (i % 30);
+                    point(
+                        offset + (f64::from(r) * angle.cos()) as i32,
+                        (f64::from(r) * angle.sin()) as i32,
+                    )
+                })
+                .collect();
+            cell.add(Polygon::new(points, layer, (i % 8) as u16));
+        }
+
+        for i in 0_i32..250 {
+            let y_base = c * 5000 + i * 80;
+            let nsegs = 3 + (i as usize % 8);
+            let points: Vec<Point> = (0..nsegs)
+                .map(|s| point(s as i32 * 150, y_base + if s % 2 == 0 { 0 } else { 60 }))
+                .collect();
+            cell.add(Path::new(
+                points,
+                ((c * 2 + i) % 64) as u16,
+                (i % 4) as u16,
+                Some(PATH_TYPES[i as usize % 3]),
+                Some(Unit::integer((i % 30 + 1) * 10, DB_UNITS)),
+            ));
+        }
+
+        for i in 0_i32..100 {
+            cell.add(Text::new(
+                &format!("L{c}_text_{i:03}"),
+                point(i * 400, c * 1000),
+                ((c + i) % 64) as u16,
+                (i % 4) as u16,
+                1.0 + f64::from(i % 3) * 0.5,
+                f64::from(i % 8) * std::f64::consts::FRAC_PI_4,
+                i % 3 == 0,
+                VERT_PRES[i as usize % 3],
+                HORIZ_PRES[i as usize % 3],
+            ));
+        }
+
+        library.add_cell(cell);
+    }
+
+    for c in 0_i32..20 {
+        let mut cell = Cell::new(&format!("mid_{c}"));
+        for r in 0_i32..3 {
+            let leaf = (c * 3 + r) % 20;
+            cell.add(
+                Reference::new(format!("leaf_{leaf}")).with_grid(
+                    Grid::default()
+                        .with_origin(point(r * 80_000, c * 40_000))
+                        .with_columns(10)
+                        .with_rows(8)
+                        .with_spacing_x(Some(point(15_000, 0)))
+                        .with_spacing_y(Some(point(0, 12_000)))
+                        .with_magnification(1.0 + f64::from(c % 5) * 0.1)
+                        .with_angle(f64::from(c % 8) * 0.05)
+                        .with_x_reflection(c % 3 == 0),
+                ),
+            );
+        }
+
+        for i in 0_i32..50 {
+            cell.add(Polygon::new(
+                vec![
+                    point(i * 2000, 0),
+                    point(i * 2000 + 1000, 0),
+                    point(i * 2000 + 1000, 1000),
+                    point(i * 2000, 1000),
+                ],
+                (i % 16) as u16,
+                0,
+            ));
+        }
+
+        library.add_cell(cell);
+    }
+
+    for c in 0_i32..10 {
+        let mut cell = Cell::new(&format!("top_{c}"));
+
+        for i in 0_i32..100 {
+            cell.add(Polygon::new(
+                vec![
+                    point(i * 1000, 0),
+                    point(i * 1000 + 500, 0),
+                    point(i * 1000 + 500, 500),
+                    point(i * 1000, 500),
+                ],
+                (i % 16) as u16,
+                0,
+            ));
+        }
+
+        for r in 0_i32..3 {
+            let mid = (c * 3 + r) % 20;
+            cell.add(
+                Reference::new(format!("mid_{mid}")).with_grid(
+                    Grid::default()
+                        .with_origin(point(r * 300_000, 0))
+                        .with_columns(5)
+                        .with_rows(4)
+                        .with_spacing_x(Some(point(150_000, 0)))
+                        .with_spacing_y(Some(point(0, 120_000)))
+                        .with_magnification(0.9 + f64::from(r) * 0.1)
+                        .with_angle(f64::from(r) * 0.03)
+                        .with_x_reflection(r % 2 == 1),
+                ),
+            );
+        }
+
+        library.add_cell(cell);
+    }
+
+    library
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() != 2 {
+        eprintln!("Usage: benchmark <write|read>");
+        std::process::exit(1);
+    }
+
+    let tmp_dir = std::env::temp_dir();
+    let path = tmp_dir.join("gdsr_bench.gds");
+
+    let library = build_library();
+
+    match args[1].as_str() {
+        "write" => {
+            library.write_file(&path, DB_UNITS, USER_UNITS).unwrap();
+        }
+        "read" => {
+            if !path.exists() {
+                library.write_file(&path, DB_UNITS, USER_UNITS).unwrap();
+            }
+            Library::read_file(&path, Some(DB_UNITS)).unwrap();
+        }
+        other => {
+            eprintln!("Unknown command: {other}");
+            std::process::exit(1);
+        }
+    }
+}

--- a/scripts/benchmark/benchmark_klayout.py
+++ b/scripts/benchmark/benchmark_klayout.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""KLayout GDS write/read benchmark. Invoked per-operation by hyperfine.
+
+Usage:
+    python benchmark_klayout.py write
+    python benchmark_klayout.py read
+
+Requires: pip install klayout
+"""
+
+import math
+import os
+import sys
+import tempfile
+
+import klayout.db as pya
+
+DB_UNITS = 1e-9
+TMP_DIR = tempfile.gettempdir()
+
+
+def build_library():
+    layout = pya.Layout()
+    layout.dbu = DB_UNITS / 1e-6
+
+    leaf_cells = []
+    for c in range(20):
+        cell = layout.create_cell(f"leaf_{c}")
+        leaf_cells.append(cell)
+
+        for i in range(500):
+            offset = i * 50
+            layer = layout.layer((c * 3 + i) % 64, i % 8)
+            npoints = 4 + (i % 5)
+            points = []
+            for p in range(npoints):
+                angle = 2 * math.pi * p / npoints
+                r = 20 + (i % 30)
+                points.append(
+                    pya.Point(
+                        offset + int(r * math.cos(angle)),
+                        int(r * math.sin(angle)),
+                    )
+                )
+            cell.shapes(layer).insert(pya.Polygon(points))
+
+        for i in range(250):
+            y_base = c * 5000 + i * 80
+            nsegs = 3 + (i % 8)
+            points = [
+                pya.Point(s * 150, y_base + (0 if s % 2 == 0 else 60))
+                for s in range(nsegs)
+            ]
+            layer = layout.layer((c * 2 + i) % 64, i % 4)
+            cell.shapes(layer).insert(pya.Path(points, (i % 30 + 1) * 10 * 2))
+
+        for i in range(100):
+            layer = layout.layer((c + i) % 64, i % 4)
+            text = pya.Text(
+                f"L{c}_text_{i:03}",
+                pya.Trans(pya.Point(i * 400, c * 1000)),
+            )
+            cell.shapes(layer).insert(text)
+
+    mid_cells = []
+    for c in range(20):
+        cell = layout.create_cell(f"mid_{c}")
+        mid_cells.append(cell)
+        for r in range(3):
+            leaf = (c * 3 + r) % 20
+            mag = 1.0 + (c % 5) * 0.1
+            angle_deg = (c % 8) * 0.05 * 180 / math.pi
+            mirror = c % 3 == 0
+            trans = pya.CplxTrans(
+                mag, angle_deg, mirror, pya.DPoint(r * 80_000, c * 40_000)
+            )
+            inst = pya.CellInstArray(
+                leaf_cells[leaf].cell_index(),
+                trans,
+                pya.Vector(15_000, 0),
+                pya.Vector(0, 12_000),
+                10,
+                8,
+            )
+            cell.insert(inst)
+
+        for i in range(50):
+            layer = layout.layer(i % 16, 0)
+            points = [
+                pya.Point(i * 2000, 0),
+                pya.Point(i * 2000 + 1000, 0),
+                pya.Point(i * 2000 + 1000, 1000),
+                pya.Point(i * 2000, 1000),
+            ]
+            cell.shapes(layer).insert(pya.Polygon(points))
+
+    for c in range(10):
+        cell = layout.create_cell(f"top_{c}")
+
+        for i in range(100):
+            layer = layout.layer(i % 16, 0)
+            points = [
+                pya.Point(i * 1000, 0),
+                pya.Point(i * 1000 + 500, 0),
+                pya.Point(i * 1000 + 500, 500),
+                pya.Point(i * 1000, 500),
+            ]
+            cell.shapes(layer).insert(pya.Polygon(points))
+
+        for r in range(4):
+            mid = (c * 4 + r) % 20
+            mag = 0.9 + r * 0.1
+            angle_deg = r * 0.03 * 180 / math.pi
+            mirror = r % 2 == 1
+            trans = pya.CplxTrans(mag, angle_deg, mirror, pya.DPoint(r * 300_000, 0))
+            inst = pya.CellInstArray(
+                mid_cells[mid].cell_index(),
+                trans,
+                pya.Vector(150_000, 0),
+                pya.Vector(0, 120_000),
+                5,
+                4,
+            )
+            cell.insert(inst)
+
+    return layout
+
+
+COMMANDS = {
+    "write": lambda lib, path: lib.write(path),
+    "read": lambda lib, path: pya.Layout().read(path),
+}
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2 or sys.argv[1] not in COMMANDS:
+        print(f"Usage: {sys.argv[0]} <{'|'.join(COMMANDS)}>", file=sys.stderr)
+        sys.exit(1)
+
+    cmd = sys.argv[1]
+    path = os.path.join(TMP_DIR, "klayout_bench.gds")
+
+    layout = build_library()
+
+    if cmd == "read" and not os.path.exists(path):
+        layout.write(path)
+
+    COMMANDS[cmd](layout, path)

--- a/scripts/benchmark/plot.py
+++ b/scripts/benchmark/plot.py
@@ -1,0 +1,146 @@
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "matplotlib",
+#     "numpy",
+# ]
+# ///
+"""Generate an SVG benchmark chart from hyperfine JSON results.
+
+Reads results/write.json and results/read.json (hyperfine --export-json format).
+
+Usage:
+    uv run scripts/benchmark/plot.py
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import matplotlib
+import matplotlib.pyplot as plt
+import numpy as np
+
+matplotlib.use("Agg")
+
+SCRIPT_DIR = Path(__file__).parent
+RESULTS_DIR = SCRIPT_DIR / "results"
+
+WRITE_COLOR = "#45744a"
+READ_COLOR = "#3a7ca5"
+
+
+def load_hyperfine(path: Path) -> dict:
+    with open(path) as f:
+        data = json.load(f)
+
+    results = {}
+    for entry in data["results"]:
+        results[entry["command"]] = entry["median"] * 1000
+    return results
+
+
+def main() -> None:
+    for name in ["write.json", "read.json"]:
+        if not (RESULTS_DIR / name).exists():
+            print(
+                f"Error: {RESULTS_DIR / name} not found. Run benchmark_comparison.sh first.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+    write_data = load_hyperfine(RESULTS_DIR / "write.json")
+    read_data = load_hyperfine(RESULTS_DIR / "read.json")
+
+    labels = ["gdsr", "KLayout"]
+    write_times = [write_data["gdsr"], write_data["klayout"]]
+    read_times = [read_data["gdsr"], read_data["klayout"]]
+
+    plt.style.use("dark_background")
+
+    y_pos = np.arange(len(labels))
+
+    fig, ax = plt.subplots(figsize=(8, 2.5))
+    fig.patch.set_facecolor("black")
+    ax.set_facecolor("black")
+
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+    ax.spines["left"].set_visible(False)
+    ax.spines["bottom"].set_visible(True)
+    ax.spines["bottom"].set_color("grey")
+    ax.tick_params(
+        axis="both",
+        which="both",
+        bottom=True,
+        top=False,
+        labelbottom=True,
+        colors="grey",
+    )
+
+    bar_height = 0.5
+    write_bars = ax.barh(
+        y_pos, write_times, color=WRITE_COLOR, height=bar_height, label="write"
+    )
+    read_bars = ax.barh(
+        y_pos,
+        read_times,
+        left=write_times,
+        color=READ_COLOR,
+        height=bar_height,
+        label="read",
+    )
+
+    max_time = max(w + r for w, r in zip(write_times, read_times))
+    ax.set_xlim(0, max_time * 1.15)
+    linspace = np.linspace(0, np.ceil(max_time), 5)
+    ax.set_xticks(linspace)
+    ax.set_xticklabels([f"{x:.0f}ms" for x in linspace], color="grey")
+
+    ax.set_yticks(y_pos)
+    ax.set_yticklabels(labels, fontsize=14, color="grey")
+
+    for i, (bw, br) in enumerate(zip(write_bars, read_bars)):
+        w_val = bw.get_width()
+        r_val = br.get_width()
+        total = w_val + r_val
+        y = bw.get_y() + bw.get_height() / 2.0
+
+        ax.text(
+            total + max_time * 0.01,
+            y,
+            f"{w_val:.1f}ms write / {r_val:.1f}ms read",
+            ha="left",
+            va="center",
+            color="grey",
+            fontsize=9,
+        )
+
+    ax.legend(
+        [write_bars, read_bars],
+        ["write", "read"],
+        loc="lower right",
+        fontsize=10,
+        frameon=False,
+        labelcolor="grey",
+    )
+
+    write_speedup = write_data["klayout"] / write_data["gdsr"]
+    read_speedup = read_data["klayout"] / read_data["gdsr"]
+
+    plt.title(
+        f"GDS I/O — gdsr is {write_speedup:.1f}x faster (write), {read_speedup:.1f}x faster (read)",
+        fontsize=13,
+        pad=20,
+        color="grey",
+        y=-0.55,
+    )
+
+    output_path = RESULTS_DIR / "benchmark.svg"
+    plt.savefig(output_path, dpi=600, bbox_inches="tight", transparent=True)
+    plt.close()
+    print(f"Chart saved to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark/results/.gitignore
+++ b/scripts/benchmark/results/.gitignore
@@ -1,0 +1,2 @@
+*
+!benchmark.svg

--- a/scripts/benchmark/results/benchmark.svg
+++ b/scripts/benchmark/results/benchmark.svg
@@ -1,0 +1,1171 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="606.034402pt" height="211.933594pt" viewBox="0 0 606.034402 211.933594" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-03-04T01:09:41.966423</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.8, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 211.933594 
+L 606.034402 211.933594 
+L 606.034402 0 
+L 0 0 
+L 0 211.933594 
+z
+" style="fill: none"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 70.974375 145.8 
+L 517.374375 145.8 
+L 517.374375 7.2 
+L 70.974375 7.2 
+L 70.974375 145.8 
+z
+" style="fill: none"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 70.974375 139.5 
+L 83.567091 139.5 
+L 83.567091 97.5 
+L 70.974375 97.5 
+z
+" clip-path="url(#pbf7b4c2119)" style="fill: #45744a"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 70.974375 55.5 
+L 268.354301 55.5 
+L 268.354301 13.5 
+L 70.974375 13.5 
+z
+" clip-path="url(#pbf7b4c2119)" style="fill: #45744a"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 83.567091 139.5 
+L 93.972172 139.5 
+L 93.972172 97.5 
+L 83.567091 97.5 
+z
+" clip-path="url(#pbf7b4c2119)" style="fill: #3a7ca5"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 268.354301 55.5 
+L 459.148288 55.5 
+L 459.148288 13.5 
+L 268.354301 13.5 
+z
+" clip-path="url(#pbf7b4c2119)" style="fill: #3a7ca5"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="ma225ce9916" d="M 0 0 
+L 0 3.5 
+" style="stroke: #808080; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#ma225ce9916" x="70.974375" y="145.8" style="fill: #808080; stroke: #808080; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 0ms -->
+      <g style="fill: #808080" transform="translate(60.318125 160.398438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(161.035156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#ma225ce9916" x="168.179663" y="145.8" style="fill: #808080; stroke: #808080; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 94ms -->
+      <g style="fill: #808080" transform="translate(154.342163 160.398438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-39"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(224.658203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#ma225ce9916" x="265.38495" y="145.8" style="fill: #808080; stroke: #808080; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 188ms -->
+      <g style="fill: #808080" transform="translate(248.3662 160.398438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-38" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(190.869141 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(288.28125 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#ma225ce9916" x="362.590238" y="145.8" style="fill: #808080; stroke: #808080; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 282ms -->
+      <g style="fill: #808080" transform="translate(345.571488 160.398438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(190.869141 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(288.28125 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#ma225ce9916" x="459.795526" y="145.8" style="fill: #808080; stroke: #808080; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 376ms -->
+      <g style="fill: #808080" transform="translate(442.776776 160.398438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(190.869141 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(288.28125 0)"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_6">
+      <defs>
+       <path id="meb82d62d79" d="M 0 0 
+L -3.5 0 
+" style="stroke: #808080; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#meb82d62d79" x="70.974375" y="118.5" style="fill: #808080; stroke: #808080; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- gdsr -->
+      <g style="fill: #808080" transform="translate(33.150313 123.818906) scale(0.14 -0.14)">
+       <defs>
+        <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-67"/>
+       <use xlink:href="#DejaVuSans-64" transform="translate(63.476562 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(126.953125 0)"/>
+       <use xlink:href="#DejaVuSans-72" transform="translate(179.052734 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#meb82d62d79" x="70.974375" y="34.5" style="fill: #808080; stroke: #808080; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- KLayout -->
+      <g style="fill: #808080" transform="translate(7.2 39.818906) scale(0.14 -0.14)">
+       <defs>
+        <path id="DejaVuSans-4b" d="M 628 4666 
+L 1259 4666 
+L 1259 2694 
+L 3353 4666 
+L 4166 4666 
+L 1850 2491 
+L 4331 0 
+L 3500 0 
+L 1259 2247 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-4c" d="M 628 4666 
+L 1259 4666 
+L 1259 531 
+L 3531 531 
+L 3531 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-79" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-4b"/>
+       <use xlink:href="#DejaVuSans-4c" transform="translate(65.576172 0)"/>
+       <use xlink:href="#DejaVuSans-61" transform="translate(121.289062 0)"/>
+       <use xlink:href="#DejaVuSans-79" transform="translate(182.568359 0)"/>
+       <use xlink:href="#DejaVuSans-6f" transform="translate(241.748047 0)"/>
+       <use xlink:href="#DejaVuSans-75" transform="translate(302.929688 0)"/>
+       <use xlink:href="#DejaVuSans-74" transform="translate(366.308594 0)"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="patch_7">
+    <path d="M 70.974375 145.8 
+L 517.374375 145.8 
+" style="fill: none; stroke: #808080; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_8">
+    <!-- 12.2ms write / 10.1ms read -->
+    <g style="fill: #808080" transform="translate(97.853911 120.983438) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-2e" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-77" d="M 269 3500 
+L 844 3500 
+L 1563 769 
+L 2278 3500 
+L 2956 3500 
+L 3675 769 
+L 4391 3500 
+L 4966 3500 
+L 4050 0 
+L 3372 0 
+L 2619 2869 
+L 1863 0 
+L 1184 0 
+L 269 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2f" d="M 1625 4666 
+L 2156 4666 
+L 531 -594 
+L 0 -594 
+L 1625 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(320.068359 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(372.167969 0)"/>
+     <use xlink:href="#DejaVuSans-77" transform="translate(403.955078 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(485.742188 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(526.855469 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(554.638672 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(593.847656 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(655.371094 0)"/>
+     <use xlink:href="#DejaVuSans-2f" transform="translate(687.158203 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(720.849609 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(752.636719 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(816.259766 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(879.882812 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(911.669922 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(975.292969 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1072.705078 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1124.804688 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1156.591797 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1195.455078 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1256.978516 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(1318.257812 0)"/>
+    </g>
+   </g>
+   <g id="text_9">
+    <!-- 190.9ms write / 184.5ms read -->
+    <g style="fill: #808080" transform="translate(463.030027 36.983438) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(190.869141 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(286.279297 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(383.691406 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(435.791016 0)"/>
+     <use xlink:href="#DejaVuSans-77" transform="translate(467.578125 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(549.365234 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(590.478516 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(618.261719 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(657.470703 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(718.994141 0)"/>
+     <use xlink:href="#DejaVuSans-2f" transform="translate(750.78125 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(784.472656 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(816.259766 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(879.882812 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(943.505859 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(1007.128906 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(1038.916016 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(1102.539062 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1199.951172 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1252.050781 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1283.837891 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1322.701172 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1384.224609 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(1445.503906 0)"/>
+    </g>
+   </g>
+   <g id="text_10">
+    <!-- GDS I/O — gdsr is 15.7x faster (write), 18.3x faster (read) -->
+    <g style="fill: #808080" transform="translate(106.540703 202.03) scale(0.13 -0.13)">
+     <defs>
+      <path id="DejaVuSans-47" d="M 3809 666 
+L 3809 1919 
+L 2778 1919 
+L 2778 2438 
+L 4434 2438 
+L 4434 434 
+Q 4069 175 3628 42 
+Q 3188 -91 2688 -91 
+Q 1594 -91 976 548 
+Q 359 1188 359 2328 
+Q 359 3472 976 4111 
+Q 1594 4750 2688 4750 
+Q 3144 4750 3555 4637 
+Q 3966 4525 4313 4306 
+L 4313 3634 
+Q 3963 3931 3569 4081 
+Q 3175 4231 2741 4231 
+Q 1884 4231 1454 3753 
+Q 1025 3275 1025 2328 
+Q 1025 1384 1454 906 
+Q 1884 428 2741 428 
+Q 3075 428 3337 486 
+Q 3600 544 3809 666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-44" d="M 1259 4147 
+L 1259 519 
+L 2022 519 
+Q 2988 519 3436 956 
+Q 3884 1394 3884 2338 
+Q 3884 3275 3436 3711 
+Q 2988 4147 2022 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 1925 4666 
+Q 3281 4666 3915 4102 
+Q 4550 3538 4550 2338 
+Q 4550 1131 3912 565 
+Q 3275 0 1925 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-53" d="M 3425 4513 
+L 3425 3897 
+Q 3066 4069 2747 4153 
+Q 2428 4238 2131 4238 
+Q 1616 4238 1336 4038 
+Q 1056 3838 1056 3469 
+Q 1056 3159 1242 3001 
+Q 1428 2844 1947 2747 
+L 2328 2669 
+Q 3034 2534 3370 2195 
+Q 3706 1856 3706 1288 
+Q 3706 609 3251 259 
+Q 2797 -91 1919 -91 
+Q 1588 -91 1214 -16 
+Q 841 59 441 206 
+L 441 856 
+Q 825 641 1194 531 
+Q 1563 422 1919 422 
+Q 2459 422 2753 634 
+Q 3047 847 3047 1241 
+Q 3047 1584 2836 1778 
+Q 2625 1972 2144 2069 
+L 1759 2144 
+Q 1053 2284 737 2584 
+Q 422 2884 422 3419 
+Q 422 4038 858 4394 
+Q 1294 4750 2059 4750 
+Q 2388 4750 2728 4690 
+Q 3069 4631 3425 4513 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-49" d="M 628 4666 
+L 1259 4666 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-4f" d="M 2522 4238 
+Q 1834 4238 1429 3725 
+Q 1025 3213 1025 2328 
+Q 1025 1447 1429 934 
+Q 1834 422 2522 422 
+Q 3209 422 3611 934 
+Q 4013 1447 4013 2328 
+Q 4013 3213 3611 3725 
+Q 3209 4238 2522 4238 
+z
+M 2522 4750 
+Q 3503 4750 4090 4092 
+Q 4678 3434 4678 2328 
+Q 4678 1225 4090 567 
+Q 3503 -91 2522 -91 
+Q 1538 -91 948 565 
+Q 359 1222 359 2328 
+Q 359 3434 948 4092 
+Q 1538 4750 2522 4750 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2014" d="M 313 1978 
+L 6088 1978 
+L 6088 1528 
+L 313 1528 
+L 313 1978 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-66" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2c" d="M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-47"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(77.490234 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(154.492188 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(217.96875 0)"/>
+     <use xlink:href="#DejaVuSans-49" transform="translate(249.755859 0)"/>
+     <use xlink:href="#DejaVuSans-2f" transform="translate(279.248047 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(312.939453 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(391.650391 0)"/>
+     <use xlink:href="#DejaVuSans-2014" transform="translate(423.4375 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(523.4375 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(555.224609 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(618.701172 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(682.177734 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(734.277344 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(775.390625 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(807.177734 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(834.960938 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(887.060547 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(918.847656 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(982.470703 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(1046.09375 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(1077.880859 0)"/>
+     <use xlink:href="#DejaVuSans-78" transform="translate(1141.503906 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1200.683594 0)"/>
+     <use xlink:href="#DejaVuSans-66" transform="translate(1232.470703 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1267.675781 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1328.955078 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1381.054688 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1420.263672 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1481.787109 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1522.900391 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(1554.6875 0)"/>
+     <use xlink:href="#DejaVuSans-77" transform="translate(1593.701172 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1675.488281 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(1716.601562 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1744.384766 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1783.59375 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(1845.117188 0)"/>
+     <use xlink:href="#DejaVuSans-2c" transform="translate(1884.130859 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1915.917969 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(1947.705078 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(2011.328125 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(2074.951172 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(2106.738281 0)"/>
+     <use xlink:href="#DejaVuSans-78" transform="translate(2170.361328 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2229.541016 0)"/>
+     <use xlink:href="#DejaVuSans-66" transform="translate(2261.328125 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(2296.533203 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(2357.8125 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(2409.912109 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2449.121094 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(2510.644531 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2551.757812 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(2583.544922 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(2622.558594 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2661.421875 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(2722.945312 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(2784.224609 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(2847.701172 0)"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="patch_8">
+     <path d="M 455.23375 120.042188 
+L 475.23375 120.042188 
+L 475.23375 113.042188 
+L 455.23375 113.042188 
+z
+" style="fill: #45744a"/>
+    </g>
+    <g id="text_11">
+     <!-- write -->
+     <g style="fill: #808080" transform="translate(483.23375 120.042188) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-77"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(81.787109 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(122.900391 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(150.683594 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(189.892578 0)"/>
+     </g>
+    </g>
+    <g id="patch_9">
+     <path d="M 455.23375 134.720313 
+L 475.23375 134.720313 
+L 475.23375 127.720313 
+L 455.23375 127.720313 
+z
+" style="fill: #3a7ca5"/>
+    </g>
+    <g id="text_12">
+     <!-- read -->
+     <g style="fill: #808080" transform="translate(483.23375 134.720313) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-72"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(38.863281 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(100.386719 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(161.666016 0)"/>
+     </g>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pbf7b4c2119">
+   <rect x="70.974375" y="7.2" width="446.4" height="138.6"/>
+  </clipPath>
+ </defs>
+</svg>


### PR DESCRIPTION
## Summary

- Adds a self-contained benchmark suite under `scripts/benchmark/` comparing GDS read/write performance between gdsr and KLayout using hyperfine
- Includes a matplotlib plot script that generates a stacked horizontal bar SVG chart
- Embeds the benchmark SVG in the project README
- Includes a README with instructions for running benchmarks and generating plots

## Test plan

- [ ] Run `./scripts/benchmark/benchmark_comparison.sh` and verify JSON results are generated
- [ ] Run `uv run scripts/benchmark/plot.py` and verify SVG is generated
- [ ] Verify benchmark SVG renders correctly in README on GitHub