### PR TITLE
Add no-checkboxes rule to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,3 +19,4 @@
 - AVOID adding new dependencies. Prefer using existing dependencies or the standard library. Only add a dependency when it is clearly necessary.
 - ALWAYS add new dependencies to `[workspace.dependencies]` in the root `Cargo.toml` and reference them with `= { workspace = true }` in crate-level `Cargo.toml` files.
 - NEVER commit directly to main. Always create a feature branch and open a pull request.
+- NEVER use checkboxes in PR descriptions. Use plain bullet points instead.


### PR DESCRIPTION
## Summary
- Adds a rule to CLAUDE.md to use plain bullet points instead of checkboxes in PR descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)