### PR TITLE
Add spatial grid with cell-level LOD for large element counts

### DIFF
--- a/crates/gdsr-viewer/src/app.rs
+++ b/crates/gdsr-viewer/src/app.rs
@@ -7,6 +7,7 @@ use gdsr::{Element, Library};
 
 use crate::colors::LayerColorMap;
 use crate::panels;
+use crate::spatial::SpatialGrid;
 use crate::viewport::{self, Viewport};
 
 #[derive(Default)]
@@ -23,6 +24,7 @@ pub struct ViewerApp {
     layer_colors: LayerColorMap,
     hidden_layers: HashSet<(u16, u16)>,
     load_receiver: Option<(PathBuf, mpsc::Receiver<Result<Library, String>>)>,
+    spatial_grid: Option<SpatialGrid>,
     mouse_world_pos: Option<(f64, f64)>,
     error_message: Option<String>,
     loading: bool,
@@ -61,6 +63,7 @@ impl ViewerApp {
         self.element_receiver = None;
         self.elements.clear();
         self.layers.clear();
+        self.spatial_grid = None;
 
         if let Some(library) = &self.library {
             if let Some(cell) = library.get_cell(name) {
@@ -142,6 +145,9 @@ impl eframe::App for ViewerApp {
                     Err(mpsc::TryRecvError::Disconnected) => {
                         self.elements_loading = false;
                         self.element_receiver = None;
+                        if let Some(bounds) = viewport::compute_bounds(&self.elements) {
+                            self.spatial_grid = Some(SpatialGrid::build(&self.elements, bounds));
+                        }
                         self.zoom_to_fit();
                         break;
                     }
@@ -226,6 +232,7 @@ impl eframe::App for ViewerApp {
                 &self.elements,
                 &self.hidden_layers,
                 &mut self.layer_colors,
+                self.spatial_grid.as_ref(),
             );
         });
     }

--- a/crates/gdsr-viewer/src/main.rs
+++ b/crates/gdsr-viewer/src/main.rs
@@ -2,6 +2,7 @@ mod app;
 mod colors;
 mod loader;
 mod panels;
+mod spatial;
 mod viewport;
 
 fn main() -> eframe::Result<()> {

--- a/crates/gdsr-viewer/src/spatial.rs
+++ b/crates/gdsr-viewer/src/spatial.rs
@@ -1,0 +1,419 @@
+use std::collections::HashMap;
+
+use gdsr::Element;
+
+use crate::viewport::element_bbox;
+
+const GRID_SIZE: usize = 256;
+
+pub struct GridCell {
+    pub indices: Vec<u32>,
+    /// Tight bounding box: `[min_x, min_y, max_x, max_y]`
+    pub bbox: [f64; 4],
+    pub dominant_layer: (u16, u16),
+}
+
+pub struct SpatialGrid {
+    cells: Vec<Option<GridCell>>,
+    world_min_x: f64,
+    world_min_y: f64,
+    cell_width: f64,
+    cell_height: f64,
+}
+
+fn element_layer(element: &Element) -> (u16, u16) {
+    match element {
+        Element::Polygon(p) => (p.layer(), p.data_type()),
+        Element::Path(p) => (p.layer(), p.data_type()),
+        Element::Text(t) => (t.layer(), 0),
+        Element::Reference(_) => (0, 0),
+    }
+}
+
+impl SpatialGrid {
+    pub fn build(elements: &[Element], bounds: (f64, f64, f64, f64)) -> Self {
+        let (min_x, min_y, max_x, max_y) = bounds;
+        let epsilon = 1e-12;
+        let cell_width = (max_x - min_x + epsilon) / GRID_SIZE as f64;
+        let cell_height = (max_y - min_y + epsilon) / GRID_SIZE as f64;
+
+        let mut cells: Vec<Option<GridCell>> = (0..GRID_SIZE * GRID_SIZE).map(|_| None).collect();
+        let mut layer_counts: HashMap<usize, HashMap<(u16, u16), u32>> = HashMap::new();
+
+        for (i, element) in elements.iter().enumerate() {
+            let Some(bbox) = element_bbox(element) else {
+                continue;
+            };
+
+            // Insert into every grid cell the element's bbox overlaps
+            let col_min = ((bbox[0] - min_x) / cell_width) as usize;
+            let col_max = ((bbox[2] - min_x) / cell_width) as usize;
+            let row_min = ((bbox[1] - min_y) / cell_height) as usize;
+            let row_max = ((bbox[3] - min_y) / cell_height) as usize;
+            let col_min = col_min.min(GRID_SIZE - 1);
+            let col_max = col_max.min(GRID_SIZE - 1);
+            let row_min = row_min.min(GRID_SIZE - 1);
+            let row_max = row_max.min(GRID_SIZE - 1);
+
+            let layer = element_layer(element);
+            for row in row_min..=row_max {
+                for col in col_min..=col_max {
+                    let cell_idx = row * GRID_SIZE + col;
+                    let cell = cells[cell_idx].get_or_insert_with(|| GridCell {
+                        indices: Vec::new(),
+                        bbox: [f64::MAX, f64::MAX, f64::MIN, f64::MIN],
+                        dominant_layer: (0, 0),
+                    });
+
+                    cell.indices.push(i as u32);
+                    cell.bbox[0] = cell.bbox[0].min(bbox[0]);
+                    cell.bbox[1] = cell.bbox[1].min(bbox[1]);
+                    cell.bbox[2] = cell.bbox[2].max(bbox[2]);
+                    cell.bbox[3] = cell.bbox[3].max(bbox[3]);
+
+                    *layer_counts
+                        .entry(cell_idx)
+                        .or_default()
+                        .entry(layer)
+                        .or_insert(0) += 1;
+                }
+            }
+        }
+
+        // Set dominant layer for each cell
+        for (cell_idx, counts) in &layer_counts {
+            if let Some(cell) = cells[*cell_idx].as_mut() {
+                if let Some((&layer, _)) = counts.iter().max_by_key(|(_, count)| *count) {
+                    cell.dominant_layer = layer;
+                }
+            }
+        }
+
+        Self {
+            cells,
+            world_min_x: min_x,
+            world_min_y: min_y,
+            cell_width,
+            cell_height,
+        }
+    }
+
+    pub fn query_visible(&self, visible: &[f64; 4]) -> impl Iterator<Item = &GridCell> {
+        let col_min = ((visible[0] - self.world_min_x) / self.cell_width).floor() as isize - 1;
+        let col_max = ((visible[2] - self.world_min_x) / self.cell_width).ceil() as isize + 1;
+        let row_min = ((visible[1] - self.world_min_y) / self.cell_height).floor() as isize - 1;
+        let row_max = ((visible[3] - self.world_min_y) / self.cell_height).ceil() as isize + 1;
+
+        let col_min = col_min.clamp(0, GRID_SIZE as isize - 1) as usize;
+        let col_max = col_max.clamp(0, GRID_SIZE as isize - 1) as usize;
+        let row_min = row_min.clamp(0, GRID_SIZE as isize - 1) as usize;
+        let row_max = row_max.clamp(0, GRID_SIZE as isize - 1) as usize;
+
+        let grid_size = GRID_SIZE;
+        let cells_ref = &self.cells;
+
+        (row_min..=row_max).flat_map(move |row| {
+            (col_min..=col_max).filter_map(move |col| cells_ref[row * grid_size + col].as_ref())
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gdsr::{HorizontalPresentation, Path, Point, Polygon, Text, Unit, VerticalPresentation};
+
+    fn make_polygon(points: Vec<(i32, i32)>, layer: u16, data_type: u16) -> Element {
+        Element::Polygon(Polygon::new(
+            points
+                .into_iter()
+                .map(|(x, y)| Point::default_integer(x, y)),
+            layer,
+            data_type,
+        ))
+    }
+
+    #[test]
+    fn build_empty() {
+        let grid = SpatialGrid::build(&[], (0.0, 0.0, 1.0, 1.0));
+        assert!(grid.cells.iter().all(Option::is_none));
+    }
+
+    /// Collects all unique element indices found across queried cells.
+    fn query_element_indices(grid: &SpatialGrid, visible: &[f64; 4]) -> Vec<u32> {
+        let mut indices: Vec<u32> = grid
+            .query_visible(visible)
+            .flat_map(|c| c.indices.iter().copied())
+            .collect();
+        indices.sort_unstable();
+        indices.dedup();
+        indices
+    }
+
+    #[test]
+    fn build_single_element() {
+        let poly = make_polygon(vec![(0, 0), (1000, 0), (1000, 1000)], 1, 0);
+        let bounds = (0.0, 0.0, 1000.0 * 1e-9, 1000.0 * 1e-9);
+        let grid = SpatialGrid::build(&[poly], bounds);
+
+        // Element should be findable via full-extent query
+        let all = query_element_indices(&grid, &[0.0, 0.0, 1000.0 * 1e-9, 1000.0 * 1e-9]);
+        assert_eq!(all, vec![0]);
+
+        // Every non-empty cell should reference element 0 with layer (1, 0)
+        for cell in grid.cells.iter().flatten() {
+            assert!(cell.indices.contains(&0));
+            assert_eq!(cell.dominant_layer, (1, 0));
+        }
+    }
+
+    #[test]
+    fn build_assigns_correct_cell() {
+        let scale = 1e-9;
+        let p1 = make_polygon(vec![(0, 0), (100, 0), (100, 100)], 1, 0);
+        let p2 = make_polygon(vec![(9900, 9900), (10000, 9900), (10000, 10000)], 2, 0);
+
+        let bounds = (0.0, 0.0, 10000.0 * scale, 10000.0 * scale);
+        let grid = SpatialGrid::build(&[p1, p2], bounds);
+
+        // Both elements should be findable
+        let all = query_element_indices(&grid, &[0.0, 0.0, 10000.0 * scale, 10000.0 * scale]);
+        assert_eq!(all, vec![0, 1]);
+
+        // They should not share any cells (far apart, small relative to grid)
+        for cell in grid.cells.iter().flatten() {
+            assert!(
+                !cell.indices.contains(&0) || !cell.indices.contains(&1),
+                "small distant elements should not share cells"
+            );
+        }
+    }
+
+    #[test]
+    fn query_returns_only_visible_elements() {
+        let scale = 1e-9;
+        let p1 = make_polygon(vec![(0, 0), (100, 0), (100, 100)], 1, 0);
+        let p2 = make_polygon(vec![(9900, 9900), (10000, 9900), (10000, 10000)], 2, 0);
+
+        let bounds = (0.0, 0.0, 10000.0 * scale, 10000.0 * scale);
+        let grid = SpatialGrid::build(&[p1, p2], bounds);
+
+        // Query only the bottom-left corner — should find p1 but not p2
+        let visible = [0.0, 0.0, 1000.0 * scale, 1000.0 * scale];
+        let indices = query_element_indices(&grid, &visible);
+        assert!(indices.contains(&0));
+        assert!(!indices.contains(&1));
+    }
+
+    #[test]
+    fn query_full_extent_returns_all() {
+        let scale = 1e-9;
+        let p1 = make_polygon(vec![(0, 0), (100, 0), (100, 100)], 1, 0);
+        let p2 = make_polygon(vec![(9900, 9900), (10000, 9900), (10000, 10000)], 2, 0);
+
+        let bounds = (0.0, 0.0, 10000.0 * scale, 10000.0 * scale);
+        let grid = SpatialGrid::build(&[p1, p2], bounds);
+
+        let visible = [0.0, 0.0, 10000.0 * scale, 10000.0 * scale];
+        let indices = query_element_indices(&grid, &visible);
+        assert_eq!(indices, vec![0, 1]);
+    }
+
+    #[test]
+    fn query_finds_element_partially_overlapping_viewport() {
+        let scale = 1e-9;
+        // Element spans from 400..600 in a 0..1000 world
+        let p = make_polygon(vec![(400, 400), (600, 400), (600, 600), (400, 600)], 1, 0);
+        let bounds = (0.0, 0.0, 1000.0 * scale, 1000.0 * scale);
+        let grid = SpatialGrid::build(&[p], bounds);
+
+        // Viewport covers 0..500 — partially overlaps the element
+        let visible = [0.0, 0.0, 500.0 * scale, 500.0 * scale];
+        let indices = query_element_indices(&grid, &visible);
+        assert!(
+            indices.contains(&0),
+            "partially overlapping element must be found"
+        );
+    }
+
+    #[test]
+    fn dominant_layer_most_frequent() {
+        let elems: Vec<Element> = vec![
+            make_polygon(vec![(0, 0), (10, 0), (10, 10)], 5, 0),
+            make_polygon(vec![(0, 0), (10, 0), (10, 10)], 5, 0),
+            make_polygon(vec![(0, 0), (10, 0), (10, 10)], 5, 0),
+            make_polygon(vec![(0, 0), (10, 0), (10, 10)], 2, 0),
+        ];
+
+        let scale = 1e-9;
+        let bounds = (0.0, 0.0, 100.0 * scale, 100.0 * scale);
+        let grid = SpatialGrid::build(&elems, bounds);
+
+        // All 4 elements overlap the same region; every cell containing them should
+        // have dominant layer (5, 0) since 3 of 4 elements are on that layer.
+        for cell in grid.cells.iter().flatten() {
+            assert_eq!(cell.dominant_layer, (5, 0));
+        }
+    }
+
+    #[test]
+    fn build_skips_references() {
+        let reference = Element::Reference(gdsr::Reference::default());
+        let poly = make_polygon(vec![(0, 0), (100, 0), (100, 100)], 1, 0);
+        let scale = 1e-9;
+        let bounds = (0.0, 0.0, 100.0 * scale, 100.0 * scale);
+        let grid = SpatialGrid::build(&[reference, poly], bounds);
+
+        let all = query_element_indices(&grid, &[0.0, 0.0, 100.0 * scale, 100.0 * scale]);
+        // Only the polygon (index 1) should appear; reference (index 0) is skipped
+        assert_eq!(all, vec![1]);
+    }
+
+    #[test]
+    fn cell_bbox_is_tight() {
+        let scale = 1e-9;
+        let poly = make_polygon(vec![(100, 200), (300, 200), (300, 400), (100, 400)], 1, 0);
+        let bounds = (0.0, 0.0, 1000.0 * scale, 1000.0 * scale);
+        let grid = SpatialGrid::build(&[poly], bounds);
+
+        for cell in grid.cells.iter().flatten() {
+            assert!((cell.bbox[0] - 100.0 * scale).abs() < 1e-15);
+            assert!((cell.bbox[1] - 200.0 * scale).abs() < 1e-15);
+            assert!((cell.bbox[2] - 300.0 * scale).abs() < 1e-15);
+            assert!((cell.bbox[3] - 400.0 * scale).abs() < 1e-15);
+        }
+    }
+
+    #[test]
+    fn large_element_found_from_opposite_edge() {
+        let scale = 1e-9;
+        // Element spans the entire world
+        let p = make_polygon(vec![(0, 0), (1000, 0), (1000, 1000), (0, 1000)], 1, 0);
+        let bounds = (0.0, 0.0, 1000.0 * scale, 1000.0 * scale);
+        let grid = SpatialGrid::build(&[p], bounds);
+
+        // Query just the top-right corner
+        let visible = [900.0 * scale, 900.0 * scale, 1000.0 * scale, 1000.0 * scale];
+        let indices = query_element_indices(&grid, &visible);
+        assert!(indices.contains(&0));
+
+        // Query just the bottom-left corner
+        let visible = [0.0, 0.0, 100.0 * scale, 100.0 * scale];
+        let indices = query_element_indices(&grid, &visible);
+        assert!(indices.contains(&0));
+    }
+
+    #[test]
+    fn element_layer_polygon() {
+        let poly = Polygon::new(
+            vec![
+                Point::default_integer(0, 0),
+                Point::default_integer(1, 0),
+                Point::default_integer(1, 1),
+            ],
+            5,
+            3,
+        );
+        assert_eq!(element_layer(&Element::Polygon(poly)), (5, 3));
+    }
+
+    #[test]
+    fn element_layer_path() {
+        let path = Path::new(
+            vec![Point::default_integer(0, 0), Point::default_integer(1, 1)],
+            7,
+            2,
+            None,
+            None,
+        );
+        assert_eq!(element_layer(&Element::Path(path)), (7, 2));
+    }
+
+    #[test]
+    fn element_layer_text() {
+        let text = Text::new(
+            "t",
+            Point::default_integer(0, 0),
+            4,
+            0,
+            1.0,
+            0.0,
+            false,
+            VerticalPresentation::default(),
+            HorizontalPresentation::default(),
+        );
+        assert_eq!(element_layer(&Element::Text(text)), (4, 0));
+    }
+
+    #[test]
+    fn element_layer_reference() {
+        let reference = Element::Reference(gdsr::Reference::default());
+        assert_eq!(element_layer(&reference), (0, 0));
+    }
+
+    #[test]
+    fn element_bbox_polygon() {
+        let poly = Polygon::new(
+            vec![
+                Point::default_integer(100, 200),
+                Point::default_integer(300, 400),
+                Point::default_integer(500, 100),
+            ],
+            1,
+            0,
+        );
+        let bbox = element_bbox(&Element::Polygon(poly)).expect("should have bbox");
+        let scale = 1e-9;
+        assert!((bbox[0] - 100.0 * scale).abs() < 1e-15);
+        assert!((bbox[1] - 100.0 * scale).abs() < 1e-15);
+        assert!((bbox[2] - 500.0 * scale).abs() < 1e-15);
+        assert!((bbox[3] - 400.0 * scale).abs() < 1e-15);
+    }
+
+    #[test]
+    fn element_bbox_path() {
+        let path = Path::new(
+            vec![
+                Point::default_integer(10, 20),
+                Point::default_integer(30, 40),
+            ],
+            1,
+            0,
+            None,
+            Some(Unit::default_integer(5)),
+        );
+        let bbox = element_bbox(&Element::Path(path)).expect("should have bbox");
+        let scale = 1e-9;
+        assert!((bbox[0] - 10.0 * scale).abs() < 1e-15);
+        assert!((bbox[1] - 20.0 * scale).abs() < 1e-15);
+        assert!((bbox[2] - 30.0 * scale).abs() < 1e-15);
+        assert!((bbox[3] - 40.0 * scale).abs() < 1e-15);
+    }
+
+    #[test]
+    fn element_bbox_text() {
+        let text = Text::new(
+            "hello",
+            Point::default_integer(500, 600),
+            1,
+            0,
+            1.0,
+            0.0,
+            false,
+            VerticalPresentation::default(),
+            HorizontalPresentation::default(),
+        );
+        let bbox = element_bbox(&Element::Text(text)).expect("should have bbox");
+        let scale = 1e-9;
+        assert!((bbox[0] - 500.0 * scale).abs() < 1e-15);
+        assert!((bbox[1] - 600.0 * scale).abs() < 1e-15);
+        assert_eq!(bbox[0], bbox[2]);
+        assert_eq!(bbox[1], bbox[3]);
+    }
+
+    #[test]
+    fn element_bbox_reference() {
+        let reference = Element::Reference(gdsr::Reference::default());
+        assert!(element_bbox(&reference).is_none());
+    }
+}

--- a/crates/gdsr-viewer/src/viewport.rs
+++ b/crates/gdsr-viewer/src/viewport.rs
@@ -1,7 +1,10 @@
+use std::collections::HashSet;
+
 use egui::{Color32, FontId, Mesh, Pos2, Rect, Sense, Shape, Stroke};
 use gdsr::Element;
 
 use crate::colors::LayerColorMap;
+use crate::spatial::SpatialGrid;
 
 /// Camera state for the 2D viewport: center position in world coordinates and zoom level.
 pub struct Viewport {
@@ -39,6 +42,13 @@ impl Viewport {
         (wx, wy)
     }
 
+    /// Returns the visible world-space rectangle as `[min_x, min_y, max_x, max_y]`.
+    pub fn visible_world_rect(&self, rect: Rect) -> [f64; 4] {
+        let (min_x, max_y) = self.screen_to_world(rect.min.x, rect.min.y, rect);
+        let (max_x, min_y) = self.screen_to_world(rect.max.x, rect.max.y, rect);
+        [min_x, min_y, max_x, max_y]
+    }
+
     /// Adjusts center and zoom to fit the given bounding box in the viewport rect.
     pub fn zoom_to_fit(&mut self, min_x: f64, min_y: f64, max_x: f64, max_y: f64, rect: Rect) {
         self.center_x = f64::midpoint(min_x, max_x);
@@ -62,8 +72,9 @@ pub fn draw_viewport(
     ui: &mut egui::Ui,
     viewport: &mut Viewport,
     elements: &[Element],
-    hidden_layers: &std::collections::HashSet<(u16, u16)>,
+    hidden_layers: &HashSet<(u16, u16)>,
     layer_colors: &mut LayerColorMap,
+    spatial_grid: Option<&SpatialGrid>,
 ) -> Option<(f64, f64)> {
     let (response, painter) = ui.allocate_painter(ui.available_size(), Sense::click_and_drag());
     let rect = response.rect;
@@ -86,6 +97,7 @@ pub fn draw_viewport(
             let factor = 1.0 + f64::from(scroll) * 0.002;
             let new_zoom = (viewport.zoom * factor).clamp(1e-3, 1e15);
             // Anchor: the world point under the cursor must stay at hover_pos
+            // screen_x = cx + (wx - center_x) * zoom  →  center_x = wx - (screen_x - cx) / zoom
             let cx = f64::from(rect.center().x);
             let cy = f64::from(rect.center().y);
             let sx = f64::from(hover_pos.x);
@@ -96,40 +108,29 @@ pub fn draw_viewport(
         }
     }
 
-    // Draw elements
-    for element in elements {
-        match element {
-            Element::Polygon(polygon) => {
-                let layer = polygon.layer();
-                let dt = polygon.data_type();
-                if hidden_layers.contains(&(layer, dt)) {
-                    continue;
-                }
-                draw_polygon(
-                    &painter,
-                    viewport,
-                    rect,
-                    polygon,
-                    layer_colors.get(layer, dt),
-                );
-            }
-            Element::Path(path) => {
-                let layer = path.layer();
-                let dt = path.data_type();
-                if hidden_layers.contains(&(layer, dt)) {
-                    continue;
-                }
-                draw_path(&painter, viewport, rect, path, layer_colors.get(layer, dt));
-            }
-            Element::Text(text) => {
-                let layer = text.layer();
-                if hidden_layers.contains(&(layer, 0)) {
-                    continue;
-                }
-                draw_text(&painter, viewport, rect, text, layer_colors.get(layer, 0));
-            }
-            Element::Reference(_) => {}
-        }
+    let visible = viewport.visible_world_rect(rect);
+
+    if let Some(grid) = spatial_grid {
+        draw_with_grid(
+            &painter,
+            viewport,
+            rect,
+            &visible,
+            elements,
+            hidden_layers,
+            layer_colors,
+            grid,
+        );
+    } else {
+        draw_elements_flat(
+            &painter,
+            viewport,
+            rect,
+            &visible,
+            elements,
+            hidden_layers,
+            layer_colors,
+        );
     }
 
     // Return mouse world position
@@ -138,10 +139,137 @@ pub fn draw_viewport(
         .map(|pos| viewport.screen_to_world(pos.x, pos.y, rect))
 }
 
+fn draw_elements_flat(
+    painter: &egui::Painter,
+    viewport: &Viewport,
+    rect: Rect,
+    visible: &[f64; 4],
+    elements: &[Element],
+    hidden_layers: &HashSet<(u16, u16)>,
+    layer_colors: &mut LayerColorMap,
+) {
+    for element in elements {
+        draw_element(
+            painter,
+            viewport,
+            rect,
+            visible,
+            element,
+            hidden_layers,
+            layer_colors,
+        );
+    }
+}
+
+fn draw_element(
+    painter: &egui::Painter,
+    viewport: &Viewport,
+    rect: Rect,
+    visible: &[f64; 4],
+    element: &Element,
+    hidden_layers: &HashSet<(u16, u16)>,
+    layer_colors: &mut LayerColorMap,
+) {
+    match element {
+        Element::Polygon(polygon) => {
+            let layer = polygon.layer();
+            let dt = polygon.data_type();
+            if hidden_layers.contains(&(layer, dt)) {
+                return;
+            }
+            draw_polygon(
+                painter,
+                viewport,
+                rect,
+                visible,
+                polygon,
+                layer_colors.get(layer, dt),
+            );
+        }
+        Element::Path(path) => {
+            let layer = path.layer();
+            let dt = path.data_type();
+            if hidden_layers.contains(&(layer, dt)) {
+                return;
+            }
+            draw_path(
+                painter,
+                viewport,
+                rect,
+                visible,
+                path,
+                layer_colors.get(layer, dt),
+            );
+        }
+        Element::Text(text) => {
+            let layer = text.layer();
+            if hidden_layers.contains(&(layer, 0)) {
+                return;
+            }
+            draw_text(painter, viewport, rect, text, layer_colors.get(layer, 0));
+        }
+        Element::Reference(_) => {}
+    }
+}
+
+/// Screen-pixel threshold below which a grid cell draws as a single LOAD rectangle.
+const CELL_LOAD_THRESHOLD_PX: f32 = 24.0;
+
+fn draw_with_grid(
+    painter: &egui::Painter,
+    viewport: &Viewport,
+    rect: Rect,
+    visible: &[f64; 4],
+    elements: &[Element],
+    hidden_layers: &HashSet<(u16, u16)>,
+    layer_colors: &mut LayerColorMap,
+    grid: &SpatialGrid,
+) {
+    for cell in grid.query_visible(visible) {
+        let s_min = viewport.world_to_screen(cell.bbox[0], cell.bbox[1], rect);
+        let s_max = viewport.world_to_screen(cell.bbox[2], cell.bbox[3], rect);
+        let sw = (s_max.x - s_min.x).abs();
+        let sh = (s_min.y - s_max.y).abs(); // Y flipped
+
+        if sw < 1.0 && sh < 1.0 {
+            continue;
+        }
+
+        if sw < CELL_LOAD_THRESHOLD_PX && sh < CELL_LOAD_THRESHOLD_PX {
+            if !hidden_layers.contains(&cell.dominant_layer) {
+                let color = layer_colors.get(cell.dominant_layer.0, cell.dominant_layer.1);
+                let fill = Color32::from_rgba_unmultiplied(color.r(), color.g(), color.b(), 80);
+                let cell_rect = Rect::from_two_pos(s_min, s_max);
+                painter.rect_filled(cell_rect, 0.0, fill);
+            }
+            continue;
+        }
+
+        for &idx in &cell.indices {
+            if let Some(element) = elements.get(idx as usize) {
+                draw_element(
+                    painter,
+                    viewport,
+                    rect,
+                    visible,
+                    element,
+                    hidden_layers,
+                    layer_colors,
+                );
+            }
+        }
+    }
+}
+
+/// Screen-pixel threshold below which polygons render as a filled bounding box instead of
+/// full triangulation. Avoids expensive earcut calls for elements that are just a few pixels.
+const BBOX_FALLBACK_PX: f32 = 8.0;
+
 fn draw_polygon(
     painter: &egui::Painter,
     viewport: &Viewport,
     rect: Rect,
+    visible: &[f64; 4],
     polygon: &gdsr::Polygon,
     color: Color32,
 ) {
@@ -150,30 +278,54 @@ fn draw_polygon(
         return;
     }
 
-    // Convert to screen coordinates
+    // World-space bounding box — cull before any vertex conversion
+    let (mut w_min_x, mut w_min_y) = (f64::MAX, f64::MAX);
+    let (mut w_max_x, mut w_max_y) = (f64::MIN, f64::MIN);
+    for p in points {
+        let x = p.x().absolute_value();
+        let y = p.y().absolute_value();
+        w_min_x = w_min_x.min(x);
+        w_min_y = w_min_y.min(y);
+        w_max_x = w_max_x.max(x);
+        w_max_y = w_max_y.max(y);
+    }
+    if w_max_x < visible[0] || w_min_x > visible[2] || w_max_y < visible[1] || w_min_y > visible[3]
+    {
+        return;
+    }
+
+    // Convert only the bounding box corners to screen space to measure pixel size
+    let s_min = viewport.world_to_screen(w_min_x, w_min_y, rect);
+    let s_max = viewport.world_to_screen(w_max_x, w_max_y, rect);
+    let sw = (s_max.x - s_min.x).abs();
+    let sh = (s_min.y - s_max.y).abs(); // Y flipped
+
+    // Skip sub-pixel elements
+    if sw < 2.0 && sh < 2.0 {
+        return;
+    }
+
+    let fill = Color32::from_rgba_unmultiplied(color.r(), color.g(), color.b(), 80);
+
+    // Small on screen — draw filled bounding box instead of triangulating
+    if sw < BBOX_FALLBACK_PX && sh < BBOX_FALLBACK_PX {
+        let bbox = Rect::from_two_pos(s_min, s_max);
+        painter.rect_filled(bbox, 0.0, fill);
+        painter.rect_stroke(
+            bbox,
+            0.0,
+            Stroke::new(1.0, color),
+            egui::StrokeKind::Outside,
+        );
+        return;
+    }
+
+    // Full rendering path: convert all vertices to screen coordinates
     let screen_pts: Vec<Pos2> = points
         .iter()
         .map(|p| viewport.world_to_screen(p.x().absolute_value(), p.y().absolute_value(), rect))
         .collect();
 
-    // Quick visibility check: skip if bounding box is completely outside the viewport
-    let (mut min_x, mut min_y) = (f32::MAX, f32::MAX);
-    let (mut max_x, mut max_y) = (f32::MIN, f32::MIN);
-    for pt in &screen_pts {
-        min_x = min_x.min(pt.x);
-        min_y = min_y.min(pt.y);
-        max_x = max_x.max(pt.x);
-        max_y = max_y.max(pt.y);
-    }
-    if max_x < rect.min.x || min_x > rect.max.x || max_y < rect.min.y || min_y > rect.max.y {
-        return;
-    }
-    // Skip polygons smaller than 2 pixels in either dimension
-    if (max_x - min_x) < 2.0 && (max_y - min_y) < 2.0 {
-        return;
-    }
-
-    // Triangulate with earcutr for correct rendering of concave polygons
     // Remove the closing point if present (earcutr expects open polygons)
     let open_pts = if screen_pts.len() >= 2 && screen_pts.first() == screen_pts.last() {
         &screen_pts[..screen_pts.len() - 1]
@@ -191,7 +343,6 @@ fn draw_polygon(
         .collect();
 
     if let Ok(indices) = earcutr::earcut(&coords, &[], 2) {
-        let fill = Color32::from_rgba_unmultiplied(color.r(), color.g(), color.b(), 80);
         let mut mesh = Mesh::default();
         for pt in open_pts {
             mesh.vertices.push(egui::epaint::Vertex {
@@ -206,7 +357,6 @@ fn draw_polygon(
         painter.add(Shape::mesh(mesh));
     }
 
-    // Outline stroke
     let stroke = Stroke::new(1.0, color);
     for i in 0..open_pts.len() {
         let next = (i + 1) % open_pts.len();
@@ -218,6 +368,7 @@ fn draw_path(
     painter: &egui::Painter,
     viewport: &Viewport,
     rect: Rect,
+    visible: &[f64; 4],
     path: &gdsr::Path,
     color: Color32,
 ) {
@@ -226,26 +377,42 @@ fn draw_path(
         return;
     }
 
+    // World-space bounding box — cull before vertex conversion
+    let (mut w_min_x, mut w_min_y) = (f64::MAX, f64::MAX);
+    let (mut w_max_x, mut w_max_y) = (f64::MIN, f64::MIN);
+    for p in points {
+        let x = p.x().absolute_value();
+        let y = p.y().absolute_value();
+        w_min_x = w_min_x.min(x);
+        w_min_y = w_min_y.min(y);
+        w_max_x = w_max_x.max(x);
+        w_max_y = w_max_y.max(y);
+    }
+    if w_max_x < visible[0] || w_min_x > visible[2] || w_max_y < visible[1] || w_min_y > visible[3]
+    {
+        return;
+    }
+
+    // Screen-space size check
+    let s_min = viewport.world_to_screen(w_min_x, w_min_y, rect);
+    let s_max = viewport.world_to_screen(w_max_x, w_max_y, rect);
+    let sw = (s_max.x - s_min.x).abs();
+    let sh = (s_min.y - s_max.y).abs();
+    if sw < 1.0 && sh < 1.0 {
+        return;
+    }
+
+    // Small on screen — draw a single line segment between bbox corners
+    if sw < BBOX_FALLBACK_PX && sh < BBOX_FALLBACK_PX {
+        let stroke = Stroke::new(1.0, color);
+        painter.line_segment([s_min, s_max], stroke);
+        return;
+    }
+
     let screen_pts: Vec<Pos2> = points
         .iter()
         .map(|p| viewport.world_to_screen(p.x().absolute_value(), p.y().absolute_value(), rect))
         .collect();
-
-    // Frustum culling and sub-pixel skip
-    let (mut min_x, mut min_y) = (f32::MAX, f32::MAX);
-    let (mut max_x, mut max_y) = (f32::MIN, f32::MIN);
-    for pt in &screen_pts {
-        min_x = min_x.min(pt.x);
-        min_y = min_y.min(pt.y);
-        max_x = max_x.max(pt.x);
-        max_y = max_y.max(pt.y);
-    }
-    if max_x < rect.min.x || min_x > rect.max.x || max_y < rect.min.y || min_y > rect.max.y {
-        return;
-    }
-    if (max_x - min_x) < 1.0 && (max_y - min_y) < 1.0 {
-        return;
-    }
 
     let width_px = path
         .width()
@@ -298,6 +465,39 @@ fn test_rect() -> Rect {
     Rect::from_min_size(Pos2::ZERO, egui::Vec2::new(800.0, 600.0))
 }
 
+/// Returns the world-space bounding box of a single element as `[min_x, min_y, max_x, max_y]`.
+/// Returns `None` for references and elements with no points.
+pub fn element_bbox(element: &Element) -> Option<[f64; 4]> {
+    let points: &[gdsr::Point] = match element {
+        Element::Polygon(p) => p.points(),
+        Element::Path(p) => p.points(),
+        Element::Text(t) => {
+            let x = t.origin().x().absolute_value();
+            let y = t.origin().y().absolute_value();
+            return Some([x, y, x, y]);
+        }
+        Element::Reference(_) => return None,
+    };
+
+    if points.is_empty() {
+        return None;
+    }
+
+    let mut min_x = f64::MAX;
+    let mut min_y = f64::MAX;
+    let mut max_x = f64::MIN;
+    let mut max_y = f64::MIN;
+    for p in points {
+        let x = p.x().absolute_value();
+        let y = p.y().absolute_value();
+        min_x = min_x.min(x);
+        min_y = min_y.min(y);
+        max_x = max_x.max(x);
+        max_y = max_y.max(y);
+    }
+    Some([min_x, min_y, max_x, max_y])
+}
+
 /// Computes the bounding box of the given elements in world coordinates.
 /// Returns `None` if there are no geometric elements.
 pub fn compute_bounds(elements: &[Element]) -> Option<(f64, f64, f64, f64)> {
@@ -308,30 +508,11 @@ pub fn compute_bounds(elements: &[Element]) -> Option<(f64, f64, f64, f64)> {
     let mut found = false;
 
     for element in elements {
-        let points: &[gdsr::Point] = match element {
-            Element::Polygon(p) => p.points(),
-            Element::Path(p) => p.points(),
-            Element::Text(t) => {
-                let o = t.origin();
-                let x = o.x().absolute_value();
-                let y = o.y().absolute_value();
-                min_x = min_x.min(x);
-                min_y = min_y.min(y);
-                max_x = max_x.max(x);
-                max_y = max_y.max(y);
-                found = true;
-                continue;
-            }
-            Element::Reference(_) => continue,
-        };
-
-        for p in points {
-            let x = p.x().absolute_value();
-            let y = p.y().absolute_value();
-            min_x = min_x.min(x);
-            min_y = min_y.min(y);
-            max_x = max_x.max(x);
-            max_y = max_y.max(y);
+        if let Some(bbox) = element_bbox(element) {
+            min_x = min_x.min(bbox[0]);
+            min_y = min_y.min(bbox[1]);
+            max_x = max_x.max(bbox[2]);
+            max_y = max_y.max(bbox[3]);
             found = true;
         }
     }
@@ -424,6 +605,27 @@ mod tests {
         // Y is flipped so max_world_y maps to smaller screen_y
         assert!(max_screen.y >= rect.min.y);
         assert!(min_screen.y <= rect.max.y);
+    }
+
+    #[test]
+    fn visible_world_rect_matches_screen_corners() {
+        let vp = Viewport {
+            center_x: 5.0,
+            center_y: 10.0,
+            zoom: 100.0,
+        };
+        let rect = test_rect();
+        let vis = vp.visible_world_rect(rect);
+
+        // Top-left screen corner → max world Y (Y flipped)
+        let (wx_tl, wy_tl) = vp.screen_to_world(rect.min.x, rect.min.y, rect);
+        assert!((vis[0] - wx_tl).abs() < EPSILON);
+        assert!((vis[3] - wy_tl).abs() < EPSILON); // max_y
+
+        // Bottom-right screen corner → min world Y
+        let (wx_br, wy_br) = vp.screen_to_world(rect.max.x, rect.max.y, rect);
+        assert!((vis[2] - wx_br).abs() < EPSILON);
+        assert!((vis[1] - wy_br).abs() < EPSILON); // min_y
     }
 
     /// Simulates the zoom logic from `draw_viewport`: zoom by `factor` anchored at `cursor`.


### PR DESCRIPTION
## Summary
- Adds a 256x256 uniform spatial grid that partitions world space, reducing per-frame iteration from O(n) to only visible grid cells
- Elements are inserted into all grid cells their bounding box overlaps, ensuring partially-visible elements are never missed
- Small-on-screen cells draw as a single colored LOD rectangle; large cells iterate individual elements
- Extracts `element_bbox` as a shared function and adds `visible_world_rect` to `Viewport`
- Adds world-space culling with bbox fallback to `draw_polygon`/`draw_path`

## Test plan
- [x] Spatial grid build/query tests (empty, single element, correct cell assignment, partial overlap, full extent)
- [x] Element bbox extraction tests (polygon, path, text, reference)
- [x] Element layer extraction tests (polygon, path, text, reference)
- [x] Grid skips references, cell bbox is tight, large elements found from edge viewports
- [x] `visible_world_rect` matches screen corners
- [x] Dominant layer selection
- [ ] Manual: open large GDS file, verify zoomed-out LOD and zoomed-in detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)