### PR TITLE
Add Drawable trait and WorldBBox type to gdsr-viewer

### DIFF
--- a/crates/gdsr-viewer/src/app.rs
+++ b/crates/gdsr-viewer/src/app.rs
@@ -6,6 +6,7 @@ use std::thread;
 use gdsr::{Element, Library};
 
 use crate::colors::LayerColorMap;
+use crate::drawable::Drawable;
 use crate::panels;
 use crate::spatial::SpatialGrid;
 use crate::viewport::{self, Viewport};
@@ -82,9 +83,9 @@ impl ViewerApp {
     }
 
     fn zoom_to_fit(&mut self) {
-        if let Some((min_x, min_y, max_x, max_y)) = viewport::compute_bounds(&self.elements) {
+        if let Some(bounds) = viewport::compute_bounds(&self.elements) {
             let rect = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::Vec2::new(800.0, 600.0));
-            self.viewport.zoom_to_fit(min_x, min_y, max_x, max_y, rect);
+            self.viewport.zoom_to_fit(&bounds, rect);
         }
     }
 }
@@ -120,19 +121,19 @@ impl eframe::App for ViewerApp {
                     Ok(element) => {
                         match &element {
                             Element::Polygon(p) => {
-                                let key = (p.layer(), p.data_type());
+                                let key = p.layer_key();
                                 if self.layers.insert(key) {
                                     self.layer_colors.get(key.0, key.1);
                                 }
                             }
                             Element::Path(p) => {
-                                let key = (p.layer(), p.data_type());
+                                let key = p.layer_key();
                                 if self.layers.insert(key) {
                                     self.layer_colors.get(key.0, key.1);
                                 }
                             }
                             Element::Text(t) => {
-                                let key = (t.layer(), 0);
+                                let key = t.layer_key();
                                 if self.layers.insert(key) {
                                     self.layer_colors.get(key.0, key.1);
                                 }
@@ -146,7 +147,7 @@ impl eframe::App for ViewerApp {
                         self.elements_loading = false;
                         self.element_receiver = None;
                         if let Some(bounds) = viewport::compute_bounds(&self.elements) {
-                            self.spatial_grid = Some(SpatialGrid::build(&self.elements, bounds));
+                            self.spatial_grid = Some(SpatialGrid::build(&self.elements, &bounds));
                         }
                         self.zoom_to_fit();
                         break;

--- a/crates/gdsr-viewer/src/drawable.rs
+++ b/crates/gdsr-viewer/src/drawable.rs
@@ -1,0 +1,368 @@
+use egui::{Color32, FontId, Mesh, Pos2, Rect, Shape, Stroke};
+use gdsr::{Dimensions, Element, Path, Polygon, Reference, Text};
+
+use crate::viewport::Viewport;
+
+/// Screen-pixel threshold below which polygons render as a filled bounding box instead of
+/// full triangulation. Avoids expensive earcut calls for elements that are just a few pixels.
+const BBOX_FALLBACK_PX: f32 = 8.0;
+
+/// Axis-aligned bounding box in absolute world coordinates (f64).
+///
+/// GDS elements store coordinates as `Unit` values (integer or float with a scale factor).
+/// This type holds the result of converting those to absolute f64 values, giving the
+/// viewer a uniform representation for culling, spatial indexing, and bounds computation.
+#[derive(Clone, Copy, Debug)]
+pub struct WorldBBox {
+    pub min_x: f64,
+    pub min_y: f64,
+    pub max_x: f64,
+    pub max_y: f64,
+}
+
+impl WorldBBox {
+    pub fn new(min_x: f64, min_y: f64, max_x: f64, max_y: f64) -> Self {
+        Self {
+            min_x,
+            min_y,
+            max_x,
+            max_y,
+        }
+    }
+
+    pub fn overlaps(&self, other: &Self) -> bool {
+        self.max_x >= other.min_x
+            && self.min_x <= other.max_x
+            && self.max_y >= other.min_y
+            && self.min_y <= other.max_y
+    }
+
+    /// Returns the smallest bbox containing both `self` and `other`.
+    pub fn merge(&self, other: &Self) -> Self {
+        Self {
+            min_x: self.min_x.min(other.min_x),
+            min_y: self.min_y.min(other.min_y),
+            max_x: self.max_x.max(other.max_x),
+            max_y: self.max_y.max(other.max_y),
+        }
+    }
+}
+
+pub trait Drawable {
+    fn layer(&self) -> u16;
+    fn data_type(&self) -> u16;
+
+    fn layer_key(&self) -> (u16, u16) {
+        (self.layer(), self.data_type())
+    }
+
+    /// World-space axis-aligned bounding box.
+    fn world_bbox(&self) -> Option<WorldBBox>;
+
+    fn draw(
+        &self,
+        painter: &egui::Painter,
+        viewport: &Viewport,
+        rect: Rect,
+        visible: &WorldBBox,
+        color: Color32,
+    );
+}
+
+/// Computes the world-space AABB from a [`Dimensions`] implementor,
+/// returning `None` for degenerate (point-like) bounding boxes.
+fn dimensions_bbox(item: &impl Dimensions) -> Option<WorldBBox> {
+    let (min, max) = item.bounding_box();
+    let (min_x, min_y) = (min.x().absolute_value(), min.y().absolute_value());
+    let (max_x, max_y) = (max.x().absolute_value(), max.y().absolute_value());
+    if min_x == max_x && min_y == max_y {
+        return None;
+    }
+    Some(WorldBBox::new(min_x, min_y, max_x, max_y))
+}
+
+impl Drawable for Polygon {
+    fn layer(&self) -> u16 {
+        self.layer()
+    }
+
+    fn data_type(&self) -> u16 {
+        self.data_type()
+    }
+
+    fn world_bbox(&self) -> Option<WorldBBox> {
+        dimensions_bbox(self)
+    }
+
+    fn draw(
+        &self,
+        painter: &egui::Painter,
+        viewport: &Viewport,
+        rect: Rect,
+        visible: &WorldBBox,
+        color: Color32,
+    ) {
+        let points = self.points();
+        if points.len() < 3 {
+            return;
+        }
+
+        let Some(bbox) = self.world_bbox() else {
+            return;
+        };
+        if !bbox.overlaps(visible) {
+            return;
+        }
+
+        let s_min = viewport.world_to_screen(bbox.min_x, bbox.min_y, rect);
+        let s_max = viewport.world_to_screen(bbox.max_x, bbox.max_y, rect);
+        let sw = (s_max.x - s_min.x).abs();
+        let sh = (s_min.y - s_max.y).abs();
+
+        if sw < 2.0 && sh < 2.0 {
+            return;
+        }
+
+        let fill = Color32::from_rgba_unmultiplied(color.r(), color.g(), color.b(), 80);
+
+        if sw < BBOX_FALLBACK_PX && sh < BBOX_FALLBACK_PX {
+            let bbox = Rect::from_two_pos(s_min, s_max);
+            painter.rect_filled(bbox, 0.0, fill);
+            painter.rect_stroke(
+                bbox,
+                0.0,
+                Stroke::new(1.0, color),
+                egui::StrokeKind::Outside,
+            );
+            return;
+        }
+
+        let screen_pts: Vec<Pos2> = points
+            .iter()
+            .map(|p| viewport.world_to_screen(p.x().absolute_value(), p.y().absolute_value(), rect))
+            .collect();
+
+        let open_pts = if screen_pts.len() >= 2 && screen_pts.first() == screen_pts.last() {
+            &screen_pts[..screen_pts.len() - 1]
+        } else {
+            &screen_pts
+        };
+
+        if open_pts.len() < 3 {
+            return;
+        }
+
+        let coords: Vec<f64> = open_pts
+            .iter()
+            .flat_map(|p| [f64::from(p.x), f64::from(p.y)])
+            .collect();
+
+        if let Ok(indices) = earcutr::earcut(&coords, &[], 2) {
+            let mut mesh = Mesh::default();
+            for pt in open_pts {
+                mesh.vertices.push(egui::epaint::Vertex {
+                    pos: *pt,
+                    uv: egui::epaint::WHITE_UV,
+                    color: fill,
+                });
+            }
+            for idx in indices {
+                mesh.indices.push(idx as u32);
+            }
+            painter.add(Shape::mesh(mesh));
+        }
+
+        let stroke = Stroke::new(1.0, color);
+        for i in 0..open_pts.len() {
+            let next = (i + 1) % open_pts.len();
+            painter.line_segment([open_pts[i], open_pts[next]], stroke);
+        }
+    }
+}
+
+impl Drawable for Path {
+    fn layer(&self) -> u16 {
+        self.layer()
+    }
+
+    fn data_type(&self) -> u16 {
+        self.data_type()
+    }
+
+    fn world_bbox(&self) -> Option<WorldBBox> {
+        dimensions_bbox(self)
+    }
+
+    fn draw(
+        &self,
+        painter: &egui::Painter,
+        viewport: &Viewport,
+        rect: Rect,
+        visible: &WorldBBox,
+        color: Color32,
+    ) {
+        let points = self.points();
+        if points.len() < 2 {
+            return;
+        }
+
+        let Some(bbox) = self.world_bbox() else {
+            return;
+        };
+        if !bbox.overlaps(visible) {
+            return;
+        }
+
+        let s_min = viewport.world_to_screen(bbox.min_x, bbox.min_y, rect);
+        let s_max = viewport.world_to_screen(bbox.max_x, bbox.max_y, rect);
+        let sw = (s_max.x - s_min.x).abs();
+        let sh = (s_min.y - s_max.y).abs();
+        if sw < 1.0 && sh < 1.0 {
+            return;
+        }
+
+        if sw < BBOX_FALLBACK_PX && sh < BBOX_FALLBACK_PX {
+            let stroke = Stroke::new(1.0, color);
+            painter.line_segment([s_min, s_max], stroke);
+            return;
+        }
+
+        let screen_pts: Vec<Pos2> = points
+            .iter()
+            .map(|p| viewport.world_to_screen(p.x().absolute_value(), p.y().absolute_value(), rect))
+            .collect();
+
+        let width_px = self
+            .width()
+            .map(|w| (w.absolute_value() * viewport.zoom) as f32)
+            .unwrap_or(1.0)
+            .clamp(1.0, 20.0);
+
+        let stroke = Stroke::new(width_px, color);
+        for pair in screen_pts.windows(2) {
+            painter.line_segment([pair[0], pair[1]], stroke);
+        }
+    }
+}
+
+impl Drawable for Text {
+    fn layer(&self) -> u16 {
+        self.layer()
+    }
+
+    fn data_type(&self) -> u16 {
+        0
+    }
+
+    /// Returns the origin as a point bbox. Text has no spatial extent but still
+    /// needs to participate in bounds computation and spatial grid building.
+    fn world_bbox(&self) -> Option<WorldBBox> {
+        let origin = self.origin();
+        let x = origin.x().absolute_value();
+        let y = origin.y().absolute_value();
+        Some(WorldBBox::new(x, y, x, y))
+    }
+
+    fn draw(
+        &self,
+        painter: &egui::Painter,
+        viewport: &Viewport,
+        rect: Rect,
+        _visible: &WorldBBox,
+        color: Color32,
+    ) {
+        let origin = self.origin();
+        let screen_pos = viewport.world_to_screen(
+            origin.x().absolute_value(),
+            origin.y().absolute_value(),
+            rect,
+        );
+
+        if !rect.contains(screen_pos) {
+            return;
+        }
+
+        let font_size = (12.0 * viewport.zoom.log10().max(1.0)) as f32;
+        if font_size < 4.0 {
+            return;
+        }
+        let font_size = font_size.min(48.0);
+
+        painter.text(
+            screen_pos,
+            egui::Align2::LEFT_BOTTOM,
+            self.text(),
+            FontId::monospace(font_size),
+            color,
+        );
+    }
+}
+
+impl Drawable for Reference {
+    fn layer(&self) -> u16 {
+        0
+    }
+
+    fn data_type(&self) -> u16 {
+        0
+    }
+
+    fn world_bbox(&self) -> Option<WorldBBox> {
+        None
+    }
+
+    fn draw(
+        &self,
+        _painter: &egui::Painter,
+        _viewport: &Viewport,
+        _rect: Rect,
+        _visible: &WorldBBox,
+        _color: Color32,
+    ) {
+    }
+}
+
+impl Drawable for Element {
+    fn layer(&self) -> u16 {
+        match self {
+            Self::Polygon(p) => p.layer(),
+            Self::Path(p) => p.layer(),
+            Self::Text(t) => t.layer(),
+            Self::Reference(r) => r.layer(),
+        }
+    }
+
+    fn data_type(&self) -> u16 {
+        match self {
+            Self::Polygon(p) => p.data_type(),
+            Self::Path(p) => p.data_type(),
+            Self::Text(t) => t.data_type(),
+            Self::Reference(r) => r.data_type(),
+        }
+    }
+
+    fn world_bbox(&self) -> Option<WorldBBox> {
+        match self {
+            Self::Polygon(p) => p.world_bbox(),
+            Self::Path(p) => p.world_bbox(),
+            Self::Text(t) => t.world_bbox(),
+            Self::Reference(r) => r.world_bbox(),
+        }
+    }
+
+    fn draw(
+        &self,
+        painter: &egui::Painter,
+        viewport: &Viewport,
+        rect: Rect,
+        visible: &WorldBBox,
+        color: Color32,
+    ) {
+        match self {
+            Self::Polygon(p) => p.draw(painter, viewport, rect, visible, color),
+            Self::Path(p) => p.draw(painter, viewport, rect, visible, color),
+            Self::Text(t) => t.draw(painter, viewport, rect, visible, color),
+            Self::Reference(r) => r.draw(painter, viewport, rect, visible, color),
+        }
+    }
+}

--- a/crates/gdsr-viewer/src/main.rs
+++ b/crates/gdsr-viewer/src/main.rs
@@ -1,5 +1,6 @@
 mod app;
 mod colors;
+mod drawable;
 mod loader;
 mod panels;
 mod spatial;

--- a/crates/gdsr-viewer/src/spatial.rs
+++ b/crates/gdsr-viewer/src/spatial.rs
@@ -2,14 +2,14 @@ use std::collections::HashMap;
 
 use gdsr::Element;
 
-use crate::viewport::element_bbox;
+use crate::drawable::{Drawable, WorldBBox};
 
 const GRID_SIZE: usize = 256;
 
 pub struct GridCell {
     pub indices: Vec<u32>,
-    /// Tight bounding box: `[min_x, min_y, max_x, max_y]`
-    pub bbox: [f64; 4],
+    /// Tight bounding box of all elements in this cell.
+    pub bbox: WorldBBox,
     pub dominant_layer: (u16, u16),
 }
 
@@ -21,55 +21,42 @@ pub struct SpatialGrid {
     cell_height: f64,
 }
 
-fn element_layer(element: &Element) -> (u16, u16) {
-    match element {
-        Element::Polygon(p) => (p.layer(), p.data_type()),
-        Element::Path(p) => (p.layer(), p.data_type()),
-        Element::Text(t) => (t.layer(), 0),
-        Element::Reference(_) => (0, 0),
-    }
-}
-
 impl SpatialGrid {
-    pub fn build(elements: &[Element], bounds: (f64, f64, f64, f64)) -> Self {
-        let (min_x, min_y, max_x, max_y) = bounds;
+    pub fn build(elements: &[Element], bounds: &WorldBBox) -> Self {
         let epsilon = 1e-12;
-        let cell_width = (max_x - min_x + epsilon) / GRID_SIZE as f64;
-        let cell_height = (max_y - min_y + epsilon) / GRID_SIZE as f64;
+        let cell_width = (bounds.max_x - bounds.min_x + epsilon) / GRID_SIZE as f64;
+        let cell_height = (bounds.max_y - bounds.min_y + epsilon) / GRID_SIZE as f64;
 
         let mut cells: Vec<Option<GridCell>> = (0..GRID_SIZE * GRID_SIZE).map(|_| None).collect();
         let mut layer_counts: HashMap<usize, HashMap<(u16, u16), u32>> = HashMap::new();
 
         for (i, element) in elements.iter().enumerate() {
-            let Some(bbox) = element_bbox(element) else {
+            let Some(bbox) = element.world_bbox() else {
                 continue;
             };
 
             // Insert into every grid cell the element's bbox overlaps
-            let col_min = ((bbox[0] - min_x) / cell_width) as usize;
-            let col_max = ((bbox[2] - min_x) / cell_width) as usize;
-            let row_min = ((bbox[1] - min_y) / cell_height) as usize;
-            let row_max = ((bbox[3] - min_y) / cell_height) as usize;
+            let col_min = ((bbox.min_x - bounds.min_x) / cell_width) as usize;
+            let col_max = ((bbox.max_x - bounds.min_x) / cell_width) as usize;
+            let row_min = ((bbox.min_y - bounds.min_y) / cell_height) as usize;
+            let row_max = ((bbox.max_y - bounds.min_y) / cell_height) as usize;
             let col_min = col_min.min(GRID_SIZE - 1);
             let col_max = col_max.min(GRID_SIZE - 1);
             let row_min = row_min.min(GRID_SIZE - 1);
             let row_max = row_max.min(GRID_SIZE - 1);
 
-            let layer = element_layer(element);
+            let layer = element.layer_key();
             for row in row_min..=row_max {
                 for col in col_min..=col_max {
                     let cell_idx = row * GRID_SIZE + col;
                     let cell = cells[cell_idx].get_or_insert_with(|| GridCell {
                         indices: Vec::new(),
-                        bbox: [f64::MAX, f64::MAX, f64::MIN, f64::MIN],
+                        bbox: WorldBBox::new(f64::MAX, f64::MAX, f64::MIN, f64::MIN),
                         dominant_layer: (0, 0),
                     });
 
                     cell.indices.push(i as u32);
-                    cell.bbox[0] = cell.bbox[0].min(bbox[0]);
-                    cell.bbox[1] = cell.bbox[1].min(bbox[1]);
-                    cell.bbox[2] = cell.bbox[2].max(bbox[2]);
-                    cell.bbox[3] = cell.bbox[3].max(bbox[3]);
+                    cell.bbox = cell.bbox.merge(&bbox);
 
                     *layer_counts
                         .entry(cell_idx)
@@ -91,18 +78,18 @@ impl SpatialGrid {
 
         Self {
             cells,
-            world_min_x: min_x,
-            world_min_y: min_y,
+            world_min_x: bounds.min_x,
+            world_min_y: bounds.min_y,
             cell_width,
             cell_height,
         }
     }
 
-    pub fn query_visible(&self, visible: &[f64; 4]) -> impl Iterator<Item = &GridCell> {
-        let col_min = ((visible[0] - self.world_min_x) / self.cell_width).floor() as isize - 1;
-        let col_max = ((visible[2] - self.world_min_x) / self.cell_width).ceil() as isize + 1;
-        let row_min = ((visible[1] - self.world_min_y) / self.cell_height).floor() as isize - 1;
-        let row_max = ((visible[3] - self.world_min_y) / self.cell_height).ceil() as isize + 1;
+    pub fn query_visible(&self, visible: &WorldBBox) -> impl Iterator<Item = &GridCell> {
+        let col_min = ((visible.min_x - self.world_min_x) / self.cell_width).floor() as isize - 1;
+        let col_max = ((visible.max_x - self.world_min_x) / self.cell_width).ceil() as isize + 1;
+        let row_min = ((visible.min_y - self.world_min_y) / self.cell_height).floor() as isize - 1;
+        let row_max = ((visible.max_y - self.world_min_y) / self.cell_height).ceil() as isize + 1;
 
         let col_min = col_min.clamp(0, GRID_SIZE as isize - 1) as usize;
         let col_max = col_max.clamp(0, GRID_SIZE as isize - 1) as usize;
@@ -121,6 +108,7 @@ impl SpatialGrid {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::drawable::Drawable;
     use gdsr::{HorizontalPresentation, Path, Point, Polygon, Text, Unit, VerticalPresentation};
 
     fn make_polygon(points: Vec<(i32, i32)>, layer: u16, data_type: u16) -> Element {
@@ -135,12 +123,12 @@ mod tests {
 
     #[test]
     fn build_empty() {
-        let grid = SpatialGrid::build(&[], (0.0, 0.0, 1.0, 1.0));
+        let grid = SpatialGrid::build(&[], &WorldBBox::new(0.0, 0.0, 1.0, 1.0));
         assert!(grid.cells.iter().all(Option::is_none));
     }
 
     /// Collects all unique element indices found across queried cells.
-    fn query_element_indices(grid: &SpatialGrid, visible: &[f64; 4]) -> Vec<u32> {
+    fn query_element_indices(grid: &SpatialGrid, visible: &WorldBBox) -> Vec<u32> {
         let mut indices: Vec<u32> = grid
             .query_visible(visible)
             .flat_map(|c| c.indices.iter().copied())
@@ -153,14 +141,15 @@ mod tests {
     #[test]
     fn build_single_element() {
         let poly = make_polygon(vec![(0, 0), (1000, 0), (1000, 1000)], 1, 0);
-        let bounds = (0.0, 0.0, 1000.0 * 1e-9, 1000.0 * 1e-9);
-        let grid = SpatialGrid::build(&[poly], bounds);
+        let bounds = WorldBBox::new(0.0, 0.0, 1000.0 * 1e-9, 1000.0 * 1e-9);
+        let grid = SpatialGrid::build(&[poly], &bounds);
 
-        // Element should be findable via full-extent query
-        let all = query_element_indices(&grid, &[0.0, 0.0, 1000.0 * 1e-9, 1000.0 * 1e-9]);
+        let all = query_element_indices(
+            &grid,
+            &WorldBBox::new(0.0, 0.0, 1000.0 * 1e-9, 1000.0 * 1e-9),
+        );
         assert_eq!(all, vec![0]);
 
-        // Every non-empty cell should reference element 0 with layer (1, 0)
         for cell in grid.cells.iter().flatten() {
             assert!(cell.indices.contains(&0));
             assert_eq!(cell.dominant_layer, (1, 0));
@@ -173,14 +162,15 @@ mod tests {
         let p1 = make_polygon(vec![(0, 0), (100, 0), (100, 100)], 1, 0);
         let p2 = make_polygon(vec![(9900, 9900), (10000, 9900), (10000, 10000)], 2, 0);
 
-        let bounds = (0.0, 0.0, 10000.0 * scale, 10000.0 * scale);
-        let grid = SpatialGrid::build(&[p1, p2], bounds);
+        let bounds = WorldBBox::new(0.0, 0.0, 10000.0 * scale, 10000.0 * scale);
+        let grid = SpatialGrid::build(&[p1, p2], &bounds);
 
-        // Both elements should be findable
-        let all = query_element_indices(&grid, &[0.0, 0.0, 10000.0 * scale, 10000.0 * scale]);
+        let all = query_element_indices(
+            &grid,
+            &WorldBBox::new(0.0, 0.0, 10000.0 * scale, 10000.0 * scale),
+        );
         assert_eq!(all, vec![0, 1]);
 
-        // They should not share any cells (far apart, small relative to grid)
         for cell in grid.cells.iter().flatten() {
             assert!(
                 !cell.indices.contains(&0) || !cell.indices.contains(&1),
@@ -195,11 +185,10 @@ mod tests {
         let p1 = make_polygon(vec![(0, 0), (100, 0), (100, 100)], 1, 0);
         let p2 = make_polygon(vec![(9900, 9900), (10000, 9900), (10000, 10000)], 2, 0);
 
-        let bounds = (0.0, 0.0, 10000.0 * scale, 10000.0 * scale);
-        let grid = SpatialGrid::build(&[p1, p2], bounds);
+        let bounds = WorldBBox::new(0.0, 0.0, 10000.0 * scale, 10000.0 * scale);
+        let grid = SpatialGrid::build(&[p1, p2], &bounds);
 
-        // Query only the bottom-left corner — should find p1 but not p2
-        let visible = [0.0, 0.0, 1000.0 * scale, 1000.0 * scale];
+        let visible = WorldBBox::new(0.0, 0.0, 1000.0 * scale, 1000.0 * scale);
         let indices = query_element_indices(&grid, &visible);
         assert!(indices.contains(&0));
         assert!(!indices.contains(&1));
@@ -211,10 +200,10 @@ mod tests {
         let p1 = make_polygon(vec![(0, 0), (100, 0), (100, 100)], 1, 0);
         let p2 = make_polygon(vec![(9900, 9900), (10000, 9900), (10000, 10000)], 2, 0);
 
-        let bounds = (0.0, 0.0, 10000.0 * scale, 10000.0 * scale);
-        let grid = SpatialGrid::build(&[p1, p2], bounds);
+        let bounds = WorldBBox::new(0.0, 0.0, 10000.0 * scale, 10000.0 * scale);
+        let grid = SpatialGrid::build(&[p1, p2], &bounds);
 
-        let visible = [0.0, 0.0, 10000.0 * scale, 10000.0 * scale];
+        let visible = WorldBBox::new(0.0, 0.0, 10000.0 * scale, 10000.0 * scale);
         let indices = query_element_indices(&grid, &visible);
         assert_eq!(indices, vec![0, 1]);
     }
@@ -222,13 +211,11 @@ mod tests {
     #[test]
     fn query_finds_element_partially_overlapping_viewport() {
         let scale = 1e-9;
-        // Element spans from 400..600 in a 0..1000 world
         let p = make_polygon(vec![(400, 400), (600, 400), (600, 600), (400, 600)], 1, 0);
-        let bounds = (0.0, 0.0, 1000.0 * scale, 1000.0 * scale);
-        let grid = SpatialGrid::build(&[p], bounds);
+        let bounds = WorldBBox::new(0.0, 0.0, 1000.0 * scale, 1000.0 * scale);
+        let grid = SpatialGrid::build(&[p], &bounds);
 
-        // Viewport covers 0..500 — partially overlaps the element
-        let visible = [0.0, 0.0, 500.0 * scale, 500.0 * scale];
+        let visible = WorldBBox::new(0.0, 0.0, 500.0 * scale, 500.0 * scale);
         let indices = query_element_indices(&grid, &visible);
         assert!(
             indices.contains(&0),
@@ -246,11 +233,9 @@ mod tests {
         ];
 
         let scale = 1e-9;
-        let bounds = (0.0, 0.0, 100.0 * scale, 100.0 * scale);
-        let grid = SpatialGrid::build(&elems, bounds);
+        let bounds = WorldBBox::new(0.0, 0.0, 100.0 * scale, 100.0 * scale);
+        let grid = SpatialGrid::build(&elems, &bounds);
 
-        // All 4 elements overlap the same region; every cell containing them should
-        // have dominant layer (5, 0) since 3 of 4 elements are on that layer.
         for cell in grid.cells.iter().flatten() {
             assert_eq!(cell.dominant_layer, (5, 0));
         }
@@ -261,11 +246,13 @@ mod tests {
         let reference = Element::Reference(gdsr::Reference::default());
         let poly = make_polygon(vec![(0, 0), (100, 0), (100, 100)], 1, 0);
         let scale = 1e-9;
-        let bounds = (0.0, 0.0, 100.0 * scale, 100.0 * scale);
-        let grid = SpatialGrid::build(&[reference, poly], bounds);
+        let bounds = WorldBBox::new(0.0, 0.0, 100.0 * scale, 100.0 * scale);
+        let grid = SpatialGrid::build(&[reference, poly], &bounds);
 
-        let all = query_element_indices(&grid, &[0.0, 0.0, 100.0 * scale, 100.0 * scale]);
-        // Only the polygon (index 1) should appear; reference (index 0) is skipped
+        let all = query_element_indices(
+            &grid,
+            &WorldBBox::new(0.0, 0.0, 100.0 * scale, 100.0 * scale),
+        );
         assert_eq!(all, vec![1]);
     }
 
@@ -273,38 +260,35 @@ mod tests {
     fn cell_bbox_is_tight() {
         let scale = 1e-9;
         let poly = make_polygon(vec![(100, 200), (300, 200), (300, 400), (100, 400)], 1, 0);
-        let bounds = (0.0, 0.0, 1000.0 * scale, 1000.0 * scale);
-        let grid = SpatialGrid::build(&[poly], bounds);
+        let bounds = WorldBBox::new(0.0, 0.0, 1000.0 * scale, 1000.0 * scale);
+        let grid = SpatialGrid::build(&[poly], &bounds);
 
         for cell in grid.cells.iter().flatten() {
-            assert!((cell.bbox[0] - 100.0 * scale).abs() < 1e-15);
-            assert!((cell.bbox[1] - 200.0 * scale).abs() < 1e-15);
-            assert!((cell.bbox[2] - 300.0 * scale).abs() < 1e-15);
-            assert!((cell.bbox[3] - 400.0 * scale).abs() < 1e-15);
+            assert!((cell.bbox.min_x - 100.0 * scale).abs() < 1e-15);
+            assert!((cell.bbox.min_y - 200.0 * scale).abs() < 1e-15);
+            assert!((cell.bbox.max_x - 300.0 * scale).abs() < 1e-15);
+            assert!((cell.bbox.max_y - 400.0 * scale).abs() < 1e-15);
         }
     }
 
     #[test]
     fn large_element_found_from_opposite_edge() {
         let scale = 1e-9;
-        // Element spans the entire world
         let p = make_polygon(vec![(0, 0), (1000, 0), (1000, 1000), (0, 1000)], 1, 0);
-        let bounds = (0.0, 0.0, 1000.0 * scale, 1000.0 * scale);
-        let grid = SpatialGrid::build(&[p], bounds);
+        let bounds = WorldBBox::new(0.0, 0.0, 1000.0 * scale, 1000.0 * scale);
+        let grid = SpatialGrid::build(&[p], &bounds);
 
-        // Query just the top-right corner
-        let visible = [900.0 * scale, 900.0 * scale, 1000.0 * scale, 1000.0 * scale];
+        let visible = WorldBBox::new(900.0 * scale, 900.0 * scale, 1000.0 * scale, 1000.0 * scale);
         let indices = query_element_indices(&grid, &visible);
         assert!(indices.contains(&0));
 
-        // Query just the bottom-left corner
-        let visible = [0.0, 0.0, 100.0 * scale, 100.0 * scale];
+        let visible = WorldBBox::new(0.0, 0.0, 100.0 * scale, 100.0 * scale);
         let indices = query_element_indices(&grid, &visible);
         assert!(indices.contains(&0));
     }
 
     #[test]
-    fn element_layer_polygon() {
+    fn element_layer_key_polygon() {
         let poly = Polygon::new(
             vec![
                 Point::default_integer(0, 0),
@@ -314,11 +298,11 @@ mod tests {
             5,
             3,
         );
-        assert_eq!(element_layer(&Element::Polygon(poly)), (5, 3));
+        assert_eq!(Element::Polygon(poly).layer_key(), (5, 3));
     }
 
     #[test]
-    fn element_layer_path() {
+    fn element_layer_key_path() {
         let path = Path::new(
             vec![Point::default_integer(0, 0), Point::default_integer(1, 1)],
             7,
@@ -326,11 +310,11 @@ mod tests {
             None,
             None,
         );
-        assert_eq!(element_layer(&Element::Path(path)), (7, 2));
+        assert_eq!(Element::Path(path).layer_key(), (7, 2));
     }
 
     #[test]
-    fn element_layer_text() {
+    fn element_layer_key_text() {
         let text = Text::new(
             "t",
             Point::default_integer(0, 0),
@@ -342,17 +326,17 @@ mod tests {
             VerticalPresentation::default(),
             HorizontalPresentation::default(),
         );
-        assert_eq!(element_layer(&Element::Text(text)), (4, 0));
+        assert_eq!(Element::Text(text).layer_key(), (4, 0));
     }
 
     #[test]
-    fn element_layer_reference() {
+    fn element_layer_key_reference() {
         let reference = Element::Reference(gdsr::Reference::default());
-        assert_eq!(element_layer(&reference), (0, 0));
+        assert_eq!(reference.layer_key(), (0, 0));
     }
 
     #[test]
-    fn element_bbox_polygon() {
+    fn world_bbox_polygon() {
         let poly = Polygon::new(
             vec![
                 Point::default_integer(100, 200),
@@ -362,16 +346,18 @@ mod tests {
             1,
             0,
         );
-        let bbox = element_bbox(&Element::Polygon(poly)).expect("should have bbox");
+        let bbox = Element::Polygon(poly)
+            .world_bbox()
+            .expect("should have bbox");
         let scale = 1e-9;
-        assert!((bbox[0] - 100.0 * scale).abs() < 1e-15);
-        assert!((bbox[1] - 100.0 * scale).abs() < 1e-15);
-        assert!((bbox[2] - 500.0 * scale).abs() < 1e-15);
-        assert!((bbox[3] - 400.0 * scale).abs() < 1e-15);
+        assert!((bbox.min_x - 100.0 * scale).abs() < 1e-15);
+        assert!((bbox.min_y - 100.0 * scale).abs() < 1e-15);
+        assert!((bbox.max_x - 500.0 * scale).abs() < 1e-15);
+        assert!((bbox.max_y - 400.0 * scale).abs() < 1e-15);
     }
 
     #[test]
-    fn element_bbox_path() {
+    fn world_bbox_path() {
         let path = Path::new(
             vec![
                 Point::default_integer(10, 20),
@@ -382,16 +368,16 @@ mod tests {
             None,
             Some(Unit::default_integer(5)),
         );
-        let bbox = element_bbox(&Element::Path(path)).expect("should have bbox");
+        let bbox = Element::Path(path).world_bbox().expect("should have bbox");
         let scale = 1e-9;
-        assert!((bbox[0] - 10.0 * scale).abs() < 1e-15);
-        assert!((bbox[1] - 20.0 * scale).abs() < 1e-15);
-        assert!((bbox[2] - 30.0 * scale).abs() < 1e-15);
-        assert!((bbox[3] - 40.0 * scale).abs() < 1e-15);
+        assert!((bbox.min_x - 10.0 * scale).abs() < 1e-15);
+        assert!((bbox.min_y - 20.0 * scale).abs() < 1e-15);
+        assert!((bbox.max_x - 30.0 * scale).abs() < 1e-15);
+        assert!((bbox.max_y - 40.0 * scale).abs() < 1e-15);
     }
 
     #[test]
-    fn element_bbox_text() {
+    fn world_bbox_text() {
         let text = Text::new(
             "hello",
             Point::default_integer(500, 600),
@@ -403,17 +389,17 @@ mod tests {
             VerticalPresentation::default(),
             HorizontalPresentation::default(),
         );
-        let bbox = element_bbox(&Element::Text(text)).expect("should have bbox");
+        let bbox = Element::Text(text).world_bbox().expect("should have bbox");
         let scale = 1e-9;
-        assert!((bbox[0] - 500.0 * scale).abs() < 1e-15);
-        assert!((bbox[1] - 600.0 * scale).abs() < 1e-15);
-        assert_eq!(bbox[0], bbox[2]);
-        assert_eq!(bbox[1], bbox[3]);
+        assert!((bbox.min_x - 500.0 * scale).abs() < 1e-15);
+        assert!((bbox.min_y - 600.0 * scale).abs() < 1e-15);
+        assert_eq!(bbox.min_x, bbox.max_x);
+        assert_eq!(bbox.min_y, bbox.max_y);
     }
 
     #[test]
-    fn element_bbox_reference() {
+    fn world_bbox_reference() {
         let reference = Element::Reference(gdsr::Reference::default());
-        assert!(element_bbox(&reference).is_none());
+        assert!(reference.world_bbox().is_none());
     }
 }

--- a/crates/gdsr-viewer/src/viewport.rs
+++ b/crates/gdsr-viewer/src/viewport.rs
@@ -1,9 +1,10 @@
 use std::collections::HashSet;
 
-use egui::{Color32, FontId, Mesh, Pos2, Rect, Sense, Shape, Stroke};
+use egui::{Color32, Pos2, Rect, Sense};
 use gdsr::Element;
 
 use crate::colors::LayerColorMap;
+use crate::drawable::{Drawable, WorldBBox};
 use crate::spatial::SpatialGrid;
 
 /// Camera state for the 2D viewport: center position in world coordinates and zoom level.
@@ -42,20 +43,20 @@ impl Viewport {
         (wx, wy)
     }
 
-    /// Returns the visible world-space rectangle as `[min_x, min_y, max_x, max_y]`.
-    pub fn visible_world_rect(&self, rect: Rect) -> [f64; 4] {
+    /// Returns the visible world-space rectangle.
+    pub fn visible_world_rect(&self, rect: Rect) -> WorldBBox {
         let (min_x, max_y) = self.screen_to_world(rect.min.x, rect.min.y, rect);
         let (max_x, min_y) = self.screen_to_world(rect.max.x, rect.max.y, rect);
-        [min_x, min_y, max_x, max_y]
+        WorldBBox::new(min_x, min_y, max_x, max_y)
     }
 
     /// Adjusts center and zoom to fit the given bounding box in the viewport rect.
-    pub fn zoom_to_fit(&mut self, min_x: f64, min_y: f64, max_x: f64, max_y: f64, rect: Rect) {
-        self.center_x = f64::midpoint(min_x, max_x);
-        self.center_y = f64::midpoint(min_y, max_y);
+    pub fn zoom_to_fit(&mut self, bounds: &WorldBBox, rect: Rect) {
+        self.center_x = f64::midpoint(bounds.min_x, bounds.max_x);
+        self.center_y = f64::midpoint(bounds.min_y, bounds.max_y);
 
-        let world_w = max_x - min_x;
-        let world_h = max_y - min_y;
+        let world_w = bounds.max_x - bounds.min_x;
+        let world_h = bounds.max_y - bounds.min_y;
 
         if world_w > 0.0 && world_h > 0.0 {
             let zoom_x = f64::from(rect.width()) / world_w;
@@ -143,7 +144,7 @@ fn draw_elements_flat(
     painter: &egui::Painter,
     viewport: &Viewport,
     rect: Rect,
-    visible: &[f64; 4],
+    visible: &WorldBBox,
     elements: &[Element],
     hidden_layers: &HashSet<(u16, u16)>,
     layer_colors: &mut LayerColorMap,
@@ -165,51 +166,17 @@ fn draw_element(
     painter: &egui::Painter,
     viewport: &Viewport,
     rect: Rect,
-    visible: &[f64; 4],
+    visible: &WorldBBox,
     element: &Element,
     hidden_layers: &HashSet<(u16, u16)>,
     layer_colors: &mut LayerColorMap,
 ) {
-    match element {
-        Element::Polygon(polygon) => {
-            let layer = polygon.layer();
-            let dt = polygon.data_type();
-            if hidden_layers.contains(&(layer, dt)) {
-                return;
-            }
-            draw_polygon(
-                painter,
-                viewport,
-                rect,
-                visible,
-                polygon,
-                layer_colors.get(layer, dt),
-            );
-        }
-        Element::Path(path) => {
-            let layer = path.layer();
-            let dt = path.data_type();
-            if hidden_layers.contains(&(layer, dt)) {
-                return;
-            }
-            draw_path(
-                painter,
-                viewport,
-                rect,
-                visible,
-                path,
-                layer_colors.get(layer, dt),
-            );
-        }
-        Element::Text(text) => {
-            let layer = text.layer();
-            if hidden_layers.contains(&(layer, 0)) {
-                return;
-            }
-            draw_text(painter, viewport, rect, text, layer_colors.get(layer, 0));
-        }
-        Element::Reference(_) => {}
+    let key = element.layer_key();
+    if hidden_layers.contains(&key) {
+        return;
     }
+    let color = layer_colors.get(key.0, key.1);
+    element.draw(painter, viewport, rect, visible, color);
 }
 
 /// Screen-pixel threshold below which a grid cell draws as a single LOAD rectangle.
@@ -219,15 +186,15 @@ fn draw_with_grid(
     painter: &egui::Painter,
     viewport: &Viewport,
     rect: Rect,
-    visible: &[f64; 4],
+    visible: &WorldBBox,
     elements: &[Element],
     hidden_layers: &HashSet<(u16, u16)>,
     layer_colors: &mut LayerColorMap,
     grid: &SpatialGrid,
 ) {
     for cell in grid.query_visible(visible) {
-        let s_min = viewport.world_to_screen(cell.bbox[0], cell.bbox[1], rect);
-        let s_max = viewport.world_to_screen(cell.bbox[2], cell.bbox[3], rect);
+        let s_min = viewport.world_to_screen(cell.bbox.min_x, cell.bbox.min_y, rect);
+        let s_max = viewport.world_to_screen(cell.bbox.max_x, cell.bbox.max_y, rect);
         let sw = (s_max.x - s_min.x).abs();
         let sh = (s_min.y - s_max.y).abs(); // Y flipped
 
@@ -261,267 +228,26 @@ fn draw_with_grid(
     }
 }
 
-/// Screen-pixel threshold below which polygons render as a filled bounding box instead of
-/// full triangulation. Avoids expensive earcut calls for elements that are just a few pixels.
-const BBOX_FALLBACK_PX: f32 = 8.0;
-
-fn draw_polygon(
-    painter: &egui::Painter,
-    viewport: &Viewport,
-    rect: Rect,
-    visible: &[f64; 4],
-    polygon: &gdsr::Polygon,
-    color: Color32,
-) {
-    let points = polygon.points();
-    if points.len() < 3 {
-        return;
-    }
-
-    // World-space bounding box — cull before any vertex conversion
-    let (mut w_min_x, mut w_min_y) = (f64::MAX, f64::MAX);
-    let (mut w_max_x, mut w_max_y) = (f64::MIN, f64::MIN);
-    for p in points {
-        let x = p.x().absolute_value();
-        let y = p.y().absolute_value();
-        w_min_x = w_min_x.min(x);
-        w_min_y = w_min_y.min(y);
-        w_max_x = w_max_x.max(x);
-        w_max_y = w_max_y.max(y);
-    }
-    if w_max_x < visible[0] || w_min_x > visible[2] || w_max_y < visible[1] || w_min_y > visible[3]
-    {
-        return;
-    }
-
-    // Convert only the bounding box corners to screen space to measure pixel size
-    let s_min = viewport.world_to_screen(w_min_x, w_min_y, rect);
-    let s_max = viewport.world_to_screen(w_max_x, w_max_y, rect);
-    let sw = (s_max.x - s_min.x).abs();
-    let sh = (s_min.y - s_max.y).abs(); // Y flipped
-
-    // Skip sub-pixel elements
-    if sw < 2.0 && sh < 2.0 {
-        return;
-    }
-
-    let fill = Color32::from_rgba_unmultiplied(color.r(), color.g(), color.b(), 80);
-
-    // Small on screen — draw filled bounding box instead of triangulating
-    if sw < BBOX_FALLBACK_PX && sh < BBOX_FALLBACK_PX {
-        let bbox = Rect::from_two_pos(s_min, s_max);
-        painter.rect_filled(bbox, 0.0, fill);
-        painter.rect_stroke(
-            bbox,
-            0.0,
-            Stroke::new(1.0, color),
-            egui::StrokeKind::Outside,
-        );
-        return;
-    }
-
-    // Full rendering path: convert all vertices to screen coordinates
-    let screen_pts: Vec<Pos2> = points
-        .iter()
-        .map(|p| viewport.world_to_screen(p.x().absolute_value(), p.y().absolute_value(), rect))
-        .collect();
-
-    // Remove the closing point if present (earcutr expects open polygons)
-    let open_pts = if screen_pts.len() >= 2 && screen_pts.first() == screen_pts.last() {
-        &screen_pts[..screen_pts.len() - 1]
-    } else {
-        &screen_pts
-    };
-
-    if open_pts.len() < 3 {
-        return;
-    }
-
-    let coords: Vec<f64> = open_pts
-        .iter()
-        .flat_map(|p| [f64::from(p.x), f64::from(p.y)])
-        .collect();
-
-    if let Ok(indices) = earcutr::earcut(&coords, &[], 2) {
-        let mut mesh = Mesh::default();
-        for pt in open_pts {
-            mesh.vertices.push(egui::epaint::Vertex {
-                pos: *pt,
-                uv: egui::epaint::WHITE_UV,
-                color: fill,
-            });
-        }
-        for idx in indices {
-            mesh.indices.push(idx as u32);
-        }
-        painter.add(Shape::mesh(mesh));
-    }
-
-    let stroke = Stroke::new(1.0, color);
-    for i in 0..open_pts.len() {
-        let next = (i + 1) % open_pts.len();
-        painter.line_segment([open_pts[i], open_pts[next]], stroke);
-    }
-}
-
-fn draw_path(
-    painter: &egui::Painter,
-    viewport: &Viewport,
-    rect: Rect,
-    visible: &[f64; 4],
-    path: &gdsr::Path,
-    color: Color32,
-) {
-    let points = path.points();
-    if points.len() < 2 {
-        return;
-    }
-
-    // World-space bounding box — cull before vertex conversion
-    let (mut w_min_x, mut w_min_y) = (f64::MAX, f64::MAX);
-    let (mut w_max_x, mut w_max_y) = (f64::MIN, f64::MIN);
-    for p in points {
-        let x = p.x().absolute_value();
-        let y = p.y().absolute_value();
-        w_min_x = w_min_x.min(x);
-        w_min_y = w_min_y.min(y);
-        w_max_x = w_max_x.max(x);
-        w_max_y = w_max_y.max(y);
-    }
-    if w_max_x < visible[0] || w_min_x > visible[2] || w_max_y < visible[1] || w_min_y > visible[3]
-    {
-        return;
-    }
-
-    // Screen-space size check
-    let s_min = viewport.world_to_screen(w_min_x, w_min_y, rect);
-    let s_max = viewport.world_to_screen(w_max_x, w_max_y, rect);
-    let sw = (s_max.x - s_min.x).abs();
-    let sh = (s_min.y - s_max.y).abs();
-    if sw < 1.0 && sh < 1.0 {
-        return;
-    }
-
-    // Small on screen — draw a single line segment between bbox corners
-    if sw < BBOX_FALLBACK_PX && sh < BBOX_FALLBACK_PX {
-        let stroke = Stroke::new(1.0, color);
-        painter.line_segment([s_min, s_max], stroke);
-        return;
-    }
-
-    let screen_pts: Vec<Pos2> = points
-        .iter()
-        .map(|p| viewport.world_to_screen(p.x().absolute_value(), p.y().absolute_value(), rect))
-        .collect();
-
-    let width_px = path
-        .width()
-        .map(|w| (w.absolute_value() * viewport.zoom) as f32)
-        .unwrap_or(1.0)
-        .clamp(1.0, 20.0);
-
-    let stroke = Stroke::new(width_px, color);
-    for pair in screen_pts.windows(2) {
-        painter.line_segment([pair[0], pair[1]], stroke);
-    }
-}
-
-fn draw_text(
-    painter: &egui::Painter,
-    viewport: &Viewport,
-    rect: Rect,
-    text: &gdsr::Text,
-    color: Color32,
-) {
-    let origin = text.origin();
-    let screen_pos = viewport.world_to_screen(
-        origin.x().absolute_value(),
-        origin.y().absolute_value(),
-        rect,
-    );
-
-    // Skip if outside viewport
-    if !rect.contains(screen_pos) {
-        return;
-    }
-
-    let font_size = (12.0 * viewport.zoom.log10().max(1.0)) as f32;
-    if font_size < 4.0 {
-        return;
-    }
-    let font_size = font_size.min(48.0);
-
-    painter.text(
-        screen_pos,
-        egui::Align2::LEFT_BOTTOM,
-        text.text(),
-        FontId::monospace(font_size),
-        color,
-    );
-}
-
 #[cfg(test)]
 fn test_rect() -> Rect {
     Rect::from_min_size(Pos2::ZERO, egui::Vec2::new(800.0, 600.0))
 }
 
-/// Returns the world-space bounding box of a single element as `[min_x, min_y, max_x, max_y]`.
-/// Returns `None` for references and elements with no points.
-pub fn element_bbox(element: &Element) -> Option<[f64; 4]> {
-    let points: &[gdsr::Point] = match element {
-        Element::Polygon(p) => p.points(),
-        Element::Path(p) => p.points(),
-        Element::Text(t) => {
-            let x = t.origin().x().absolute_value();
-            let y = t.origin().y().absolute_value();
-            return Some([x, y, x, y]);
-        }
-        Element::Reference(_) => return None,
-    };
-
-    if points.is_empty() {
-        return None;
-    }
-
-    let mut min_x = f64::MAX;
-    let mut min_y = f64::MAX;
-    let mut max_x = f64::MIN;
-    let mut max_y = f64::MIN;
-    for p in points {
-        let x = p.x().absolute_value();
-        let y = p.y().absolute_value();
-        min_x = min_x.min(x);
-        min_y = min_y.min(y);
-        max_x = max_x.max(x);
-        max_y = max_y.max(y);
-    }
-    Some([min_x, min_y, max_x, max_y])
-}
-
 /// Computes the bounding box of the given elements in world coordinates.
 /// Returns `None` if there are no geometric elements.
-pub fn compute_bounds(elements: &[Element]) -> Option<(f64, f64, f64, f64)> {
-    let mut min_x = f64::MAX;
-    let mut min_y = f64::MAX;
-    let mut max_x = f64::MIN;
-    let mut max_y = f64::MIN;
-    let mut found = false;
+pub fn compute_bounds(elements: &[Element]) -> Option<WorldBBox> {
+    let mut result: Option<WorldBBox> = None;
 
     for element in elements {
-        if let Some(bbox) = element_bbox(element) {
-            min_x = min_x.min(bbox[0]);
-            min_y = min_y.min(bbox[1]);
-            max_x = max_x.max(bbox[2]);
-            max_y = max_y.max(bbox[3]);
-            found = true;
+        if let Some(bbox) = element.world_bbox() {
+            result = Some(match result {
+                Some(acc) => acc.merge(&bbox),
+                None => bbox,
+            });
         }
     }
 
-    if found {
-        Some((min_x, min_y, max_x, max_y))
-    } else {
-        None
-    }
+    result
 }
 
 #[cfg(test)]
@@ -586,7 +312,7 @@ mod tests {
     fn zoom_to_fit_centers_on_bounds() {
         let mut vp = Viewport::default();
         let rect = test_rect();
-        vp.zoom_to_fit(10.0, 20.0, 30.0, 40.0, rect);
+        vp.zoom_to_fit(&WorldBBox::new(10.0, 20.0, 30.0, 40.0), rect);
         assert!((vp.center_x - 20.0).abs() < EPSILON);
         assert!((vp.center_y - 30.0).abs() < EPSILON);
     }
@@ -595,7 +321,7 @@ mod tests {
     fn zoom_to_fit_bounds_are_within_viewport() {
         let mut vp = Viewport::default();
         let rect = test_rect();
-        vp.zoom_to_fit(-1.0, -2.0, 3.0, 4.0, rect);
+        vp.zoom_to_fit(&WorldBBox::new(-1.0, -2.0, 3.0, 4.0), rect);
 
         let min_screen = vp.world_to_screen(-1.0, -2.0, rect);
         let max_screen = vp.world_to_screen(3.0, 4.0, rect);
@@ -619,13 +345,13 @@ mod tests {
 
         // Top-left screen corner → max world Y (Y flipped)
         let (wx_tl, wy_tl) = vp.screen_to_world(rect.min.x, rect.min.y, rect);
-        assert!((vis[0] - wx_tl).abs() < EPSILON);
-        assert!((vis[3] - wy_tl).abs() < EPSILON); // max_y
+        assert!((vis.min_x - wx_tl).abs() < EPSILON);
+        assert!((vis.max_y - wy_tl).abs() < EPSILON);
 
         // Bottom-right screen corner → min world Y
         let (wx_br, wy_br) = vp.screen_to_world(rect.max.x, rect.max.y, rect);
-        assert!((vis[2] - wx_br).abs() < EPSILON);
-        assert!((vis[1] - wy_br).abs() < EPSILON); // min_y
+        assert!((vis.max_x - wx_br).abs() < EPSILON);
+        assert!((vis.min_y - wy_br).abs() < EPSILON);
     }
 
     /// Simulates the zoom logic from `draw_viewport`: zoom by `factor` anchored at `cursor`.
@@ -698,12 +424,11 @@ mod tests {
             1,
             0,
         );
-        let bounds = compute_bounds(&[Element::Polygon(polygon)]);
-        let (min_x, min_y, max_x, max_y) = bounds.expect("should have bounds");
-        assert!((min_x - 0.0).abs() < EPSILON);
-        assert!((min_y - 0.0).abs() < EPSILON);
-        assert!((max_x - 1000.0 * 1e-9).abs() < EPSILON);
-        assert!((max_y - 2000.0 * 1e-9).abs() < EPSILON);
+        let bounds = compute_bounds(&[Element::Polygon(polygon)]).expect("should have bounds");
+        assert!((bounds.min_x - 0.0).abs() < EPSILON);
+        assert!((bounds.min_y - 0.0).abs() < EPSILON);
+        assert!((bounds.max_x - 1000.0 * 1e-9).abs() < EPSILON);
+        assert!((bounds.max_y - 2000.0 * 1e-9).abs() < EPSILON);
     }
 
     #[test]
@@ -718,12 +443,11 @@ mod tests {
             None,
             Some(Unit::default_integer(10)),
         );
-        let bounds = compute_bounds(&[Element::Path(path)]);
-        let (min_x, min_y, max_x, max_y) = bounds.expect("should have bounds");
-        assert!((min_x - 100.0 * 1e-9).abs() < EPSILON);
-        assert!((min_y - 200.0 * 1e-9).abs() < EPSILON);
-        assert!((max_x - 300.0 * 1e-9).abs() < EPSILON);
-        assert!((max_y - 400.0 * 1e-9).abs() < EPSILON);
+        let bounds = compute_bounds(&[Element::Path(path)]).expect("should have bounds");
+        assert!((bounds.min_x - 100.0 * 1e-9).abs() < EPSILON);
+        assert!((bounds.min_y - 200.0 * 1e-9).abs() < EPSILON);
+        assert!((bounds.max_x - 300.0 * 1e-9).abs() < EPSILON);
+        assert!((bounds.max_y - 400.0 * 1e-9).abs() < EPSILON);
     }
 
     #[test]
@@ -739,12 +463,11 @@ mod tests {
             VerticalPresentation::default(),
             HorizontalPresentation::default(),
         );
-        let bounds = compute_bounds(&[Element::Text(text)]);
-        let (min_x, min_y, max_x, max_y) = bounds.expect("should have bounds");
-        assert!((min_x - 500.0 * 1e-9).abs() < EPSILON);
-        assert!((min_y - 600.0 * 1e-9).abs() < EPSILON);
-        assert_eq!(min_x, max_x);
-        assert_eq!(min_y, max_y);
+        let bounds = compute_bounds(&[Element::Text(text)]).expect("should have bounds");
+        assert!((bounds.min_x - 500.0 * 1e-9).abs() < EPSILON);
+        assert!((bounds.min_y - 600.0 * 1e-9).abs() < EPSILON);
+        assert_eq!(bounds.min_x, bounds.max_x);
+        assert_eq!(bounds.min_y, bounds.max_y);
     }
 
     #[test]
@@ -769,9 +492,9 @@ mod tests {
             VerticalPresentation::default(),
             HorizontalPresentation::default(),
         );
-        let bounds = compute_bounds(&[Element::Polygon(polygon), Element::Text(text)]);
-        let (min_x, min_y, _, _) = bounds.expect("should have bounds");
-        assert!((min_x - 0.0).abs() < EPSILON);
-        assert!((min_y - 0.0).abs() < EPSILON);
+        let bounds = compute_bounds(&[Element::Polygon(polygon), Element::Text(text)])
+            .expect("should have bounds");
+        assert!((bounds.min_x - 0.0).abs() < EPSILON);
+        assert!((bounds.min_y - 0.0).abs() < EPSILON);
     }
 }


### PR DESCRIPTION
## Summary

- Introduce a `Drawable` trait that consolidates repeated element dispatch (layer extraction, bounding box computation, drawing) into one place, implemented for `Polygon`, `Path`, `Text`, `Reference`, and `Element`
- Replace ad-hoc `[f64; 4]` arrays and `(f64, f64, f64, f64)` tuples with a `WorldBBox` struct with named fields (`min_x`, `min_y`, `max_x`, `max_y`) and methods (`overlaps`, `merge`)
- Remove `element_bbox`, `element_layer`, and free `draw_polygon`/`draw_path`/`draw_text` functions — their logic now lives in trait implementations
- Simplify `draw_element` from a 50-line match to 5 lines: get `layer_key()`, check hidden, get color, call `element.draw()`

## Test plan

- `cargo nextest run -p gdsr-viewer` — all 37 tests pass
- `cargo clippy -p gdsr-viewer` — no warnings
- `uvx prek run -a` — all pre-commit checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)