### PR TITLE
Replace Layer and DataType type aliases with newtype structs

### DIFF
--- a/crates/gdsr-viewer/src/colors.rs
+++ b/crates/gdsr-viewer/src/colors.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use egui::Color32;
+use gdsr::{DataType, Layer};
 
 const PALETTE: [Color32; 16] = [
     Color32::from_rgb(230, 25, 75),
@@ -24,13 +25,13 @@ const PALETTE: [Color32; 16] = [
 /// Maps (layer, datatype) pairs to distinct colors from a fixed palette.
 #[derive(Default)]
 pub struct LayerColorMap {
-    map: HashMap<(u16, u16), Color32>,
+    map: HashMap<(Layer, DataType), Color32>,
     next_index: usize,
 }
 
 impl LayerColorMap {
     /// Returns the color for the given layer/datatype pair, assigning one if needed.
-    pub fn get(&mut self, layer: u16, datatype: u16) -> Color32 {
+    pub fn get(&mut self, layer: Layer, datatype: DataType) -> Color32 {
         *self.map.entry((layer, datatype)).or_insert_with(|| {
             let color = PALETTE[self.next_index % PALETTE.len()];
             self.next_index += 1;
@@ -46,35 +47,35 @@ mod tests {
     #[test]
     fn same_layer_returns_same_color() {
         let mut map = LayerColorMap::default();
-        let c1 = map.get(1, 0);
-        let c2 = map.get(1, 0);
+        let c1 = map.get(Layer::new(1), DataType::new(0));
+        let c2 = map.get(Layer::new(1), DataType::new(0));
         assert_eq!(c1, c2);
     }
 
     #[test]
     fn different_layers_get_different_colors() {
         let mut map = LayerColorMap::default();
-        let c1 = map.get(1, 0);
-        let c2 = map.get(2, 0);
+        let c1 = map.get(Layer::new(1), DataType::new(0));
+        let c2 = map.get(Layer::new(2), DataType::new(0));
         assert_ne!(c1, c2);
     }
 
     #[test]
     fn different_datatypes_get_different_colors() {
         let mut map = LayerColorMap::default();
-        let c1 = map.get(1, 0);
-        let c2 = map.get(1, 1);
+        let c1 = map.get(Layer::new(1), DataType::new(0));
+        let c2 = map.get(Layer::new(1), DataType::new(1));
         assert_ne!(c1, c2);
     }
 
     #[test]
     fn colors_wrap_around_palette() {
         let mut map = LayerColorMap::default();
-        let first = map.get(0, 0);
+        let first = map.get(Layer::new(0), DataType::new(0));
         for i in 1..PALETTE.len() as u16 {
-            map.get(i, 0);
+            map.get(Layer::new(i), DataType::new(0));
         }
-        let wrapped = map.get(PALETTE.len() as u16, 0);
+        let wrapped = map.get(Layer::new(PALETTE.len() as u16), DataType::new(0));
         assert_eq!(first, wrapped);
     }
 }

--- a/crates/gdsr-viewer/src/drawable.rs
+++ b/crates/gdsr-viewer/src/drawable.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use egui::epaint;
 use egui::{Color32, FontId, Mesh, Pos2, Rect, Shape, Stroke, StrokeKind};
-use gdsr::{Dimensions, Element, Library};
+use gdsr::{DataType, Dimensions, Element, Layer, Library};
 
 use crate::state::LayerState;
 use crate::viewport::Viewport;
@@ -51,7 +51,7 @@ impl WorldBBox {
 /// avoid per-element allocations.
 pub struct DrawContext<'a> {
     pub painter: &'a egui::Painter,
-    pub layer_meshes: &'a mut HashMap<(u16, u16), Mesh>,
+    pub layer_meshes: &'a mut HashMap<(Layer, DataType), Mesh>,
     pub extra_shapes: &'a mut Vec<Shape>,
     pub viewport: &'a Viewport,
     pub rect: Rect,
@@ -65,7 +65,7 @@ pub struct DrawContext<'a> {
 
 impl DrawContext<'_> {
     /// Merges a mesh's geometry into the batched mesh for the given layer.
-    pub fn merge_mesh(&mut self, key: (u16, u16), src: &Mesh) {
+    pub fn merge_mesh(&mut self, key: (Layer, DataType), src: &Mesh) {
         let dst = self.layer_meshes.entry(key).or_default();
         let base = dst.vertices.len() as u32;
         dst.vertices.extend_from_slice(&src.vertices);
@@ -157,7 +157,7 @@ pub(crate) fn stroke_polyline_to_mesh(points: &[Pos2], stroke: Stroke, closed: b
 /// Trait for viewer-drawable elements. Provides layer info, bounding box, and drawing.
 pub trait Drawable {
     /// Returns all `(layer, data_type)` pairs this element contributes to.
-    fn layer_keys(&self) -> Vec<(u16, u16)>;
+    fn layer_keys(&self) -> Vec<(Layer, DataType)>;
 
     /// Returns the world-space bounding box, or `None` for elements without geometry.
     fn world_bbox(&self) -> Option<WorldBBox>;
@@ -170,7 +170,7 @@ pub trait Drawable {
 const BBOX_FALLBACK_PX: f32 = 8.0;
 
 impl Drawable for gdsr::Polygon {
-    fn layer_keys(&self) -> Vec<(u16, u16)> {
+    fn layer_keys(&self) -> Vec<(Layer, DataType)> {
         vec![(self.layer(), self.data_type())]
     }
 
@@ -280,7 +280,7 @@ impl Drawable for gdsr::Polygon {
 }
 
 impl Drawable for gdsr::Path {
-    fn layer_keys(&self) -> Vec<(u16, u16)> {
+    fn layer_keys(&self) -> Vec<(Layer, DataType)> {
         vec![(self.layer(), self.data_type())]
     }
 
@@ -352,8 +352,8 @@ impl Drawable for gdsr::Path {
 }
 
 impl Drawable for gdsr::Text {
-    fn layer_keys(&self) -> Vec<(u16, u16)> {
-        vec![(self.layer(), 0)]
+    fn layer_keys(&self) -> Vec<(Layer, DataType)> {
+        vec![(self.layer(), DataType::new(0))]
     }
 
     fn world_bbox(&self) -> Option<WorldBBox> {
@@ -364,7 +364,7 @@ impl Drawable for gdsr::Text {
     }
 
     fn draw(&self, ctx: &mut DrawContext) {
-        let key = (self.layer(), 0);
+        let key = (self.layer(), DataType::new(0));
         if ctx.layer_state.hidden_layers.contains(&key) {
             return;
         }
@@ -398,7 +398,7 @@ impl Drawable for gdsr::Text {
 }
 
 impl Drawable for gdsr::Reference {
-    fn layer_keys(&self) -> Vec<(u16, u16)> {
+    fn layer_keys(&self) -> Vec<(Layer, DataType)> {
         match self.instance().as_element() {
             Some(element) => element.layer_keys(),
             None => vec![],
@@ -455,7 +455,7 @@ impl Drawable for gdsr::Reference {
 }
 
 impl Drawable for Element {
-    fn layer_keys(&self) -> Vec<(u16, u16)> {
+    fn layer_keys(&self) -> Vec<(Layer, DataType)> {
         match self {
             Self::Polygon(p) => p.layer_keys(),
             Self::Path(p) => p.layer_keys(),

--- a/crates/gdsr-viewer/src/panels.rs
+++ b/crates/gdsr-viewer/src/panels.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeSet;
 
 use egui::{ComboBox, Ui, Vec2};
+use gdsr::{DataType, Layer};
 
 use crate::state::LayerState;
 
@@ -11,7 +12,7 @@ pub fn draw_side_panel(
     cell_names: &[String],
     selected_cell: &mut Option<String>,
     cell_changed: &mut bool,
-    layers: &BTreeSet<(u16, u16)>,
+    layers: &BTreeSet<(Layer, DataType)>,
     layer_state: &mut LayerState,
 ) -> bool {
     let mut zoom_to_fit = false;

--- a/crates/gdsr-viewer/src/spatial.rs
+++ b/crates/gdsr-viewer/src/spatial.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use gdsr::Element;
+use gdsr::{DataType, Element, Layer};
 
 use crate::drawable::{Drawable, WorldBBox};
 
@@ -13,7 +13,7 @@ pub struct GridCell {
     /// Tight bounding box of all elements in this cell.
     pub bbox: WorldBBox,
     /// The most frequently occurring `(layer, data_type)` pair among elements in this cell.
-    pub dominant_layer: (u16, u16),
+    pub dominant_layer: (Layer, DataType),
 }
 
 /// A 256x256 uniform grid that maps world-space regions to element indices,
@@ -35,7 +35,7 @@ impl SpatialGrid {
         let cell_height = (bounds.max_y - bounds.min_y + epsilon) / GRID_SIZE as f64;
 
         let mut cells: Vec<Option<GridCell>> = (0..GRID_SIZE * GRID_SIZE).map(|_| None).collect();
-        let mut layer_counts: HashMap<usize, HashMap<(u16, u16), u32>> = HashMap::new();
+        let mut layer_counts: HashMap<usize, HashMap<(Layer, DataType), u32>> = HashMap::new();
 
         for (i, element) in elements.iter().enumerate() {
             let Some(bbox) = element.world_bbox() else {
@@ -52,14 +52,17 @@ impl SpatialGrid {
             let row_max = row_max.min(GRID_SIZE - 1);
 
             let layer_keys = element.layer_keys();
-            let layer = layer_keys.first().copied().unwrap_or((0, 0));
+            let layer = layer_keys
+                .first()
+                .copied()
+                .unwrap_or((Layer::new(0), DataType::new(0)));
             for row in row_min..=row_max {
                 for col in col_min..=col_max {
                     let cell_idx = row * GRID_SIZE + col;
                     let cell = cells[cell_idx].get_or_insert_with(|| GridCell {
                         indices: Vec::new(),
                         bbox: WorldBBox::new(f64::MAX, f64::MAX, f64::MIN, f64::MIN),
-                        dominant_layer: (0, 0),
+                        dominant_layer: (Layer::new(0), DataType::new(0)),
                     });
 
                     cell.indices.push(i as u32);
@@ -149,7 +152,7 @@ mod tests {
 
         for cell in grid.cells.iter().flatten() {
             assert!(cell.indices.contains(&0));
-            assert_eq!(cell.dominant_layer, (1, 0));
+            assert_eq!(cell.dominant_layer, (Layer::new(1), DataType::new(0)));
         }
     }
 
@@ -234,7 +237,7 @@ mod tests {
         let grid = SpatialGrid::build(&elems, &bounds);
 
         for cell in grid.cells.iter().flatten() {
-            assert_eq!(cell.dominant_layer, (5, 0));
+            assert_eq!(cell.dominant_layer, (Layer::new(5), DataType::new(0)));
         }
     }
 
@@ -287,19 +290,19 @@ mod tests {
     #[test]
     fn layer_keys_polygon() {
         let elem = polygon(vec![(0, 0), (1, 0), (1, 1)], 5, 3);
-        assert_eq!(elem.layer_keys(), vec![(5, 3)]);
+        assert_eq!(elem.layer_keys(), vec![(Layer::new(5), DataType::new(3))]);
     }
 
     #[test]
     fn layer_keys_path() {
         let elem = path(vec![(0, 0), (1, 1)], 7, 2, None);
-        assert_eq!(elem.layer_keys(), vec![(7, 2)]);
+        assert_eq!(elem.layer_keys(), vec![(Layer::new(7), DataType::new(2))]);
     }
 
     #[test]
     fn layer_keys_text() {
         let elem = text("t", 0, 0, 4);
-        assert_eq!(elem.layer_keys(), vec![(4, 0)]);
+        assert_eq!(elem.layer_keys(), vec![(Layer::new(4), DataType::new(0))]);
     }
 
     #[test]
@@ -316,11 +319,14 @@ mod tests {
                 gdsr::Point::default_integer(10, 0),
                 gdsr::Point::default_integer(10, 10),
             ],
-            5,
-            3,
+            Layer::new(5),
+            DataType::new(3),
         );
         let reference = Element::Reference(gdsr::Reference::new(poly));
-        assert_eq!(reference.layer_keys(), vec![(5, 3)]);
+        assert_eq!(
+            reference.layer_keys(),
+            vec![(Layer::new(5), DataType::new(3))]
+        );
     }
 
     #[test]
@@ -372,8 +378,8 @@ mod tests {
                 gdsr::Point::default_integer(100, 0),
                 gdsr::Point::default_integer(100, 200),
             ],
-            1,
-            0,
+            Layer::new(1),
+            DataType::new(0),
         );
         let reference = Element::Reference(gdsr::Reference::new(poly));
         let bbox = reference.world_bbox().expect("should have bbox");
@@ -392,8 +398,8 @@ mod tests {
                 gdsr::Point::default_integer(10, 0),
                 gdsr::Point::default_integer(10, 10),
             ],
-            1,
-            0,
+            Layer::new(1),
+            DataType::new(0),
         );
         let grid = gdsr::Grid::default()
             .with_columns(2)

--- a/crates/gdsr-viewer/src/state.rs
+++ b/crates/gdsr-viewer/src/state.rs
@@ -4,7 +4,7 @@ use std::sync::mpsc;
 
 use egui::{Mesh, Pos2, Shape};
 use emath::{TSTransform, Vec2};
-use gdsr::{Element, Library};
+use gdsr::{DataType, Element, Layer, Library};
 
 use crate::colors::LayerColorMap;
 use crate::spatial::SpatialGrid;
@@ -26,7 +26,7 @@ pub struct CellState {
     pub elements: Vec<Element>,
     pub element_receiver: Option<mpsc::Receiver<Element>>,
     pub elements_loading: bool,
-    pub layers: BTreeSet<(u16, u16)>,
+    pub layers: BTreeSet<(Layer, DataType)>,
     pub spatial_grid: Option<SpatialGrid>,
     pub tessellation_cache: HashMap<u32, Vec<usize>>,
 }
@@ -56,7 +56,7 @@ impl CellState {
 /// Geometry is split into batched layer meshes (few large meshes, cheap to clone)
 /// and extra shapes (text, rect fallbacks).
 pub struct RenderCache {
-    layer_meshes: Vec<((u16, u16), Mesh)>,
+    layer_meshes: Vec<((Layer, DataType), Mesh)>,
     extra_shapes: Vec<Shape>,
     /// Viewport state at the time shapes were rendered.
     render_center_x: f64,
@@ -64,7 +64,7 @@ pub struct RenderCache {
     render_zoom: f64,
     render_rect_center: Pos2,
     /// Invalidation metadata — if any of these change, full re-render.
-    hidden_layers: Vec<(u16, u16)>,
+    hidden_layers: Vec<(Layer, DataType)>,
     element_count: usize,
     populated: bool,
 }
@@ -89,7 +89,7 @@ impl RenderCache {
     /// Returns `true` when a full re-render is needed (cannot use delta transform).
     pub fn needs_full_render(
         &self,
-        hidden_layers: &[(u16, u16)],
+        hidden_layers: &[(Layer, DataType)],
         element_count: usize,
         current_center_x: f64,
         current_center_y: f64,
@@ -142,13 +142,13 @@ impl RenderCache {
     /// Stores batched layer meshes, extra shapes, and the viewport state.
     pub fn update(
         &mut self,
-        layer_meshes: Vec<((u16, u16), Mesh)>,
+        layer_meshes: Vec<((Layer, DataType), Mesh)>,
         extra_shapes: Vec<Shape>,
         center_x: f64,
         center_y: f64,
         zoom: f64,
         rect_center: Pos2,
-        hidden_layers: Vec<(u16, u16)>,
+        hidden_layers: Vec<(Layer, DataType)>,
         element_count: usize,
     ) {
         self.layer_meshes = layer_meshes;
@@ -162,7 +162,7 @@ impl RenderCache {
         self.populated = true;
     }
 
-    pub fn layer_meshes(&self) -> &[((u16, u16), Mesh)] {
+    pub fn layer_meshes(&self) -> &[((Layer, DataType), Mesh)] {
         &self.layer_meshes
     }
 
@@ -242,7 +242,14 @@ mod tests {
     #[test]
     fn rerender_on_hidden_layer_change() {
         let cache = populated_cache();
-        assert!(cache.needs_full_render(&[(1, 0)], 42, 0.0, 0.0, 1.0, test_rect()));
+        assert!(cache.needs_full_render(
+            &[(Layer::new(1), DataType::new(0))],
+            42,
+            0.0,
+            0.0,
+            1.0,
+            test_rect()
+        ));
     }
 
     #[test]
@@ -349,5 +356,5 @@ mod tests {
 #[derive(Default)]
 pub struct LayerState {
     pub layer_colors: LayerColorMap,
-    pub hidden_layers: HashSet<(u16, u16)>,
+    pub hidden_layers: HashSet<(Layer, DataType)>,
 }

--- a/crates/gdsr-viewer/src/testutil.rs
+++ b/crates/gdsr-viewer/src/testutil.rs
@@ -1,6 +1,7 @@
 pub mod helpers {
     use gdsr::{
-        Element, HorizontalPresentation, Path, Point, Polygon, Text, Unit, VerticalPresentation,
+        DataType, Element, HorizontalPresentation, Layer, Path, Point, Polygon, Text, Unit,
+        VerticalPresentation,
     };
 
     pub fn polygon(points: Vec<(i32, i32)>, layer: u16, data_type: u16) -> Element {
@@ -8,8 +9,8 @@ pub mod helpers {
             points
                 .into_iter()
                 .map(|(x, y)| Point::default_integer(x, y)),
-            layer,
-            data_type,
+            Layer::new(layer),
+            DataType::new(data_type),
         ))
     }
 
@@ -23,8 +24,8 @@ pub mod helpers {
             points
                 .into_iter()
                 .map(|(x, y)| Point::default_integer(x, y)),
-            layer,
-            data_type,
+            Layer::new(layer),
+            DataType::new(data_type),
             None,
             width.map(Unit::default_integer),
         ))
@@ -34,8 +35,8 @@ pub mod helpers {
         Element::Text(Text::new(
             value,
             Point::default_integer(x, y),
-            layer,
-            0,
+            Layer::new(layer),
+            DataType::new(0),
             1.0,
             0.0,
             false,

--- a/crates/gdsr-viewer/src/viewport/mod.rs
+++ b/crates/gdsr-viewer/src/viewport/mod.rs
@@ -5,7 +5,7 @@ pub use bounds::compute_bounds;
 use std::collections::HashMap;
 
 use egui::{Color32, Pos2, Rect, Sense};
-use gdsr::{Element, Library};
+use gdsr::{DataType, Element, Layer, Library};
 
 use crate::drawable::{DrawContext, Drawable, WorldBBox};
 use crate::spatial::SpatialGrid;
@@ -117,7 +117,7 @@ impl Viewport {
             }
         }
 
-        let mut hidden_layers: Vec<(u16, u16)> =
+        let mut hidden_layers: Vec<(Layer, DataType)> =
             layer_state.hidden_layers.iter().copied().collect();
         hidden_layers.sort_unstable();
 
@@ -229,7 +229,8 @@ impl Viewport {
             }
         }
 
-        let batched: Vec<((u16, u16), egui::epaint::Mesh)> = layer_meshes.into_iter().collect();
+        let batched: Vec<((Layer, DataType), egui::epaint::Mesh)> =
+            layer_meshes.into_iter().collect();
         for (_, mesh) in &batched {
             painter.add(egui::Shape::mesh(mesh.clone()));
         }

--- a/crates/gdsr/benches/benches/io.rs
+++ b/crates/gdsr/benches/benches/io.rs
@@ -1,6 +1,6 @@
 use criterion::{Criterion, criterion_group, criterion_main};
 use gdsr::{
-    Cell, Grid, HorizontalPresentation, Library, Path, PathType, Point, Polygon, Reference, Text,
+    Cell, DataType, Grid, HorizontalPresentation, Layer, Library, Path, PathType, Point, Polygon, Reference, Text,
     Unit, VerticalPresentation,
 };
 
@@ -38,8 +38,8 @@ fn medium_library() -> Library {
                 point(offset + 50, 70),
                 point(offset + 10, 40),
             ],
-            (i % 16) as u16,
-            (i % 4) as u16,
+            Layer::new((i % 16) as u16),
+            DataType::new((i % 4) as u16),
         ));
     }
 
@@ -53,8 +53,8 @@ fn medium_library() -> Library {
                 point(600, y + 50),
                 point(800, y),
             ],
-            (i % 16) as u16,
-            (i % 4) as u16,
+            Layer::new((i % 16) as u16),
+            DataType::new((i % 4) as u16),
             Some(PATH_TYPES[i as usize % 3]),
             Some(Unit::integer((i % 50 + 1) * 10, DB_UNITS)),
         ));
@@ -64,8 +64,8 @@ fn medium_library() -> Library {
         cell.add(Text::new(
             &format!("medium_label_{i:04}"),
             point(i * 200, -100),
-            (i % 16) as u16,
-            0,
+            Layer::new((i % 16) as u16),
+            DataType::new(0),
             1.0 + f64::from(i % 5) * 0.5,
             f64::from(i % 4) * 0.785,
             i % 2 == 0,
@@ -99,7 +99,7 @@ fn complex_library() -> Library {
                     )
                 })
                 .collect();
-            cell.add(Polygon::new(points, layer, (i % 8) as u16));
+            cell.add(Polygon::new(points, Layer::new(layer), DataType::new((i % 8) as u16)));
         }
 
         for i in 0_i32..100 {
@@ -110,8 +110,9 @@ fn complex_library() -> Library {
                 .collect();
             cell.add(Path::new(
                 points,
-                ((c * 2 + i) % 64) as u16,
-                (i % 4) as u16,
+                Layer::new(((c * 2 + i) % 64) as u16),
+
+                DataType::new((i % 4) as u16),
                 Some(PATH_TYPES[i as usize % 3]),
                 Some(Unit::integer((i % 30 + 1) * 10, DB_UNITS)),
             ));
@@ -121,8 +122,9 @@ fn complex_library() -> Library {
             cell.add(Text::new(
                 &format!("L{c}_text_{i:03}"),
                 point(i * 400, c * 1000),
-                ((c + i) % 64) as u16,
-                (i % 4) as u16,
+                Layer::new(((c + i) % 64) as u16),
+
+                DataType::new((i % 4) as u16),
                 1.0 + f64::from(i % 3) * 0.5,
                 f64::from(i % 8) * std::f64::consts::FRAC_PI_4,
                 i % 3 == 0,
@@ -166,8 +168,8 @@ fn complex_library() -> Library {
                     point(i * 1000 + 500, 500),
                     point(i * 1000, 500),
                 ],
-                (i % 16) as u16,
-                0,
+                Layer::new((i % 16) as u16),
+                DataType::new(0),
             ));
         }
 

--- a/crates/gdsr/benches/io.rs
+++ b/crates/gdsr/benches/io.rs
@@ -1,7 +1,7 @@
 use criterion::{Criterion, criterion_group, criterion_main};
 use gdsr::{
-    Cell, Grid, HorizontalPresentation, Library, Path, PathType, Point, Polygon, Reference, Text,
-    Unit, VerticalPresentation,
+    Cell, DataType, Grid, HorizontalPresentation, Layer, Library, Path, PathType, Point, Polygon,
+    Reference, Text, Unit, VerticalPresentation,
 };
 
 const DB_UNITS: f64 = 1e-9;
@@ -38,8 +38,8 @@ fn medium_library() -> Library {
                 point(offset + 50, 70),
                 point(offset + 10, 40),
             ],
-            (i % 16) as u16,
-            (i % 4) as u16,
+            Layer::new((i % 16) as u16),
+            DataType::new((i % 4) as u16),
         ));
     }
 
@@ -53,8 +53,8 @@ fn medium_library() -> Library {
                 point(600, y + 50),
                 point(800, y),
             ],
-            (i % 16) as u16,
-            (i % 4) as u16,
+            Layer::new((i % 16) as u16),
+            DataType::new((i % 4) as u16),
             Some(PATH_TYPES[i as usize % 3]),
             Some(Unit::integer((i % 50 + 1) * 10, DB_UNITS)),
         ));
@@ -64,8 +64,8 @@ fn medium_library() -> Library {
         cell.add(Text::new(
             &format!("medium_label_{i:04}"),
             point(i * 200, -100),
-            (i % 16) as u16,
-            0,
+            Layer::new((i % 16) as u16),
+            DataType::new(0),
             1.0 + f64::from(i % 5) * 0.5,
             f64::from(i % 4) * 0.785,
             i % 2 == 0,
@@ -99,7 +99,11 @@ fn complex_library() -> Library {
                     )
                 })
                 .collect();
-            cell.add(Polygon::new(points, layer, (i % 8) as u16));
+            cell.add(Polygon::new(
+                points,
+                Layer::new(layer),
+                DataType::new((i % 8) as u16),
+            ));
         }
 
         for i in 0_i32..100 {
@@ -110,8 +114,8 @@ fn complex_library() -> Library {
                 .collect();
             cell.add(Path::new(
                 points,
-                ((c * 2 + i) % 64) as u16,
-                (i % 4) as u16,
+                Layer::new(((c * 2 + i) % 64) as u16),
+                DataType::new((i % 4) as u16),
                 Some(PATH_TYPES[i as usize % 3]),
                 Some(Unit::integer((i % 30 + 1) * 10, DB_UNITS)),
             ));
@@ -121,8 +125,8 @@ fn complex_library() -> Library {
             cell.add(Text::new(
                 &format!("L{c}_text_{i:03}"),
                 point(i * 400, c * 1000),
-                ((c + i) % 64) as u16,
-                (i % 4) as u16,
+                Layer::new(((c + i) % 64) as u16),
+                DataType::new((i % 4) as u16),
                 1.0 + f64::from(i % 3) * 0.5,
                 f64::from(i % 8) * std::f64::consts::FRAC_PI_4,
                 i % 3 == 0,
@@ -166,8 +170,8 @@ fn complex_library() -> Library {
                     point(i * 1000 + 500, 500),
                     point(i * 1000, 500),
                 ],
-                (i % 16) as u16,
-                0,
+                Layer::new((i % 16) as u16),
+                DataType::new(0),
             ));
         }
 

--- a/crates/gdsr/examples/sample.rs
+++ b/crates/gdsr/examples/sample.rs
@@ -1,6 +1,6 @@
 use gdsr::{
-    Cell, Grid, HorizontalPresentation, Library, Path, PathType, Point, Polygon, Reference, Text,
-    Unit, VerticalPresentation,
+    Cell, DataType, Grid, HorizontalPresentation, Layer, Library, Path, PathType, Point, Polygon,
+    Reference, Text, Unit, VerticalPresentation,
 };
 
 fn main() -> Result<(), gdsr::GdsError> {
@@ -15,8 +15,8 @@ fn main() -> Result<(), gdsr::GdsError> {
             Point::default_integer(1000, 1000),
             Point::default_integer(0, 1000),
         ],
-        1,
-        0,
+        Layer::new(1),
+        DataType::new(0),
     ));
     polygons_cell.add(Polygon::new(
         vec![
@@ -25,8 +25,8 @@ fn main() -> Result<(), gdsr::GdsError> {
             Point::default_integer(2000, 1000),
             Point::default_integer(1500, 1000),
         ],
-        2,
-        0,
+        Layer::new(2),
+        DataType::new(0),
     ));
     polygons_cell.add(Polygon::new(
         vec![
@@ -34,8 +34,8 @@ fn main() -> Result<(), gdsr::GdsError> {
             Point::default_integer(4000, 0),
             Point::default_integer(3500, 1000),
         ],
-        3,
-        0,
+        Layer::new(3),
+        DataType::new(0),
     ));
 
     // Cell with paths
@@ -46,8 +46,8 @@ fn main() -> Result<(), gdsr::GdsError> {
             Point::default_integer(1000, 0),
             Point::default_integer(1000, 1000),
         ],
-        4,
-        0,
+        Layer::new(4),
+        DataType::new(0),
         Some(PathType::Square),
         Some(Unit::default_integer(50)),
     ));
@@ -57,8 +57,8 @@ fn main() -> Result<(), gdsr::GdsError> {
             Point::default_integer(2500, 500),
             Point::default_integer(2500, 1000),
         ],
-        5,
-        0,
+        Layer::new(5),
+        DataType::new(0),
         Some(PathType::Round),
         Some(Unit::default_integer(100)),
     ));
@@ -67,8 +67,8 @@ fn main() -> Result<(), gdsr::GdsError> {
             Point::default_integer(3000, 0),
             Point::default_integer(3000, 1000),
         ],
-        4,
-        0,
+        Layer::new(4),
+        DataType::new(0),
         Some(PathType::Overlap),
         Some(Unit::default_integer(75)),
     ));
@@ -78,8 +78,8 @@ fn main() -> Result<(), gdsr::GdsError> {
     text_cell.add(Text::new(
         "Hello",
         Point::default_integer(0, 0),
-        6,
-        0,
+        Layer::new(6),
+        DataType::new(0),
         1.0,
         0.0,
         false,
@@ -89,8 +89,8 @@ fn main() -> Result<(), gdsr::GdsError> {
     text_cell.add(Text::new(
         "World",
         Point::default_integer(0, 500),
-        7,
-        0,
+        Layer::new(7),
+        DataType::new(0),
         2.0,
         0.0,
         false,

--- a/crates/gdsr/src/cell.rs
+++ b/crates/gdsr/src/cell.rs
@@ -358,6 +358,7 @@ impl ToGds for Cell {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{DataType, Layer};
 
     #[test]
     fn test_cell_new() {
@@ -427,13 +428,13 @@ mod tests {
                 Point::float(10.0, 0.0, 1e-6),
                 Point::float(10.0, 10.0, 1e-6),
             ],
-            1,
-            0,
+            Layer::new(1),
+            DataType::new(0),
         ));
         cell.add(Path::new(
             vec![Point::float(0.0, 0.0, 1e-6)],
-            0,
-            0,
+            Layer::new(0),
+            DataType::new(0),
             None,
             None,
         ));
@@ -458,8 +459,8 @@ mod tests {
                 Point::integer(10, 0, 1e-9),
                 Point::integer(10, 10, 1e-9),
             ],
-            1,
-            0,
+            Layer::new(1),
+            DataType::new(0),
         ));
 
         let converted = cell.to_float_unit();
@@ -515,13 +516,13 @@ mod tests {
                 Point::integer(10, 0, 1e-9),
                 Point::integer(10, 10, 1e-9),
             ],
-            1,
-            0,
+            Layer::new(1),
+            DataType::new(0),
         ));
         cell.add(Path::new(
             vec![Point::integer(-5, 5, 1e-9), Point::integer(15, 20, 1e-9)],
-            1,
-            0,
+            Layer::new(1),
+            DataType::new(0),
             None,
             None,
         ));
@@ -549,8 +550,8 @@ mod tests {
                 Point::integer(5, 0, 1e-9),
                 Point::integer(5, 5, 1e-9),
             ],
-            1,
-            0,
+            Layer::new(1),
+            DataType::new(0),
         ));
         cell.add(Polygon::new(
             [
@@ -558,8 +559,8 @@ mod tests {
                 Point::integer(20, 10, 1e-9),
                 Point::integer(20, 20, 1e-9),
             ],
-            1,
-            0,
+            Layer::new(1),
+            DataType::new(0),
         ));
 
         let (min, max) = cell.bounding_box();
@@ -577,13 +578,13 @@ mod tests {
                 Point::integer(10, 0, 1e-9),
                 Point::integer(10, 10, 1e-9),
             ],
-            1,
-            0,
+            Layer::new(1),
+            DataType::new(0),
         );
         let path = Path::new(
             vec![Point::integer(0, 0, 1e-9), Point::integer(5, 5, 1e-9)],
-            2,
-            0,
+            Layer::new(2),
+            DataType::new(0),
             None,
             None,
         );
@@ -621,8 +622,8 @@ mod tests {
                 Point::integer(10, 0, 1e-9),
                 Point::integer(10, 10, 1e-9),
             ],
-            1,
-            0,
+            Layer::new(1),
+            DataType::new(0),
         ));
 
         let (tx, rx) = mpsc::channel();

--- a/crates/gdsr/src/elements/element.rs
+++ b/crates/gdsr/src/elements/element.rs
@@ -161,7 +161,7 @@ impl Dimensions for Element {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Grid, Point};
+    use crate::{DataType, Grid, Layer, Point};
 
     const UNITS: f64 = 1e-9;
 
@@ -178,11 +178,21 @@ mod tests {
     }
 
     fn simple_polygon() -> Polygon {
-        Polygon::new(vec![p(0, 0), p(10, 0), p(10, 10)], 1, 0)
+        Polygon::new(
+            vec![p(0, 0), p(10, 0), p(10, 10)],
+            Layer::new(1),
+            DataType::new(0),
+        )
     }
 
     fn simple_path() -> Path {
-        Path::new(vec![p(0, 0), p(10, 10)], 1, 0, None, None)
+        Path::new(
+            vec![p(0, 0), p(10, 10)],
+            Layer::new(1),
+            DataType::new(0),
+            None,
+            None,
+        )
     }
 
     fn simple_grid() -> Grid {
@@ -278,7 +288,11 @@ mod tests {
 
     #[test]
     fn test_element_to_integer_unit_converts_points() {
-        let polygon = Polygon::new([pf(1.5, 2.5), pf(10.0, 0.0), pf(10.0, 10.0)], 1, 0);
+        let polygon = Polygon::new(
+            [pf(1.5, 2.5), pf(10.0, 0.0), pf(10.0, 10.0)],
+            Layer::new(1),
+            DataType::new(0),
+        );
         let element: Element = polygon.into();
         let converted = element.to_integer_unit();
 
@@ -333,7 +347,13 @@ mod tests {
 
     #[test]
     fn test_element_bounding_box_path() {
-        let path = Path::new(vec![p(-5, 3), p(10, 7)], 1, 0, None, None);
+        let path = Path::new(
+            vec![p(-5, 3), p(10, 7)],
+            Layer::new(1),
+            DataType::new(0),
+            None,
+            None,
+        );
         let element: Element = path.into();
         let (min, max) = element.bounding_box();
         assert_eq!(min, p(-5, 3));

--- a/crates/gdsr/src/elements/path.rs
+++ b/crates/gdsr/src/elements/path.rs
@@ -169,10 +169,10 @@ impl ToGds for Path {
             combine_record_and_data_type(GDSRecord::Path, GDSDataType::NoData),
             6,
             combine_record_and_data_type(GDSRecord::Layer, GDSDataType::TwoByteSignedInteger),
-            self.layer(),
+            self.layer().value(),
             6,
             combine_record_and_data_type(GDSRecord::DataType, GDSDataType::TwoByteSignedInteger),
-            self.data_type(),
+            self.data_type().value(),
         ];
 
         write_u16_array_to_file(&mut buffer, &path_head)?;
@@ -279,15 +279,15 @@ mod tests {
         let points = vec![Point::integer(0, 0, 1e-9), Point::integer(100, 100, 1e-9)];
         let path = Path::new(
             points.clone(),
-            1,
-            2,
+            Layer::new(1),
+            DataType::new(2),
             Some(PathType::Round),
             Some(Unit::default_integer(10)),
         );
 
         assert_eq!(path.points(), &points);
-        assert_eq!(path.layer(), 1);
-        assert_eq!(path.data_type(), 2);
+        assert_eq!(path.layer(), Layer::new(1));
+        assert_eq!(path.data_type(), DataType::new(2));
         assert_eq!(path.path_type(), &Some(PathType::Round));
         assert_eq!(path.width(), Some(Unit::default_integer(10)));
     }
@@ -297,8 +297,8 @@ mod tests {
         let path = Path::default();
 
         assert!(path.points().is_empty());
-        assert_eq!(path.layer(), 0);
-        assert_eq!(path.data_type(), 0);
+        assert_eq!(path.layer(), Layer::new(0));
+        assert_eq!(path.data_type(), DataType::new(0));
         assert_eq!(path.path_type(), &None);
         assert_eq!(path.width(), None);
     }
@@ -308,8 +308,8 @@ mod tests {
         let points = vec![Point::integer(0, 0, 1e-9), Point::integer(100, 100, 1e-9)];
         let path = Path::new(
             points,
-            5,
-            10,
+            Layer::new(5),
+            DataType::new(10),
             Some(PathType::Square),
             Some(Unit::default_integer(20)),
         );
@@ -322,8 +322,8 @@ mod tests {
         let points = vec![Point::integer(0, 0, 1e-9), Point::integer(10, 10, 1e-9)];
         let path1 = Path::new(
             points.clone(),
-            1,
-            2,
+            Layer::new(1),
+            DataType::new(2),
             Some(PathType::Round),
             Some(Unit::default_integer(5)),
         );
@@ -333,8 +333,8 @@ mod tests {
 
         let path3 = Path::new(
             points,
-            1,
-            2,
+            Layer::new(1),
+            DataType::new(2),
             Some(PathType::Square),
             Some(Unit::default_integer(5)),
         );
@@ -346,8 +346,8 @@ mod tests {
         let points = vec![Point::float(1.5, 2.5, 1e-6), Point::float(10.0, 10.0, 1e-6)];
         let path = Path::new(
             points,
-            1,
-            0,
+            Layer::new(1),
+            DataType::new(0),
             Some(PathType::Round),
             Some(Unit::default_float(5.0)),
         );
@@ -365,7 +365,13 @@ mod tests {
     #[test]
     fn test_path_to_float_unit() {
         let points = vec![Point::integer(0, 0, 1e-9), Point::integer(100, 100, 1e-9)];
-        let path = Path::new(points, 1, 0, None, Some(Unit::default_integer(10)));
+        let path = Path::new(
+            points,
+            Layer::new(1),
+            DataType::new(0),
+            None,
+            Some(Unit::default_integer(10)),
+        );
         let converted = path.to_float_unit();
 
         for point in converted.points() {
@@ -380,7 +386,7 @@ mod tests {
     #[test]
     fn test_path_to_integer_unit_no_width() {
         let points = vec![Point::float(1.0, 2.0, 1e-6)];
-        let path = Path::new(points, 0, 0, None, None);
+        let path = Path::new(points, Layer::new(0), DataType::new(0), None, None);
         let converted = path.to_integer_unit();
 
         assert_eq!(converted.width(), None);
@@ -389,7 +395,7 @@ mod tests {
     #[test]
     fn test_path_with_different_unit_points() {
         let points = vec![Point::integer(0, 0, 1e-9), Point::float(100.0, 100.0, 1e-6)];
-        let path = Path::new(points, 0, 0, None, None);
+        let path = Path::new(points, Layer::new(0), DataType::new(0), None, None);
         assert_eq!(path.points().len(), 2);
     }
 
@@ -400,7 +406,7 @@ mod tests {
             Point::integer(10, 5, 1e-9),
             Point::integer(20, -3, 1e-9),
         ];
-        let path = Path::new(points, 1, 0, None, None);
+        let path = Path::new(points, Layer::new(1), DataType::new(0), None, None);
         let (min, max) = path.bounding_box();
         assert_eq!(min, Point::integer(0, -3, 1e-9));
         assert_eq!(max, Point::integer(20, 5, 1e-9));
@@ -417,7 +423,7 @@ mod tests {
     #[test]
     fn test_path_bounding_box_single_point() {
         let points = vec![Point::integer(5, 10, 1e-9)];
-        let path = Path::new(points, 1, 0, None, None);
+        let path = Path::new(points, Layer::new(1), DataType::new(0), None, None);
         let (min, max) = path.bounding_box();
         assert_eq!(min, Point::integer(5, 10, 1e-9));
         assert_eq!(max, Point::integer(5, 10, 1e-9));

--- a/crates/gdsr/src/elements/polygon.rs
+++ b/crates/gdsr/src/elements/polygon.rs
@@ -107,14 +107,14 @@ impl std::fmt::Display for Polygon {
         if self.points().is_empty() {
             write!(
                 f,
-                "Polygon with 0 points on layer {:?}, data type {:?}",
+                "Polygon with 0 points on layer {}, data type {}",
                 self.layer(),
                 self.data_type()
             )
         } else {
             write!(
                 f,
-                "Polygon with {} point(s), starting at ({}, {}) on layer {:?}, data type {:?}",
+                "Polygon with {} point(s), starting at ({}, {}) on layer {}, data type {}",
                 self.points().len(),
                 self.points()[0].x(),
                 self.points()[0].y(),
@@ -184,10 +184,10 @@ impl ToGds for Polygon {
             combine_record_and_data_type(GDSRecord::Boundary, GDSDataType::NoData),
             6,
             combine_record_and_data_type(GDSRecord::Layer, GDSDataType::TwoByteSignedInteger),
-            self.layer(),
+            self.layer().value(),
             6,
             combine_record_and_data_type(GDSRecord::DataType, GDSDataType::TwoByteSignedInteger),
-            self.data_type(),
+            self.data_type().value(),
         ];
 
         write_u16_array_to_file(&mut buffer, &polygon_head)?;
@@ -246,10 +246,10 @@ mod tests {
             Point::integer(10, 0, 1e-9),
             Point::integer(10, 10, 1e-9),
         ];
-        let polygon = Polygon::new(points, 1, 0);
+        let polygon = Polygon::new(points, Layer::new(1), DataType::new(0));
 
-        assert_eq!(polygon.layer(), 1);
-        assert_eq!(polygon.data_type(), 0);
+        assert_eq!(polygon.layer(), Layer::new(1));
+        assert_eq!(polygon.data_type(), DataType::new(0));
         // Should be closed automatically
         assert_eq!(polygon.points().len(), 4);
     }
@@ -258,8 +258,8 @@ mod tests {
     fn test_polygon_default() {
         let polygon = Polygon::default();
         assert_eq!(polygon.points().len(), 0);
-        assert_eq!(polygon.layer(), 0);
-        assert_eq!(polygon.data_type(), 0);
+        assert_eq!(polygon.layer(), Layer::new(0));
+        assert_eq!(polygon.data_type(), DataType::new(0));
     }
 
     #[test]
@@ -269,14 +269,14 @@ mod tests {
             Point::integer(5, 0, 1e-9),
             Point::integer(5, 5, 1e-9),
         ];
-        let polygon = Polygon::new(points, 2, 1);
+        let polygon = Polygon::new(points, Layer::new(2), DataType::new(1));
 
         insta::assert_snapshot!(polygon.to_string(), @"Polygon with 4 point(s), starting at (0 (1.000e-9), 0 (1.000e-9)) on layer 2, data type 1");
     }
 
     #[test]
     fn test_polygon_display_empty() {
-        let polygon = Polygon::new(vec![], 1, 0);
+        let polygon = Polygon::new(vec![], Layer::new(1), DataType::new(0));
         insta::assert_snapshot!(polygon.to_string(), @"Polygon with 0 points on layer 1, data type 0");
     }
 
@@ -288,7 +288,7 @@ mod tests {
             Point::integer(10, 10, 1e-9),
             Point::integer(0, 10, 1e-9),
         ];
-        let polygon = Polygon::new(points, 1, 0);
+        let polygon = Polygon::new(points, Layer::new(1), DataType::new(0));
         assert_eq!(polygon.area(), Unit::float(100.0, 1e-9));
 
         let points = vec![
@@ -296,10 +296,10 @@ mod tests {
             Point::integer(10, 0, 1e-9),
             Point::integer(5, 10, 1e-9),
         ];
-        let polygon = Polygon::new(points, 1, 0);
+        let polygon = Polygon::new(points, Layer::new(1), DataType::new(0));
         assert_eq!(polygon.area(), Unit::float(50.0, 1e-9));
 
-        let polygon = Polygon::new(vec![], 1, 0);
+        let polygon = Polygon::new(vec![], Layer::new(1), DataType::new(0));
         assert_eq!(polygon.area(), Unit::float(0.0, 1e-9));
     }
 
@@ -311,7 +311,7 @@ mod tests {
             Point::integer(10, 10, 1e-9),
             Point::integer(0, 10, 1e-9),
         ];
-        let polygon = Polygon::new(points, 1, 0);
+        let polygon = Polygon::new(points, Layer::new(1), DataType::new(0));
         assert_eq!(polygon.perimeter(), Unit::float(40.0, 1e-9));
 
         let points = vec![
@@ -319,10 +319,10 @@ mod tests {
             Point::integer(3, 0, 1e-9),
             Point::integer(0, 4, 1e-9),
         ];
-        let polygon = Polygon::new(points, 1, 0);
+        let polygon = Polygon::new(points, Layer::new(1), DataType::new(0));
         assert_eq!(polygon.perimeter(), Unit::float(12.0, 1e-9));
 
-        let polygon = Polygon::new(vec![], 1, 0);
+        let polygon = Polygon::new(vec![], Layer::new(1), DataType::new(0));
         assert_eq!(polygon.perimeter(), Unit::float(0.0, 1e-9));
     }
 
@@ -334,7 +334,7 @@ mod tests {
             Point::integer(10, 10, 1e-9),
             Point::integer(0, 10, 1e-9),
         ];
-        let polygon = Polygon::new(points, 1, 0);
+        let polygon = Polygon::new(points, Layer::new(1), DataType::new(0));
 
         assert!(polygon.is_point_inside(&Point::integer(5, 5, 1e-9)));
         assert!(!polygon.is_point_inside(&Point::integer(15, 15, 1e-9)));
@@ -349,7 +349,7 @@ mod tests {
             Point::integer(10, 10, 1e-9),
             Point::integer(0, 10, 1e-9),
         ];
-        let polygon = Polygon::new(points, 1, 0);
+        let polygon = Polygon::new(points, Layer::new(1), DataType::new(0));
 
         assert!(polygon.is_point_on_edge(&Point::integer(5, 0, 1e-9)));
         assert!(polygon.is_point_on_edge(&Point::integer(10, 5, 1e-9)));
@@ -367,7 +367,7 @@ mod tests {
             Point::integer(10, 10, 1e-9),
             Point::integer(0, 10, 1e-9),
         ];
-        let polygon = Polygon::new(points, 1, 0);
+        let polygon = Polygon::new(points, Layer::new(1), DataType::new(0));
         let (min, max) = polygon.bounding_box();
         assert_eq!(min, Point::integer(0, 0, 1e-9));
         assert_eq!(max, Point::integer(10, 10, 1e-9));
@@ -377,7 +377,7 @@ mod tests {
             Point::integer(7, 2, 1e-9),
             Point::integer(3, 8, 1e-9),
         ];
-        let polygon = Polygon::new(points, 1, 0);
+        let polygon = Polygon::new(points, Layer::new(1), DataType::new(0));
         let (min, max) = polygon.bounding_box();
         assert_eq!(min, Point::integer(-5, -3, 1e-9));
         assert_eq!(max, Point::integer(7, 8, 1e-9));
@@ -391,7 +391,7 @@ mod tests {
             Point::integer(10, 10, 1e-9),
             Point::integer(0, 10, 1e-9),
         ];
-        let polygon = Polygon::new(points, 1, 0);
+        let polygon = Polygon::new(points, Layer::new(1), DataType::new(0));
         let target = Point::integer(5, 5, 1e-9);
         let moved = polygon.move_to(target);
 
@@ -409,7 +409,7 @@ mod tests {
             Point::float(10.0, 0.0, 1e-6),
             Point::float(10.0, 10.0, 1e-6),
         ];
-        let polygon = Polygon::new(points, 1, 0);
+        let polygon = Polygon::new(points, Layer::new(1), DataType::new(0));
         let converted = polygon.to_integer_unit();
 
         for point in converted.points() {
@@ -424,7 +424,7 @@ mod tests {
             Point::integer(10, 0, 1e-9),
             Point::integer(10, 10, 1e-9),
         ];
-        let polygon = Polygon::new(points, 1, 0);
+        let polygon = Polygon::new(points, Layer::new(1), DataType::new(0));
         let converted = polygon.to_float_unit();
 
         for point in converted.points() {
@@ -434,7 +434,7 @@ mod tests {
 
     #[test]
     fn test_polygon_move_to_empty() {
-        let polygon = Polygon::new(vec![], 1, 0);
+        let polygon = Polygon::new(vec![], Layer::new(1), DataType::new(0));
         let moved = polygon.move_to(Point::integer(5, 5, 1e-9));
         assert_eq!(moved.points().len(), 0);
     }

--- a/crates/gdsr/src/elements/reference.rs
+++ b/crates/gdsr/src/elements/reference.rs
@@ -424,6 +424,7 @@ impl Reference {
 mod tests {
     use super::*;
     use crate::elements::Polygon;
+    use crate::{DataType, Layer};
 
     mod instance {
         use super::*;
@@ -449,8 +450,8 @@ mod tests {
                     Point::integer(10, 0, 1e-9),
                     Point::integer(10, 10, 1e-9),
                 ],
-                1,
-                0,
+                Layer::new(1),
+                DataType::new(0),
             );
             assert!(Instance::from(polygon).as_element().is_some());
         }
@@ -478,8 +479,8 @@ mod tests {
         fn test_instance_from_path() {
             let path = Path::new(
                 vec![Point::integer(0, 0, 1e-9), Point::integer(10, 10, 1e-9)],
-                1,
-                0,
+                Layer::new(1),
+                DataType::new(0),
                 None,
                 None,
             );
@@ -496,8 +497,8 @@ mod tests {
             let text = Text::new(
                 "test",
                 Point::integer(0, 0, 1e-9),
-                1,
-                0,
+                Layer::new(1),
+                DataType::new(0),
                 1.0,
                 0.0,
                 false,
@@ -526,8 +527,8 @@ mod tests {
                     Point::integer(10, 0, 1e-9),
                     Point::integer(10, 10, 1e-9),
                 ],
-                1,
-                0,
+                Layer::new(1),
+                DataType::new(0),
             );
             let instance = Instance::from(polygon);
             insta::assert_snapshot!(instance.to_string(), @"Element instance: Polygon with 4 point(s), starting at (0 (1.000e-9), 0 (1.000e-9)) on layer 1, data type 0");
@@ -542,8 +543,8 @@ mod tests {
                 Point::integer(10, 0, 1e-9),
                 Point::integer(10, 10, 1e-9),
             ],
-            1,
-            0,
+            Layer::new(1),
+            DataType::new(0),
         );
         let grid = Grid::default()
             .with_columns(2)
@@ -584,8 +585,8 @@ mod tests {
                 Point::integer(10, 0, 1e-9),
                 Point::integer(10, 10, 1e-9),
             ],
-            1,
-            0,
+            Layer::new(1),
+            DataType::new(0),
         );
 
         let reference = Reference::new(polygon.clone());
@@ -620,8 +621,8 @@ mod tests {
                 Point::integer(10, 0, 1e-9),
                 Point::integer(10, 10, 1e-9),
             ],
-            1,
-            0,
+            Layer::new(1),
+            DataType::new(0),
         );
         let grid = Grid::default()
             .with_origin(Point::float(1.5, 2.5, 1e-6))
@@ -648,8 +649,8 @@ mod tests {
                 Point::integer(10, 0, 1e-9),
                 Point::integer(10, 10, 1e-9),
             ],
-            1,
-            0,
+            Layer::new(1),
+            DataType::new(0),
         );
         let grid = Grid::default()
             .with_origin(Point::integer(10, 20, 1e-9))
@@ -677,8 +678,8 @@ mod tests {
                 Point::integer(10, 0, 1e-9),
                 Point::integer(10, 10, 1e-9),
             ],
-            1,
-            0,
+            Layer::new(1),
+            DataType::new(0),
         );
         let grid = Grid::default()
             .with_columns(2)
@@ -703,8 +704,8 @@ mod tests {
                 Point::integer(10, 0, 1e-9),
                 Point::integer(10, 10, 1e-9),
             ],
-            1,
-            0,
+            Layer::new(1),
+            DataType::new(0),
         );
         let grid = Grid::default()
             .with_columns(2)
@@ -727,8 +728,8 @@ mod tests {
                 Point::integer(10, 0, 1e-9),
                 Point::integer(10, 10, 1e-9),
             ],
-            1,
-            0,
+            Layer::new(1),
+            DataType::new(0),
         );
         let grid = Grid::default()
             .with_columns(3)
@@ -752,8 +753,8 @@ mod tests {
                 Point::integer(10, 0, 1e-9),
                 Point::integer(10, 10, 1e-9),
             ],
-            1,
-            0,
+            Layer::new(1),
+            DataType::new(0),
         );
         let grid = Grid::default()
             .with_columns(2)
@@ -778,8 +779,8 @@ mod tests {
                 Point::integer(10, 0, 1e-9),
                 Point::integer(10, 10, 1e-9),
             ],
-            1,
-            0,
+            Layer::new(1),
+            DataType::new(0),
         );
         let grid = Grid::default()
             .with_columns(2)
@@ -806,8 +807,8 @@ mod tests {
                 Point::integer(10, 0, 1e-9),
                 Point::integer(10, 10, 1e-9),
             ],
-            1,
-            0,
+            Layer::new(1),
+            DataType::new(0),
         );
         let grid = Grid::default()
             .with_columns(2)
@@ -831,8 +832,8 @@ mod tests {
                 Point::integer(10, 0, 1e-9),
                 Point::integer(10, 10, 1e-9),
             ],
-            1,
-            0,
+            Layer::new(1),
+            DataType::new(0),
         );
         let grid = Grid::default()
             .with_columns(2)
@@ -858,8 +859,8 @@ mod tests {
                 Point::integer(10, 0, 1e-9),
                 Point::integer(10, 10, 1e-9),
             ],
-            1,
-            0,
+            Layer::new(1),
+            DataType::new(0),
         );
 
         let mut cell = crate::Cell::new("test_cell");
@@ -886,8 +887,8 @@ mod tests {
                 Point::integer(10, 0, 1e-9),
                 Point::integer(10, 10, 1e-9),
             ],
-            1,
-            0,
+            Layer::new(1),
+            DataType::new(0),
         );
         let grid = Grid::default()
             .with_columns(1)
@@ -913,8 +914,8 @@ mod tests {
                 Point::integer(10, 0, 1e-9),
                 Point::integer(10, 10, 1e-9),
             ],
-            1,
-            0,
+            Layer::new(1),
+            DataType::new(0),
         );
         let grid = Grid::default()
             .with_columns(1)
@@ -943,8 +944,8 @@ mod tests {
                 Point::integer(10, 0, 1e-9),
                 Point::integer(10, 10, 1e-9),
             ],
-            1,
-            0,
+            Layer::new(1),
+            DataType::new(0),
         );
         let grid = Grid::default()
             .with_columns(5)
@@ -973,8 +974,8 @@ mod tests {
                 Point::integer(10, 0, 1e-9),
                 Point::integer(10, 10, 1e-9),
             ],
-            1,
-            0,
+            Layer::new(1),
+            DataType::new(0),
         );
         let grid = Grid::default().with_columns(3).with_rows(3);
 
@@ -998,8 +999,8 @@ mod tests {
                 Point::integer(10, 0, 1e-9),
                 Point::integer(10, 10, 1e-9),
             ],
-            1,
-            0,
+            Layer::new(1),
+            DataType::new(0),
         );
         let grid = Grid::default()
             .with_columns(3)
@@ -1027,8 +1028,8 @@ mod tests {
                 Point::integer(10, 0, 1e-9),
                 Point::integer(10, 10, 1e-9),
             ],
-            1,
-            0,
+            Layer::new(1),
+            DataType::new(0),
         );
         let grid = Grid::default()
             .with_columns(3)
@@ -1057,8 +1058,8 @@ mod tests {
                 Point::integer(1, 0, 1e-9),
                 Point::integer(1, 1, 1e-9),
             ],
-            1,
-            0,
+            Layer::new(1),
+            DataType::new(0),
         );
         let grid = Grid::default()
             .with_columns(10)
@@ -1138,8 +1139,8 @@ mod tests {
                 Point::integer(10, 0, 1e-9),
                 Point::integer(10, 10, 1e-9),
             ],
-            1,
-            0,
+            Layer::new(1),
+            DataType::new(0),
         );
 
         let mut inner_cell = crate::Cell::new("inner");
@@ -1172,8 +1173,8 @@ mod tests {
                 Point::integer(5, 0, 1e-9),
                 Point::integer(5, 5, 1e-9),
             ],
-            1,
-            0,
+            Layer::new(1),
+            DataType::new(0),
         );
 
         let mut cell_a = crate::Cell::new("a");
@@ -1219,8 +1220,8 @@ mod tests {
                 Point::integer(10, 0, 1e-9),
                 Point::integer(10, 10, 1e-9),
             ],
-            1,
-            0,
+            Layer::new(1),
+            DataType::new(0),
         );
         let grid = Grid::default()
             .with_columns(0)
@@ -1244,8 +1245,8 @@ mod tests {
                 Point::integer(10, 0, 1e-9),
                 Point::integer(10, 10, 1e-9),
             ],
-            1,
-            0,
+            Layer::new(1),
+            DataType::new(0),
         );
         let grid = Grid::default()
             .with_columns(3)
@@ -1270,8 +1271,8 @@ mod tests {
                 Point::integer(10, 0, 1e-9),
                 Point::integer(10, 10, 1e-9),
             ],
-            1,
-            0,
+            Layer::new(1),
+            DataType::new(0),
         );
         let grid = Grid::default()
             .with_columns(0)
@@ -1295,8 +1296,8 @@ mod tests {
                 Point::integer(10, 0, 1e-9),
                 Point::integer(10, 10, 1e-9),
             ],
-            1,
-            0,
+            Layer::new(1),
+            DataType::new(0),
         );
 
         let mut cell = crate::Cell::new("test_cell");
@@ -1334,8 +1335,8 @@ mod tests {
                 Point::integer(10, 0, 1e-9),
                 Point::integer(10, 10, 1e-9),
             ],
-            1,
-            0,
+            Layer::new(1),
+            DataType::new(0),
         );
         let grid = Grid::default()
             .with_columns(2)
@@ -1367,8 +1368,8 @@ mod tests {
                 Point::integer(10, 0, 1e-9),
                 Point::integer(10, 10, 1e-9),
             ],
-            1,
-            0,
+            Layer::new(1),
+            DataType::new(0),
         );
 
         let mut cell = crate::Cell::new("test_cell");

--- a/crates/gdsr/src/elements/snapshots/gdsr__elements__reference__tests__reference_flatten.snap
+++ b/crates/gdsr/src/elements/snapshots/gdsr__elements__reference__tests__reference_flatten.snap
@@ -63,8 +63,12 @@ expression: flattened
                     ),
                 },
             ],
-            layer: 1,
-            data_type: 0,
+            layer: Layer(
+                1,
+            ),
+            data_type: DataType(
+                0,
+            ),
         },
     ),
     Polygon(
@@ -127,8 +131,12 @@ expression: flattened
                     ),
                 },
             ],
-            layer: 1,
-            data_type: 0,
+            layer: Layer(
+                1,
+            ),
+            data_type: DataType(
+                0,
+            ),
         },
     ),
     Polygon(
@@ -191,8 +199,12 @@ expression: flattened
                     ),
                 },
             ],
-            layer: 1,
-            data_type: 0,
+            layer: Layer(
+                1,
+            ),
+            data_type: DataType(
+                0,
+            ),
         },
     ),
     Polygon(
@@ -255,8 +267,12 @@ expression: flattened
                     ),
                 },
             ],
-            layer: 1,
-            data_type: 0,
+            layer: Layer(
+                1,
+            ),
+            data_type: DataType(
+                0,
+            ),
         },
     ),
 ]

--- a/crates/gdsr/src/elements/text.rs
+++ b/crates/gdsr/src/elements/text.rs
@@ -176,8 +176,8 @@ impl Default for Text {
         Self {
             value: String::new(),
             origin: Point::integer(0, 0, 1e-9),
-            layer: 0,
-            datatype: 0,
+            layer: Layer::new(0),
+            datatype: DataType::new(0),
             magnification: 1.0,
             angle: 0.0,
             x_reflection: false,
@@ -394,7 +394,7 @@ impl ToGds for Text {
             combine_record_and_data_type(GDSRecord::Text, GDSDataType::NoData),
             6,
             combine_record_and_data_type(GDSRecord::Layer, GDSDataType::TwoByteSignedInteger),
-            self.layer(),
+            self.layer().value(),
             6,
             combine_record_and_data_type(GDSRecord::TextType, GDSDataType::TwoByteSignedInteger),
             0,
@@ -698,8 +698,8 @@ mod tests {
         let text = Text::new(
             "Hello World",
             Point::integer(100, 200, 1e-9),
-            5,
-            0,
+            Layer::new(5),
+            DataType::new(0),
             2.0,
             45.0,
             true,
@@ -709,7 +709,7 @@ mod tests {
 
         assert_eq!(text.text(), "Hello World");
         assert_eq!(text.origin(), &Point::integer(100, 200, 1e-9));
-        assert_eq!(text.layer(), 5);
+        assert_eq!(text.layer(), Layer::new(5));
         assert_eq!(text.magnification(), 2.0);
         assert_eq!(text.angle(), 45.0);
         assert!(text.x_reflection());
@@ -721,7 +721,7 @@ mod tests {
 
         assert_eq!(text.text(), "");
         assert_eq!(text.origin(), &Point::integer(0, 0, 1e-9));
-        assert_eq!(text.layer(), 0);
+        assert_eq!(text.layer(), Layer::new(0));
         assert_eq!(text.magnification(), 1.0);
         assert_eq!(text.angle(), 0.0);
         assert!(!text.x_reflection());
@@ -732,8 +732,8 @@ mod tests {
         let text = Text::new(
             "Test Text",
             Point::integer(10, 20, 1e-9),
-            1,
-            0,
+            Layer::new(1),
+            DataType::new(0),
             1.5,
             30.0,
             false,
@@ -759,8 +759,8 @@ mod tests {
 
     #[test]
     fn test_set_layer() {
-        let text = Text::default().set_layer(10);
-        assert_eq!(text.layer(), 10);
+        let text = Text::default().set_layer(Layer::new(10));
+        assert_eq!(text.layer(), Layer::new(10));
     }
 
     #[test]
@@ -801,7 +801,7 @@ mod tests {
         let text = Text::default()
             .set_text("Chained".to_string())
             .set_origin(Point::integer(100, 200, 1e-9))
-            .set_layer(5)
+            .set_layer(Layer::new(5))
             .set_magnification(2.0)
             .set_angle(45.0)
             .set_x_reflection(true)
@@ -810,7 +810,7 @@ mod tests {
 
         assert_eq!(text.text(), "Chained");
         assert_eq!(text.origin(), &Point::integer(100, 200, 1e-9));
-        assert_eq!(text.layer(), 5);
+        assert_eq!(text.layer(), Layer::new(5));
         assert_eq!(text.magnification(), 2.0);
         assert_eq!(text.angle(), 45.0);
         assert!(text.x_reflection());
@@ -866,8 +866,12 @@ mod tests {
                     },
                 ),
             },
-            layer: 0,
-            datatype: 0,
+            layer: Layer(
+                0,
+            ),
+            datatype: DataType(
+                0,
+            ),
             magnification: 1.0,
             angle: 1.5707963267948966,
             x_reflection: false,
@@ -957,8 +961,12 @@ mod tests {
                     },
                 ),
             },
-            layer: 0,
-            datatype: 0,
+            layer: Layer(
+                0,
+            ),
+            datatype: DataType(
+                0,
+            ),
             magnification: 2.0,
             angle: 1.5707963267948966,
             x_reflection: true,

--- a/crates/gdsr/src/property_tests/arbitrary.rs
+++ b/crates/gdsr/src/property_tests/arbitrary.rs
@@ -176,8 +176,8 @@ impl Arbitrary for Polygon {
                 Point::integer(x, y, units)
             })
             .collect();
-        let layer = u16::arbitrary(g);
-        let data_type = u16::arbitrary(g);
+        let layer = Layer::new(u16::arbitrary(g));
+        let data_type = DataType::new(u16::arbitrary(g));
         Self::new(points, layer, data_type)
     }
 }
@@ -201,8 +201,8 @@ impl Arbitrary for Path {
                 Point::integer(x, y, units)
             })
             .collect();
-        let layer = u16::arbitrary(g);
-        let data_type = u16::arbitrary(g);
+        let layer = Layer::new(u16::arbitrary(g));
+        let data_type = DataType::new(u16::arbitrary(g));
         let path_type = if bool::arbitrary(g) {
             Some(PathType::arbitrary(g))
         } else {
@@ -229,8 +229,8 @@ impl Arbitrary for Text {
         let value: String = (0..len)
             .map(|_| (b'a' + (u8::arbitrary(g) % 26)) as char)
             .collect();
-        let layer = u16::arbitrary(g) % 256;
-        let datatype = u16::arbitrary(g) % 256;
+        let layer = Layer::new(u16::arbitrary(g) % 256);
+        let datatype = DataType::new(u16::arbitrary(g) % 256);
         let vp_options = [
             HorizontalPresentation::Left,
             HorizontalPresentation::Centre,
@@ -278,12 +278,12 @@ impl Arbitrary for Grid {
 
 const GDS_NAME_CHARS: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_$?";
 
-pub(super) fn arb_layer(g: &mut Gen) -> u16 {
-    u16::arbitrary(g) % 256
+pub(super) fn arb_layer(g: &mut Gen) -> Layer {
+    Layer::new(u16::arbitrary(g) % 256)
 }
 
-pub(super) fn arb_data_type(g: &mut Gen) -> u16 {
-    u16::arbitrary(g) % 256
+pub(super) fn arb_data_type(g: &mut Gen) -> DataType {
+    DataType::new(u16::arbitrary(g) % 256)
 }
 
 pub(super) fn arb_structure_name(g: &mut Gen) -> String {
@@ -347,7 +347,7 @@ pub(super) fn arb_gds_text(g: &mut Gen) -> Text {
         &value,
         origin,
         arb_layer(g),
-        0,
+        DataType::new(0),
         1.0,
         0.0,
         false,

--- a/crates/gdsr/src/property_tests/validation.rs
+++ b/crates/gdsr/src/property_tests/validation.rs
@@ -31,15 +31,15 @@ fn get_elements(units: f64) -> Vec<Element> {
                 Point::integer(20, 20, units),
                 Point::integer(0, 20, units),
             ],
-            4,
-            0,
+            Layer::new(4),
+            DataType::new(0),
         )
         .into(),
         Text::new(
             "All Elements",
             Point::integer(250, 50, units),
-            3,
-            0,
+            Layer::new(3),
+            DataType::new(0),
             2.0,
             0.0,
             false,
@@ -53,8 +53,8 @@ fn get_elements(units: f64) -> Vec<Element> {
                 Point::integer(200, 50, units),
                 Point::integer(200, 100, units),
             ],
-            2,
-            0,
+            Layer::new(2),
+            DataType::new(0),
             Some(PathType::Round),
             Some(Unit::float(5.0, units)),
         )
@@ -65,8 +65,8 @@ fn get_elements(units: f64) -> Vec<Element> {
                 Point::integer(200, 50, units),
                 Point::integer(200, 100, units),
             ],
-            2,
-            0,
+            Layer::new(2),
+            DataType::new(0),
             None,
             None,
         )
@@ -77,8 +77,8 @@ fn get_elements(units: f64) -> Vec<Element> {
                 Point::integer(10, 0, units),
                 Point::integer(10, 10, units),
             ],
-            4,
-            0,
+            Layer::new(4),
+            DataType::new(0),
         ))
         .with_grid(Grid::new(
             Point::integer(300, 50, units),
@@ -97,8 +97,8 @@ fn get_elements(units: f64) -> Vec<Element> {
                 Point::integer(10, 0, units),
                 Point::integer(10, 10, units),
             ],
-            4,
-            0,
+            Layer::new(4),
+            DataType::new(0),
         ))
         .with_grid(Grid::new(
             Point::integer(300, 50, units),
@@ -117,8 +117,8 @@ fn get_elements(units: f64) -> Vec<Element> {
                 Point::integer(10, 0, units),
                 Point::integer(10, 10, units),
             ],
-            4,
-            0,
+            Layer::new(4),
+            DataType::new(0),
         ))
         .with_grid(Grid::new(
             Point::integer(300, 50, units),
@@ -138,8 +138,8 @@ fn get_elements(units: f64) -> Vec<Element> {
                 Point::integer(20, 20, units),
                 Point::integer(0, 20, units),
             ],
-            4,
-            0,
+            Layer::new(4),
+            DataType::new(0),
         ))
         .with_grid(Grid::new(
             Point::integer(300, 50, units),
@@ -159,50 +159,8 @@ fn get_elements(units: f64) -> Vec<Element> {
                 Point::integer(20, 20, units),
                 Point::integer(0, 20, units),
             ],
-            4,
-            0,
-        ))
-        .with_grid(Grid::new(
-            Point::integer(300, 50, units),
-            1,
-            2,
-            None,
-            Some(Point::integer(10, 10, units)),
-            1.0,
-            0.0,
-            false,
-        ))
-        .into(),
-        Reference::new(Polygon::new(
-            [
-                Point::integer(0, 0, units),
-                Point::integer(20, 0, units),
-                Point::integer(20, 20, units),
-                Point::integer(0, 20, units),
-            ],
-            4,
-            0,
-        ))
-        .with_grid(Grid::new(
-            Point::integer(300, 50, units),
-            2,
-            1,
-            Some(Point::integer(10, 10, units)),
-            None,
-            1.0,
-            0.0,
-            false,
-        ))
-        .into(),
-        Reference::new(Polygon::new(
-            [
-                Point::integer(0, 0, units),
-                Point::integer(20, 0, units),
-                Point::integer(20, 20, units),
-                Point::integer(0, 20, units),
-            ],
-            4,
-            0,
+            Layer::new(4),
+            DataType::new(0),
         ))
         .with_grid(Grid::new(
             Point::integer(300, 50, units),
@@ -222,8 +180,50 @@ fn get_elements(units: f64) -> Vec<Element> {
                 Point::integer(20, 20, units),
                 Point::integer(0, 20, units),
             ],
-            4,
-            0,
+            Layer::new(4),
+            DataType::new(0),
+        ))
+        .with_grid(Grid::new(
+            Point::integer(300, 50, units),
+            2,
+            1,
+            Some(Point::integer(10, 10, units)),
+            None,
+            1.0,
+            0.0,
+            false,
+        ))
+        .into(),
+        Reference::new(Polygon::new(
+            [
+                Point::integer(0, 0, units),
+                Point::integer(20, 0, units),
+                Point::integer(20, 20, units),
+                Point::integer(0, 20, units),
+            ],
+            Layer::new(4),
+            DataType::new(0),
+        ))
+        .with_grid(Grid::new(
+            Point::integer(300, 50, units),
+            1,
+            2,
+            None,
+            Some(Point::integer(10, 10, units)),
+            1.0,
+            0.0,
+            false,
+        ))
+        .into(),
+        Reference::new(Polygon::new(
+            [
+                Point::integer(0, 0, units),
+                Point::integer(20, 0, units),
+                Point::integer(20, 20, units),
+                Point::integer(0, 20, units),
+            ],
+            Layer::new(4),
+            DataType::new(0),
         ))
         .with_grid(Grid::new(
             Point::integer(300, 50, units),
@@ -254,16 +254,16 @@ fn test_library_roundtrip_mixed_elements() {
             Point::integer(10, 10, units),
             Point::integer(0, 10, units),
         ],
-        1,
-        0,
+        Layer::new(1),
+        DataType::new(0),
     );
     cell.add(polygon);
 
     let text = Text::new(
         "Test Label",
         Point::integer(5, 5, units),
-        1,
-        0,
+        Layer::new(1),
+        DataType::new(0),
         1.0,
         0.0,
         false,
@@ -278,8 +278,8 @@ fn test_library_roundtrip_mixed_elements() {
             Point::integer(5, 5, units),
             Point::integer(10, 0, units),
         ],
-        1,
-        0,
+        Layer::new(1),
+        DataType::new(0),
         Some(PathType::Square),
         Some(Unit::float(2.0, units)),
     );
@@ -292,8 +292,8 @@ fn test_library_roundtrip_mixed_elements() {
             Point::integer(20, 20, units),
             Point::integer(15, 20, units),
         ],
-        2,
-        0,
+        Layer::new(2),
+        DataType::new(0),
     );
 
     let reference = Reference::new(ref_polygon.clone()).with_grid(
@@ -340,8 +340,8 @@ fn test_library_roundtrip_different_units() {
                 Point::integer(100, 100, units),
                 Point::integer(0, 100, units),
             ],
-            1,
-            0,
+            Layer::new(1),
+            DataType::new(0),
         );
 
         let reference = Reference::new(polygon.clone()).with_grid(Grid::new(
@@ -370,8 +370,8 @@ fn test_library_roundtrip_different_units() {
                 Point::integer(100, 100, units),
                 Point::integer(0, 100, units),
             ],
-            1,
-            0,
+            Layer::new(1),
+            DataType::new(0),
         );
 
         cell2.add(polygon2);
@@ -426,8 +426,8 @@ fn test_complex_path_types_roundtrip() {
             Point::integer(50, 0, units),
             Point::integer(50, 50, units),
         ],
-        1,
-        0,
+        Layer::new(1),
+        DataType::new(0),
         Some(PathType::Square),
         Some(Unit::float(5.0, units)),
     ));
@@ -438,16 +438,16 @@ fn test_complex_path_types_roundtrip() {
             Point::integer(150, 0, units),
             Point::integer(150, 50, units),
         ],
-        2,
-        0,
+        Layer::new(2),
+        DataType::new(0),
         Some(PathType::Round),
         Some(Unit::float(3.0, units)),
     ));
 
     cell.add(Path::new(
         vec![Point::integer(200, 0, units), Point::integer(250, 0, units)],
-        3,
-        0,
+        Layer::new(3),
+        DataType::new(0),
         Some(PathType::Overlap),
         Some(Unit::float(4.0, units)),
     ));
@@ -466,8 +466,8 @@ fn test_text_with_various_presentations() {
     cell.add(Text::new(
         "Top Left",
         Point::integer(0, 0, units),
-        1,
-        0,
+        Layer::new(1),
+        DataType::new(0),
         1.0,
         0.0,
         false,
@@ -478,8 +478,8 @@ fn test_text_with_various_presentations() {
     cell.add(Text::new(
         "Middle Centre",
         Point::integer(50, 50, units),
-        1,
-        0,
+        Layer::new(1),
+        DataType::new(0),
         1.5,
         45.0,
         false,
@@ -490,8 +490,8 @@ fn test_text_with_various_presentations() {
     cell.add(Text::new(
         "Bottom Right",
         Point::integer(100, 100, units),
-        2,
-        0,
+        Layer::new(2),
+        DataType::new(0),
         2.0,
         90.0,
         true,
@@ -517,8 +517,8 @@ fn test_nested_references() {
             Point::integer(10, 10, units),
             Point::integer(0, 10, units),
         ],
-        1,
-        0,
+        Layer::new(1),
+        DataType::new(0),
     ));
 
     let mut cell2 = Cell::new("mid_cell");
@@ -558,8 +558,8 @@ fn test_large_polygon_coordinates() {
             Point::integer(2_000_000, 2_000_000, units),
             Point::integer(1_000_000, 2_000_000, units),
         ],
-        1,
-        0,
+        Layer::new(1),
+        DataType::new(0),
     ));
 
     library.add_cell(cell);
@@ -583,8 +583,8 @@ fn test_float_coordinates() {
             Point::float(10.5, 10.5, units),
             Point::float(0.5, 10.5, units),
         ],
-        1,
-        0,
+        Layer::new(1),
+        DataType::new(0),
     );
     cell.add(polygon);
 
@@ -594,8 +594,8 @@ fn test_float_coordinates() {
             Point::float(20.75, 15.25, units),
             Point::float(20.75, 20.75, units),
         ],
-        2,
-        0,
+        Layer::new(2),
+        DataType::new(0),
         Some(PathType::Round),
         Some(Unit::float(1.5, units)),
     );
@@ -629,8 +629,8 @@ fn test_multiple_cells_different_layers() {
                 Point::integer(layer * 10 + 10, 10, units),
                 Point::integer(layer * 10, 10, units),
             ],
-            layer as u16,
-            0,
+            Layer::new(layer as u16),
+            DataType::new(0),
         ));
 
         library.add_cell(cell);
@@ -658,8 +658,8 @@ fn test_single_cell_with_all_element_types() {
             Point::integer(100, 100, units),
             Point::integer(0, 100, units),
         ],
-        1,
-        0,
+        Layer::new(1),
+        DataType::new(0),
     ));
 
     cell.add(Path::new(
@@ -668,8 +668,8 @@ fn test_single_cell_with_all_element_types() {
             Point::integer(200, 50, units),
             Point::integer(200, 100, units),
         ],
-        2,
-        0,
+        Layer::new(2),
+        DataType::new(0),
         Some(PathType::Round),
         Some(Unit::float(5.0, units)),
     ));
@@ -677,8 +677,8 @@ fn test_single_cell_with_all_element_types() {
     cell.add(Text::new(
         "All Elements",
         Point::integer(250, 50, units),
-        3,
-        0,
+        Layer::new(3),
+        DataType::new(0),
         2.0,
         0.0,
         false,
@@ -694,8 +694,8 @@ fn test_single_cell_with_all_element_types() {
             Point::integer(20, 20, units),
             Point::integer(0, 20, units),
         ],
-        4,
-        0,
+        Layer::new(4),
+        DataType::new(0),
     ));
     library.add_cell(ref_cell);
 
@@ -835,8 +835,8 @@ fn test_invalid_path() {
 
     let path = Path::new(
         vec![Point::integer(150, 50, units)],
-        2,
-        0,
+        Layer::new(2),
+        DataType::new(0),
         Some(PathType::Round),
         Some(Unit::float(5.0, units)),
     );
@@ -866,7 +866,7 @@ fn test_invalid_polygon() {
         polygon_points.push(Point::integer(i, 0, units));
     }
 
-    let polygon = Polygon::new(polygon_points, 1, 0);
+    let polygon = Polygon::new(polygon_points, Layer::new(1), DataType::new(0));
 
     cell.add(polygon);
 
@@ -928,8 +928,8 @@ fn test_max_coordinate_values_roundtrip() {
             Point::integer(i32::MIN, i32::MIN, units),
             Point::integer(i32::MAX, i32::MIN, units),
         ],
-        1,
-        0,
+        Layer::new(1),
+        DataType::new(0),
     ));
 
     library.add_cell(cell);
@@ -957,8 +957,8 @@ fn test_special_characters_in_cell_names_roundtrip() {
                 Point::integer(10, 10, units),
                 Point::integer(0, 10, units),
             ],
-            1,
-            0,
+            Layer::new(1),
+            DataType::new(0),
         ));
         library.add_cell(cell);
     }
@@ -989,8 +989,8 @@ fn test_all_presentation_combinations_roundtrip() {
             cell.add(Text::new(
                 &format!("{vp}_{hp}"),
                 Point::integer(0, y_offset, units),
-                1,
-                0,
+                Layer::new(1),
+                DataType::new(0),
                 1.0,
                 0.0,
                 false,
@@ -1019,8 +1019,8 @@ fn test_multiple_cells_referencing_same_cell() {
             Point::integer(5, 5, units),
             Point::integer(0, 5, units),
         ],
-        1,
-        0,
+        Layer::new(1),
+        DataType::new(0),
     ));
     library.add_cell(shared_cell);
 
@@ -1052,8 +1052,8 @@ fn test_polygon_invalid_layer() {
             Point::integer(10, 0, units),
             Point::integer(10, 10, units),
         ],
-        256,
-        0,
+        Layer::new(256),
+        DataType::new(0),
     ));
     library.add_cell(cell);
     assert_write_validation_error(&library);
@@ -1070,8 +1070,8 @@ fn test_polygon_invalid_data_type() {
             Point::integer(10, 0, units),
             Point::integer(10, 10, units),
         ],
-        0,
-        256,
+        Layer::new(0),
+        DataType::new(256),
     ));
     library.add_cell(cell);
     assert_write_validation_error(&library);
@@ -1084,8 +1084,8 @@ fn test_polygon_too_few_points() {
     let mut cell = Cell::new("cell");
     cell.add(Polygon::new(
         [Point::integer(0, 0, units), Point::integer(10, 0, units)],
-        0,
-        0,
+        Layer::new(0),
+        DataType::new(0),
     ));
     library.add_cell(cell);
     assert_write_validation_error(&library);
@@ -1098,8 +1098,8 @@ fn test_path_invalid_layer() {
     let mut cell = Cell::new("cell");
     cell.add(Path::new(
         vec![Point::integer(0, 0, units), Point::integer(10, 0, units)],
-        256,
-        0,
+        Layer::new(256),
+        DataType::new(0),
         None,
         None,
     ));
@@ -1114,8 +1114,8 @@ fn test_path_invalid_data_type() {
     let mut cell = Cell::new("cell");
     cell.add(Path::new(
         vec![Point::integer(0, 0, units), Point::integer(10, 0, units)],
-        0,
-        256,
+        Layer::new(0),
+        DataType::new(256),
         None,
         None,
     ));
@@ -1131,8 +1131,8 @@ fn test_text_invalid_layer() {
     cell.add(Text::new(
         "hello",
         Point::integer(0, 0, units),
-        256,
-        0,
+        Layer::new(256),
+        DataType::new(0),
         1.0,
         0.0,
         false,
@@ -1152,8 +1152,8 @@ fn test_text_string_too_long() {
     cell.add(Text::new(
         &long_string,
         Point::integer(0, 0, units),
-        0,
-        0,
+        Layer::new(0),
+        DataType::new(0),
         1.0,
         0.0,
         false,
@@ -1173,8 +1173,8 @@ fn test_text_string_at_max_length() {
     cell.add(Text::new(
         &max_string,
         Point::integer(0, 0, units),
-        0,
-        0,
+        Layer::new(0),
+        DataType::new(0),
         1.0,
         0.0,
         false,
@@ -1237,8 +1237,8 @@ fn test_reference_columns_exceed_max() {
             Point::integer(10, 10, units),
             Point::integer(0, 10, units),
         ],
-        0,
-        0,
+        Layer::new(0),
+        DataType::new(0),
     ));
     library.add_cell(base_cell);
 
@@ -1260,8 +1260,8 @@ fn test_reference_rows_exceed_max() {
             Point::integer(10, 10, units),
             Point::integer(0, 10, units),
         ],
-        0,
-        0,
+        Layer::new(0),
+        DataType::new(0),
     ));
     library.add_cell(base_cell);
 
@@ -1283,8 +1283,8 @@ fn test_reference_col_row_at_max() {
             Point::integer(10, 10, units),
             Point::integer(0, 10, units),
         ],
-        0,
-        0,
+        Layer::new(0),
+        DataType::new(0),
     ));
     library.add_cell(base_cell);
 
@@ -1310,8 +1310,8 @@ fn test_polygon_layer_and_data_type_at_boundary() {
             Point::integer(10, 10, units),
             Point::integer(0, 10, units),
         ],
-        255,
-        255,
+        Layer::new(255),
+        DataType::new(255),
     ));
     library.add_cell(cell);
     let temp_dir = tempdir().unwrap();

--- a/crates/gdsr/src/snapshots/gdsr__cell__tests__cell_get_elements-2.snap
+++ b/crates/gdsr/src/snapshots/gdsr__cell__tests__cell_get_elements-2.snap
@@ -6,15 +6,23 @@ expression: moved_elements
     Polygon(
         Polygon {
             points: [],
-            layer: 0,
-            data_type: 0,
+            layer: Layer(
+                0,
+            ),
+            data_type: DataType(
+                0,
+            ),
         },
     ),
     Path(
         Path {
             points: [],
-            layer: 0,
-            data_type: 0,
+            layer: Layer(
+                0,
+            ),
+            data_type: DataType(
+                0,
+            ),
             type: None,
             width: None,
         },
@@ -36,8 +44,12 @@ expression: moved_elements
                     },
                 ),
             },
-            layer: 0,
-            datatype: 0,
+            layer: Layer(
+                0,
+            ),
+            datatype: DataType(
+                0,
+            ),
             magnification: 1.0,
             angle: 0.0,
             x_reflection: false,
@@ -48,8 +60,12 @@ expression: moved_elements
     Polygon(
         Polygon {
             points: [],
-            layer: 0,
-            data_type: 0,
+            layer: Layer(
+                0,
+            ),
+            data_type: DataType(
+                0,
+            ),
         },
     ),
 ]

--- a/crates/gdsr/src/snapshots/gdsr__cell__tests__cell_get_elements-3.snap
+++ b/crates/gdsr/src/snapshots/gdsr__cell__tests__cell_get_elements-3.snap
@@ -6,15 +6,23 @@ expression: rotated_elements
     Polygon(
         Polygon {
             points: [],
-            layer: 0,
-            data_type: 0,
+            layer: Layer(
+                0,
+            ),
+            data_type: DataType(
+                0,
+            ),
         },
     ),
     Path(
         Path {
             points: [],
-            layer: 0,
-            data_type: 0,
+            layer: Layer(
+                0,
+            ),
+            data_type: DataType(
+                0,
+            ),
             type: None,
             width: None,
         },
@@ -36,8 +44,12 @@ expression: rotated_elements
                     },
                 ),
             },
-            layer: 0,
-            datatype: 0,
+            layer: Layer(
+                0,
+            ),
+            datatype: DataType(
+                0,
+            ),
             magnification: 1.0,
             angle: 90.0,
             x_reflection: false,
@@ -48,8 +60,12 @@ expression: rotated_elements
     Polygon(
         Polygon {
             points: [],
-            layer: 0,
-            data_type: 0,
+            layer: Layer(
+                0,
+            ),
+            data_type: DataType(
+                0,
+            ),
         },
     ),
 ]

--- a/crates/gdsr/src/snapshots/gdsr__cell__tests__cell_get_elements.snap
+++ b/crates/gdsr/src/snapshots/gdsr__cell__tests__cell_get_elements.snap
@@ -6,15 +6,23 @@ expression: elements
     Polygon(
         Polygon {
             points: [],
-            layer: 0,
-            data_type: 0,
+            layer: Layer(
+                0,
+            ),
+            data_type: DataType(
+                0,
+            ),
         },
     ),
     Path(
         Path {
             points: [],
-            layer: 0,
-            data_type: 0,
+            layer: Layer(
+                0,
+            ),
+            data_type: DataType(
+                0,
+            ),
             type: None,
             width: None,
         },
@@ -36,8 +44,12 @@ expression: elements
                     },
                 ),
             },
-            layer: 0,
-            datatype: 0,
+            layer: Layer(
+                0,
+            ),
+            datatype: DataType(
+                0,
+            ),
             magnification: 1.0,
             angle: 0.0,
             x_reflection: false,
@@ -48,8 +60,12 @@ expression: elements
     Polygon(
         Polygon {
             points: [],
-            layer: 0,
-            data_type: 0,
+            layer: Layer(
+                0,
+            ),
+            data_type: DataType(
+                0,
+            ),
         },
     ),
 ]

--- a/crates/gdsr/src/types.rs
+++ b/crates/gdsr/src/types.rs
@@ -1,3 +1,41 @@
-pub type Layer = u16;
-pub type DataType = u16;
+/// A GDS layer number (0–255 in spec, stored as `u16`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct Layer(u16);
+
+impl Layer {
+    pub const fn new(value: u16) -> Self {
+        Self(value)
+    }
+
+    pub const fn value(self) -> u16 {
+        self.0
+    }
+}
+
+impl std::fmt::Display for Layer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// A GDS data type number (0–255 in spec, stored as `u16`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct DataType(u16);
+
+impl DataType {
+    pub const fn new(value: u16) -> Self {
+        Self(value)
+    }
+
+    pub const fn value(self) -> u16 {
+        self.0
+    }
+}
+
+impl std::fmt::Display for DataType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 pub type AngleInRadians = f64;

--- a/crates/gdsr/src/utils/io.rs
+++ b/crates/gdsr/src/utils/io.rs
@@ -91,20 +91,26 @@ pub const MAX_COL_ROW: u32 = 32767;
 pub const MIN_POLYGON_POINTS: usize = 4;
 
 /// Returns an `InvalidInput` error if the layer is out of the GDS2 spec range (0-255).
-pub fn validate_layer(layer: u16) -> Result<(), GdsError> {
-    if layer > MAX_LAYER {
+pub fn validate_layer(layer: Layer) -> Result<(), GdsError> {
+    if layer.value() > MAX_LAYER {
         return Err(GdsError::ValidationError {
-            message: format!("Layer {layer} exceeds maximum value of {MAX_LAYER}"),
+            message: format!(
+                "Layer {} exceeds maximum value of {MAX_LAYER}",
+                layer.value()
+            ),
         });
     }
     Ok(())
 }
 
 /// Returns a validation error if the data type is out of the GDS2 spec range (0-255).
-pub fn validate_data_type(data_type: u16) -> Result<(), GdsError> {
-    if data_type > MAX_DATA_TYPE {
+pub fn validate_data_type(data_type: DataType) -> Result<(), GdsError> {
+    if data_type.value() > MAX_DATA_TYPE {
         return Err(GdsError::ValidationError {
-            message: format!("Data type {data_type} exceeds maximum value of {MAX_DATA_TYPE}"),
+            message: format!(
+                "Data type {} exceeds maximum value of {MAX_DATA_TYPE}",
+                data_type.value()
+            ),
         });
     }
     Ok(())
@@ -349,7 +355,7 @@ pub fn from_gds<P: AsRef<std::path::Path>>(
                 }
                 GDSRecord::Layer => {
                     if let GDSRecordData::I16(layer) = data {
-                        let layer_value = layer[0] as Layer;
+                        let layer_value = Layer::new(layer[0] as u16);
                         if let Some(polygon) = &mut polygon {
                             polygon.layer = layer_value;
                         } else if let Some(path) = &mut path {
@@ -361,7 +367,7 @@ pub fn from_gds<P: AsRef<std::path::Path>>(
                 }
                 GDSRecord::DataType | GDSRecord::BoxType => {
                     if let GDSRecordData::I16(data_type) = data {
-                        let data_type_val = data_type[0] as DataType;
+                        let data_type_val = DataType::new(data_type[0] as u16);
                         if let Some(polygon) = &mut polygon {
                             polygon.data_type = data_type_val;
                         } else if let Some(path) = &mut path {

--- a/scripts/benchmark/benchmark_gdsr.rs
+++ b/scripts/benchmark/benchmark_gdsr.rs
@@ -1,5 +1,5 @@
 use gdsr::{
-    Cell, Grid, HorizontalPresentation, Library, Path, PathType, Point, Polygon, Reference, Text,
+    Cell, DataType, Grid, HorizontalPresentation, Layer, Library, Path, PathType, Point, Polygon, Reference, Text,
     Unit, VerticalPresentation,
 };
 
@@ -42,7 +42,7 @@ fn build_library() -> Library {
                     )
                 })
                 .collect();
-            cell.add(Polygon::new(points, layer, (i % 8) as u16));
+            cell.add(Polygon::new(points, Layer::new(layer), DataType::new((i % 8) as u16)));
         }
 
         for i in 0_i32..250 {
@@ -53,8 +53,9 @@ fn build_library() -> Library {
                 .collect();
             cell.add(Path::new(
                 points,
-                ((c * 2 + i) % 64) as u16,
-                (i % 4) as u16,
+                Layer::new(((c * 2 + i) % 64) as u16),
+
+                DataType::new((i % 4) as u16),
                 Some(PATH_TYPES[i as usize % 3]),
                 Some(Unit::integer((i % 30 + 1) * 10, DB_UNITS)),
             ));
@@ -64,8 +65,9 @@ fn build_library() -> Library {
             cell.add(Text::new(
                 &format!("L{c}_text_{i:03}"),
                 point(i * 400, c * 1000),
-                ((c + i) % 64) as u16,
-                (i % 4) as u16,
+                Layer::new(((c + i) % 64) as u16),
+
+                DataType::new((i % 4) as u16),
                 1.0 + f64::from(i % 3) * 0.5,
                 f64::from(i % 8) * std::f64::consts::FRAC_PI_4,
                 i % 3 == 0,
@@ -104,8 +106,8 @@ fn build_library() -> Library {
                     point(i * 2000 + 1000, 1000),
                     point(i * 2000, 1000),
                 ],
-                (i % 16) as u16,
-                0,
+                Layer::new((i % 16) as u16),
+                DataType::new(0),
             ));
         }
 
@@ -123,8 +125,8 @@ fn build_library() -> Library {
                     point(i * 1000 + 500, 500),
                     point(i * 1000, 500),
                 ],
-                (i % 16) as u16,
-                0,
+                Layer::new((i % 16) as u16),
+                DataType::new(0),
             ));
         }
 


### PR DESCRIPTION
## Summary
- Replace `pub type Layer = u16` and `pub type DataType = u16` aliases with explicit newtype structs wrapping `u16`, each with `new()` and `value()` methods
- Propagate the new types across the entire codebase: core library, viewer, benchmarks, examples, property tests, and snapshot tests
- All call sites use explicit `Layer::new()` / `DataType::new()` constructors for full type safety

## Test plan
- All 607 existing tests pass with `cargo nextest run`
- Snapshot tests updated and accepted via `cargo insta test --accept`
- Pre-commit hooks (cargo check, clippy, fmt) pass cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)