### PR TITLE
Add path extension support (BgnExtn/EndExtn)

### DIFF
--- a/crates/gdsr-viewer/src/testutil.rs
+++ b/crates/gdsr-viewer/src/testutil.rs
@@ -28,6 +28,8 @@ pub mod helpers {
             DataType::new(data_type),
             None,
             width.map(Unit::default_integer),
+            None,
+            None,
         ))
     }
 

--- a/crates/gdsr/benches/benches/io.rs
+++ b/crates/gdsr/benches/benches/io.rs
@@ -57,6 +57,8 @@ fn medium_library() -> Library {
             DataType::new((i % 4) as u16),
             Some(PATH_TYPES[i as usize % 3]),
             Some(Unit::integer((i % 50 + 1) * 10, DB_UNITS)),
+            None,
+            None,
         ));
     }
 
@@ -115,6 +117,8 @@ fn complex_library() -> Library {
                 DataType::new((i % 4) as u16),
                 Some(PATH_TYPES[i as usize % 3]),
                 Some(Unit::integer((i % 30 + 1) * 10, DB_UNITS)),
+                None,
+                None,
             ));
         }
 

--- a/crates/gdsr/benches/io.rs
+++ b/crates/gdsr/benches/io.rs
@@ -57,6 +57,8 @@ fn medium_library() -> Library {
             DataType::new((i % 4) as u16),
             Some(PATH_TYPES[i as usize % 3]),
             Some(Unit::integer((i % 50 + 1) * 10, DB_UNITS)),
+            None,
+            None,
         ));
     }
 
@@ -118,6 +120,8 @@ fn complex_library() -> Library {
                 DataType::new((i % 4) as u16),
                 Some(PATH_TYPES[i as usize % 3]),
                 Some(Unit::integer((i % 30 + 1) * 10, DB_UNITS)),
+                None,
+                None,
             ));
         }
 

--- a/crates/gdsr/examples/sample.rs
+++ b/crates/gdsr/examples/sample.rs
@@ -50,6 +50,8 @@ fn main() -> Result<(), gdsr::GdsError> {
         DataType::new(0),
         Some(PathType::Square),
         Some(Unit::default_integer(50)),
+        None,
+        None,
     ));
     paths_cell.add(Path::new(
         vec![
@@ -61,6 +63,8 @@ fn main() -> Result<(), gdsr::GdsError> {
         DataType::new(0),
         Some(PathType::Round),
         Some(Unit::default_integer(100)),
+        None,
+        None,
     ));
     paths_cell.add(Path::new(
         vec![
@@ -71,6 +75,8 @@ fn main() -> Result<(), gdsr::GdsError> {
         DataType::new(0),
         Some(PathType::Overlap),
         Some(Unit::default_integer(75)),
+        None,
+        None,
     ));
 
     // Cell with text

--- a/crates/gdsr/src/cell.rs
+++ b/crates/gdsr/src/cell.rs
@@ -437,6 +437,8 @@ mod tests {
             DataType::new(0),
             None,
             None,
+            None,
+            None,
         ));
         cell.add(Text::default().set_origin(Point::float(5.0, 5.0, 1e-6)));
 
@@ -525,6 +527,8 @@ mod tests {
             DataType::new(0),
             None,
             None,
+            None,
+            None,
         ));
         cell.add(Text::default().set_origin(Point::integer(3, -2, 1e-9)));
 
@@ -585,6 +589,8 @@ mod tests {
             vec![Point::integer(0, 0, 1e-9), Point::integer(5, 5, 1e-9)],
             Layer::new(2),
             DataType::new(0),
+            None,
+            None,
             None,
             None,
         );

--- a/crates/gdsr/src/elements/element.rs
+++ b/crates/gdsr/src/elements/element.rs
@@ -192,6 +192,8 @@ mod tests {
             DataType::new(0),
             None,
             None,
+            None,
+            None,
         )
     }
 
@@ -351,6 +353,8 @@ mod tests {
             vec![p(-5, 3), p(10, 7)],
             Layer::new(1),
             DataType::new(0),
+            None,
+            None,
             None,
             None,
         );

--- a/crates/gdsr/src/elements/path.rs
+++ b/crates/gdsr/src/elements/path.rs
@@ -43,16 +43,20 @@ pub struct Path {
     pub(crate) data_type: DataType,
     pub(crate) r#type: Option<PathType>,
     pub(crate) width: Option<Unit>,
+    pub(crate) begin_extension: Option<Unit>,
+    pub(crate) end_extension: Option<Unit>,
 }
 
 impl Path {
-    /// Creates a new path from the given points, layer, data type, optional end cap type, and optional width.
+    /// Creates a new path from the given points, layer, data type, optional end cap type, optional width, and optional extensions.
     pub fn new(
         points: impl IntoIterator<Item = Point>,
         layer: Layer,
         data_type: DataType,
         path_type: Option<PathType>,
         width: Option<Unit>,
+        begin_extension: Option<Unit>,
+        end_extension: Option<Unit>,
     ) -> Self {
         Self {
             points: points.into_iter().collect(),
@@ -60,6 +64,8 @@ impl Path {
             data_type,
             r#type: path_type,
             width,
+            begin_extension,
+            end_extension,
         }
     }
 
@@ -88,22 +94,36 @@ impl Path {
         self.width
     }
 
-    /// Converts all points and width to integer units.
+    /// Returns the beginning extension distance, if set.
+    pub const fn begin_extension(&self) -> Option<Unit> {
+        self.begin_extension
+    }
+
+    /// Returns the end extension distance, if set.
+    pub const fn end_extension(&self) -> Option<Unit> {
+        self.end_extension
+    }
+
+    /// Converts all points, width, and extensions to integer units.
     #[must_use]
     pub fn to_integer_unit(self) -> Self {
         Self {
             points: self.points.iter().map(Point::to_integer_unit).collect(),
             width: self.width.map(Unit::to_integer_unit),
+            begin_extension: self.begin_extension.map(Unit::to_integer_unit),
+            end_extension: self.end_extension.map(Unit::to_integer_unit),
             ..self
         }
     }
 
-    /// Converts all points and width to float units.
+    /// Converts all points, width, and extensions to float units.
     #[must_use]
     pub fn to_float_unit(self) -> Self {
         Self {
             points: self.points.iter().map(Point::to_float_unit).collect(),
             width: self.width.map(Unit::to_float_unit),
+            begin_extension: self.begin_extension.map(Unit::to_float_unit),
+            end_extension: self.end_extension.map(Unit::to_float_unit),
             ..self
         }
     }
@@ -119,7 +139,14 @@ impl std::fmt::Display for Path {
             self.data_type(),
             self.path_type().unwrap_or_default(),
             self.width().unwrap_or_default()
-        )
+        )?;
+        if let Some(begin_ext) = self.begin_extension() {
+            write!(f, ", begin_extension {begin_ext}")?;
+        }
+        if let Some(end_ext) = self.end_extension() {
+            write!(f, ", end_extension {end_ext}")?;
+        }
+        Ok(())
     }
 }
 
@@ -208,6 +235,38 @@ impl ToGds for Path {
             buffer.write_all(&bytes)?;
         }
 
+        if let Some(begin_ext) = self.begin_extension() {
+            let scaled = begin_ext.scale_to(database_units);
+            let value = scaled.as_integer_unit().value as u32;
+            write_u16_array_to_file(
+                &mut buffer,
+                &[
+                    8,
+                    combine_record_and_data_type(
+                        GDSRecord::BgnExtn,
+                        GDSDataType::FourByteSignedInteger,
+                    ),
+                ],
+            )?;
+            buffer.write_all(&value.to_be_bytes())?;
+        }
+
+        if let Some(end_ext) = self.end_extension() {
+            let scaled = end_ext.scale_to(database_units);
+            let value = scaled.as_integer_unit().value as u32;
+            write_u16_array_to_file(
+                &mut buffer,
+                &[
+                    8,
+                    combine_record_and_data_type(
+                        GDSRecord::EndExtn,
+                        GDSDataType::FourByteSignedInteger,
+                    ),
+                ],
+            )?;
+            buffer.write_all(&value.to_be_bytes())?;
+        }
+
         write_points_to_file(&mut buffer, self.points(), database_units)?;
 
         write_element_tail_to_file(&mut buffer)?;
@@ -283,6 +342,8 @@ mod tests {
             DataType::new(2),
             Some(PathType::Round),
             Some(Unit::default_integer(10)),
+            Some(Unit::default_integer(5)),
+            Some(Unit::default_integer(15)),
         );
 
         assert_eq!(path.points(), &points);
@@ -290,6 +351,8 @@ mod tests {
         assert_eq!(path.data_type(), DataType::new(2));
         assert_eq!(path.path_type(), &Some(PathType::Round));
         assert_eq!(path.width(), Some(Unit::default_integer(10)));
+        assert_eq!(path.begin_extension(), Some(Unit::default_integer(5)));
+        assert_eq!(path.end_extension(), Some(Unit::default_integer(15)));
     }
 
     #[test]
@@ -301,6 +364,8 @@ mod tests {
         assert_eq!(path.data_type(), DataType::new(0));
         assert_eq!(path.path_type(), &None);
         assert_eq!(path.width(), None);
+        assert_eq!(path.begin_extension(), None);
+        assert_eq!(path.end_extension(), None);
     }
 
     #[test]
@@ -312,6 +377,8 @@ mod tests {
             DataType::new(10),
             Some(PathType::Square),
             Some(Unit::default_integer(20)),
+            None,
+            None,
         );
 
         insta::assert_snapshot!(path.to_string(), @"Path with 2 points on layer 5 with data type 10, Square and width 20 (1.000e-9)");
@@ -326,6 +393,8 @@ mod tests {
             DataType::new(2),
             Some(PathType::Round),
             Some(Unit::default_integer(5)),
+            None,
+            None,
         );
         let path2 = path1.clone();
 
@@ -337,6 +406,8 @@ mod tests {
             DataType::new(2),
             Some(PathType::Square),
             Some(Unit::default_integer(5)),
+            None,
+            None,
         );
         assert_ne!(path1, path3);
     }
@@ -350,6 +421,8 @@ mod tests {
             DataType::new(0),
             Some(PathType::Round),
             Some(Unit::default_float(5.0)),
+            None,
+            None,
         );
         let converted = path.to_integer_unit();
 
@@ -371,6 +444,8 @@ mod tests {
             DataType::new(0),
             None,
             Some(Unit::default_integer(10)),
+            None,
+            None,
         );
         let converted = path.to_float_unit();
 
@@ -386,7 +461,15 @@ mod tests {
     #[test]
     fn test_path_to_integer_unit_no_width() {
         let points = vec![Point::float(1.0, 2.0, 1e-6)];
-        let path = Path::new(points, Layer::new(0), DataType::new(0), None, None);
+        let path = Path::new(
+            points,
+            Layer::new(0),
+            DataType::new(0),
+            None,
+            None,
+            None,
+            None,
+        );
         let converted = path.to_integer_unit();
 
         assert_eq!(converted.width(), None);
@@ -395,7 +478,15 @@ mod tests {
     #[test]
     fn test_path_with_different_unit_points() {
         let points = vec![Point::integer(0, 0, 1e-9), Point::float(100.0, 100.0, 1e-6)];
-        let path = Path::new(points, Layer::new(0), DataType::new(0), None, None);
+        let path = Path::new(
+            points,
+            Layer::new(0),
+            DataType::new(0),
+            None,
+            None,
+            None,
+            None,
+        );
         assert_eq!(path.points().len(), 2);
     }
 
@@ -406,7 +497,15 @@ mod tests {
             Point::integer(10, 5, 1e-9),
             Point::integer(20, -3, 1e-9),
         ];
-        let path = Path::new(points, Layer::new(1), DataType::new(0), None, None);
+        let path = Path::new(
+            points,
+            Layer::new(1),
+            DataType::new(0),
+            None,
+            None,
+            None,
+            None,
+        );
         let (min, max) = path.bounding_box();
         assert_eq!(min, Point::integer(0, -3, 1e-9));
         assert_eq!(max, Point::integer(20, 5, 1e-9));
@@ -423,7 +522,15 @@ mod tests {
     #[test]
     fn test_path_bounding_box_single_point() {
         let points = vec![Point::integer(5, 10, 1e-9)];
-        let path = Path::new(points, Layer::new(1), DataType::new(0), None, None);
+        let path = Path::new(
+            points,
+            Layer::new(1),
+            DataType::new(0),
+            None,
+            None,
+            None,
+            None,
+        );
         let (min, max) = path.bounding_box();
         assert_eq!(min, Point::integer(5, 10, 1e-9));
         assert_eq!(max, Point::integer(5, 10, 1e-9));

--- a/crates/gdsr/src/elements/reference.rs
+++ b/crates/gdsr/src/elements/reference.rs
@@ -483,6 +483,8 @@ mod tests {
                 DataType::new(0),
                 None,
                 None,
+                None,
+                None,
             );
 
             let instance = Instance::from(path);

--- a/crates/gdsr/src/property_tests/arbitrary.rs
+++ b/crates/gdsr/src/property_tests/arbitrary.rs
@@ -214,7 +214,27 @@ impl Arbitrary for Path {
         } else {
             None
         };
-        Self::new(points, layer, data_type, path_type, width)
+        let begin_extension = if bool::arbitrary(g) {
+            let e = (i32::arbitrary(g) % MAX_VALUE).clamp(0, MAX_VALUE);
+            Some(Unit::integer(e, units))
+        } else {
+            None
+        };
+        let end_extension = if bool::arbitrary(g) {
+            let e = (i32::arbitrary(g) % MAX_VALUE).clamp(0, MAX_VALUE);
+            Some(Unit::integer(e, units))
+        } else {
+            None
+        };
+        Self::new(
+            points,
+            layer,
+            data_type,
+            path_type,
+            width,
+            begin_extension,
+            end_extension,
+        )
     }
 }
 
@@ -326,7 +346,27 @@ pub(super) fn arb_gds_path(g: &mut Gen) -> Path {
     } else {
         None
     };
-    Path::new(points, arb_layer(g), arb_data_type(g), path_type, width)
+    let begin_extension = if bool::arbitrary(g) {
+        let e = (i32::arbitrary(g) % MAX_VALUE).clamp(0, MAX_VALUE);
+        Some(Unit::integer(e, 1e-9))
+    } else {
+        None
+    };
+    let end_extension = if bool::arbitrary(g) {
+        let e = (i32::arbitrary(g) % MAX_VALUE).clamp(0, MAX_VALUE);
+        Some(Unit::integer(e, 1e-9))
+    } else {
+        None
+    };
+    Path::new(
+        points,
+        arb_layer(g),
+        arb_data_type(g),
+        path_type,
+        width,
+        begin_extension,
+        end_extension,
+    )
 }
 
 /// GDS `TextType` is always written as 0, so we use 0 here for roundtrip compatibility.

--- a/crates/gdsr/src/property_tests/path.rs
+++ b/crates/gdsr/src/property_tests/path.rs
@@ -1,6 +1,10 @@
 use quickcheck_macros::quickcheck;
 
+use crate::config::gds_file_types::GDSRecord;
+use crate::traits::ToGds;
+use crate::utils::io::RecordReader;
 use crate::*;
+use std::io::{BufReader, Cursor};
 
 #[quickcheck]
 fn bounding_box_contains_all_points(path: Path) -> bool {
@@ -24,4 +28,30 @@ fn translation_preserves_point_count(path: Path, dx: i32, dy: i32) -> bool {
     let delta = Point::integer(dx, dy, units);
     let translated = path.clone().translate(delta);
     translated.points().len() == path.points().len()
+}
+
+/// Verifies that BgnExtn/EndExtn records appear in serialized output iff the path has extensions.
+#[quickcheck]
+fn serialized_path_contains_extension_records(path: Path) -> bool {
+    if path.points().len() < 2 {
+        return true;
+    }
+    let Ok(bytes) = path.to_gds_impl(1e-9) else {
+        return true;
+    };
+
+    let reader = RecordReader::new(BufReader::new(Cursor::new(&bytes)));
+    let mut has_bgn_extn = false;
+    let mut has_end_extn = false;
+    for record in reader {
+        let Ok((rec, _)) = record else { continue };
+        match rec {
+            GDSRecord::BgnExtn => has_bgn_extn = true,
+            GDSRecord::EndExtn => has_end_extn = true,
+            _ => {}
+        }
+    }
+
+    has_bgn_extn == path.begin_extension().is_some()
+        && has_end_extn == path.end_extension().is_some()
 }

--- a/crates/gdsr/src/property_tests/validation.rs
+++ b/crates/gdsr/src/property_tests/validation.rs
@@ -57,6 +57,8 @@ fn get_elements(units: f64) -> Vec<Element> {
             DataType::new(0),
             Some(PathType::Round),
             Some(Unit::float(5.0, units)),
+            None,
+            None,
         )
         .into(),
         Path::new(
@@ -67,6 +69,8 @@ fn get_elements(units: f64) -> Vec<Element> {
             ],
             Layer::new(2),
             DataType::new(0),
+            None,
+            None,
             None,
             None,
         )
@@ -282,6 +286,8 @@ fn test_library_roundtrip_mixed_elements() {
         DataType::new(0),
         Some(PathType::Square),
         Some(Unit::float(2.0, units)),
+        None,
+        None,
     );
     cell.add(path);
 
@@ -430,6 +436,8 @@ fn test_complex_path_types_roundtrip() {
         DataType::new(0),
         Some(PathType::Square),
         Some(Unit::float(5.0, units)),
+        None,
+        None,
     ));
 
     cell.add(Path::new(
@@ -442,6 +450,8 @@ fn test_complex_path_types_roundtrip() {
         DataType::new(0),
         Some(PathType::Round),
         Some(Unit::float(3.0, units)),
+        None,
+        None,
     ));
 
     cell.add(Path::new(
@@ -450,6 +460,8 @@ fn test_complex_path_types_roundtrip() {
         DataType::new(0),
         Some(PathType::Overlap),
         Some(Unit::float(4.0, units)),
+        None,
+        None,
     ));
 
     library.add_cell(cell);
@@ -598,6 +610,8 @@ fn test_float_coordinates() {
         DataType::new(0),
         Some(PathType::Round),
         Some(Unit::float(1.5, units)),
+        None,
+        None,
     );
 
     cell.add(path);
@@ -672,6 +686,8 @@ fn test_single_cell_with_all_element_types() {
         DataType::new(0),
         Some(PathType::Round),
         Some(Unit::float(5.0, units)),
+        None,
+        None,
     ));
 
     cell.add(Text::new(
@@ -839,6 +855,8 @@ fn test_invalid_path() {
         DataType::new(0),
         Some(PathType::Round),
         Some(Unit::float(5.0, units)),
+        None,
+        None,
     );
 
     cell.add(path);
@@ -1102,6 +1120,8 @@ fn test_path_invalid_layer() {
         DataType::new(0),
         None,
         None,
+        None,
+        None,
     ));
     library.add_cell(cell);
     assert_write_validation_error(&library);
@@ -1116,6 +1136,8 @@ fn test_path_invalid_data_type() {
         vec![Point::integer(0, 0, units), Point::integer(10, 0, units)],
         Layer::new(0),
         DataType::new(256),
+        None,
+        None,
         None,
         None,
     ));

--- a/crates/gdsr/src/snapshots/gdsr__cell__tests__cell_get_elements-2.snap
+++ b/crates/gdsr/src/snapshots/gdsr__cell__tests__cell_get_elements-2.snap
@@ -25,6 +25,8 @@ expression: moved_elements
             ),
             type: None,
             width: None,
+            begin_extension: None,
+            end_extension: None,
         },
     ),
     Text(

--- a/crates/gdsr/src/snapshots/gdsr__cell__tests__cell_get_elements-3.snap
+++ b/crates/gdsr/src/snapshots/gdsr__cell__tests__cell_get_elements-3.snap
@@ -25,6 +25,8 @@ expression: rotated_elements
             ),
             type: None,
             width: None,
+            begin_extension: None,
+            end_extension: None,
         },
     ),
     Text(

--- a/crates/gdsr/src/snapshots/gdsr__cell__tests__cell_get_elements.snap
+++ b/crates/gdsr/src/snapshots/gdsr__cell__tests__cell_get_elements.snap
@@ -25,6 +25,8 @@ expression: elements
             ),
             type: None,
             width: None,
+            begin_extension: None,
+            end_extension: None,
         },
     ),
     Text(

--- a/crates/gdsr/src/utils/io.rs
+++ b/crates/gdsr/src/utils/io.rs
@@ -533,6 +533,22 @@ pub fn from_gds<P: AsRef<std::path::Path>>(
                         }
                     }
                 }
+                GDSRecord::BgnExtn => {
+                    if let GDSRecordData::I32(extn) = data {
+                        if let Some(path) = &mut path {
+                            let value = round_to_decimals(f64::from(extn[0]) * scale, 10);
+                            path.begin_extension = Some(Unit::float(value, db_units));
+                        }
+                    }
+                }
+                GDSRecord::EndExtn => {
+                    if let GDSRecordData::I32(extn) = data {
+                        if let Some(path) = &mut path {
+                            let value = round_to_decimals(f64::from(extn[0]) * scale, 10);
+                            path.end_extension = Some(Unit::float(value, db_units));
+                        }
+                    }
+                }
                 _ => {}
             },
             Err(e) => return Err(e),

--- a/scripts/benchmark/benchmark_gdsr.rs
+++ b/scripts/benchmark/benchmark_gdsr.rs
@@ -58,6 +58,8 @@ fn build_library() -> Library {
                 DataType::new((i % 4) as u16),
                 Some(PATH_TYPES[i as usize % 3]),
                 Some(Unit::integer((i % 30 + 1) * 10, DB_UNITS)),
+                None,
+                None,
             ));
         }
 


### PR DESCRIPTION
## Summary

- Add `begin_extension` and `end_extension` optional fields to `Path` for GDS II BgnExtn/EndExtn records
- Serialize BgnExtn (0x30) and EndExtn (0x31) records in GDS writer, preventing data loss on roundtrip
- Parse BgnExtn/EndExtn records in GDS reader using the same pattern as Width
- Add property test verifying extension record presence matches path field state
- Update `Arbitrary` impl to randomly generate extensions for fuzz testing

Closes #117

## Test plan

- All 542 gdsr tests pass including the existing `path_roundtrip` property test
- New `serialized_path_contains_extension_records` property test verifies BgnExtn/EndExtn records appear in output iff extensions are set
- Pre-commit checks (clippy, fmt, typos) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)