### PR TITLE
Add first-class GdsBox element type

### DIFF
--- a/crates/gdsr-viewer/src/drawable.rs
+++ b/crates/gdsr-viewer/src/drawable.rs
@@ -397,6 +397,113 @@ impl Drawable for gdsr::Text {
     }
 }
 
+impl Drawable for gdsr::GdsBox {
+    fn layer_keys(&self) -> Vec<(Layer, DataType)> {
+        vec![(self.layer(), self.box_type())]
+    }
+
+    fn world_bbox(&self) -> Option<WorldBBox> {
+        let (min_pt, max_pt) = self.bounding_box();
+        Some(WorldBBox::new(
+            min_pt.x().absolute_value(),
+            min_pt.y().absolute_value(),
+            max_pt.x().absolute_value(),
+            max_pt.y().absolute_value(),
+        ))
+    }
+
+    fn draw(&self, ctx: &mut DrawContext) {
+        let key = (self.layer(), self.box_type());
+        if ctx.layer_state.hidden_layers.contains(&key) {
+            return;
+        }
+
+        let points = self.points();
+
+        let Some(bbox) = self.world_bbox() else {
+            return;
+        };
+        if !bbox.overlaps(ctx.visible) {
+            return;
+        }
+
+        let s_min = ctx
+            .viewport
+            .world_to_screen(bbox.min_x, bbox.min_y, ctx.rect);
+        let s_max = ctx
+            .viewport
+            .world_to_screen(bbox.max_x, bbox.max_y, ctx.rect);
+        let sw = (s_max.x - s_min.x).abs();
+        let sh = (s_min.y - s_max.y).abs();
+
+        if sw < 2.0 && sh < 2.0 {
+            return;
+        }
+
+        let color = ctx.layer_state.layer_colors.get(key.0, key.1);
+        let fill = Color32::from_rgba_unmultiplied(color.r(), color.g(), color.b(), 80);
+
+        if sw < BBOX_FALLBACK_PX && sh < BBOX_FALLBACK_PX {
+            let bbox_rect = Rect::from_two_pos(s_min, s_max);
+            ctx.rect_filled(bbox_rect, 0.0, fill);
+            ctx.rect_stroke(bbox_rect, 0.0, Stroke::new(1.0, color), StrokeKind::Outside);
+            return;
+        }
+
+        ctx.screen_pts_buf.clear();
+        ctx.screen_pts_buf.extend(points.iter().map(|p| {
+            ctx.viewport
+                .world_to_screen(p.x().absolute_value(), p.y().absolute_value(), ctx.rect)
+        }));
+
+        let open_len = if ctx.screen_pts_buf.len() >= 2
+            && ctx.screen_pts_buf.first() == ctx.screen_pts_buf.last()
+        {
+            ctx.screen_pts_buf.len() - 1
+        } else {
+            ctx.screen_pts_buf.len()
+        };
+
+        if open_len < 3 {
+            return;
+        }
+
+        let coords: Vec<f64> = ctx.screen_pts_buf[..open_len]
+            .iter()
+            .flat_map(|p| [f64::from(p.x), f64::from(p.y)])
+            .collect();
+
+        let indices = if let Some(idx) = ctx.current_element_idx {
+            ctx.tessellation_cache
+                .entry(idx)
+                .or_insert_with(|| earcutr::earcut(&coords, &[], 2).unwrap_or_default())
+                .clone()
+        } else {
+            earcutr::earcut(&coords, &[], 2).unwrap_or_default()
+        };
+
+        let mut mesh = Mesh::default();
+        for pt in &ctx.screen_pts_buf[..open_len] {
+            mesh.vertices.push(egui::epaint::Vertex {
+                pos: *pt,
+                uv: egui::epaint::WHITE_UV,
+                color: fill,
+            });
+        }
+        for idx in indices {
+            mesh.indices.push(idx as u32);
+        }
+        ctx.merge_mesh(key, &mesh);
+
+        let outline = stroke_polyline_to_mesh(
+            &ctx.screen_pts_buf[..open_len],
+            Stroke::new(1.0, color),
+            true,
+        );
+        ctx.merge_mesh(key, &outline);
+    }
+}
+
 impl Drawable for gdsr::Reference {
     fn layer_keys(&self) -> Vec<(Layer, DataType)> {
         match self.instance().as_element() {
@@ -437,6 +544,11 @@ impl Drawable for gdsr::Reference {
                             el.draw(ctx);
                         }
                     }
+                    for gds_box in cell.boxes() {
+                        for el in self.get_elements_in_grid(&Element::Box(gds_box.clone())) {
+                            el.draw(ctx);
+                        }
+                    }
                     for text in cell.texts() {
                         for el in self.get_elements_in_grid(&Element::Text(text.clone())) {
                             el.draw(ctx);
@@ -458,6 +570,7 @@ impl Drawable for Element {
     fn layer_keys(&self) -> Vec<(Layer, DataType)> {
         match self {
             Self::Polygon(p) => p.layer_keys(),
+            Self::Box(b) => b.layer_keys(),
             Self::Path(p) => p.layer_keys(),
             Self::Text(t) => t.layer_keys(),
             Self::Reference(r) => r.layer_keys(),
@@ -467,6 +580,7 @@ impl Drawable for Element {
     fn world_bbox(&self) -> Option<WorldBBox> {
         match self {
             Self::Polygon(p) => p.world_bbox(),
+            Self::Box(b) => b.world_bbox(),
             Self::Path(p) => p.world_bbox(),
             Self::Text(t) => t.world_bbox(),
             Self::Reference(r) => r.world_bbox(),
@@ -476,6 +590,7 @@ impl Drawable for Element {
     fn draw(&self, ctx: &mut DrawContext) {
         match self {
             Self::Polygon(p) => p.draw(ctx),
+            Self::Box(b) => b.draw(ctx),
             Self::Path(p) => p.draw(ctx),
             Self::Text(t) => t.draw(ctx),
             Self::Reference(r) => r.draw(ctx),

--- a/crates/gdsr/src/cell.rs
+++ b/crates/gdsr/src/cell.rs
@@ -10,16 +10,17 @@ use crate::utils::io::{
     validate_structure_name, write_string_with_record_to_file, write_u16_array_to_file,
 };
 use crate::{
-    Dimensions, Element, Library, Movable, Path, Point, Polygon, Reference, Text, Transformable,
-    Transformation,
+    Dimensions, Element, GdsBox, Library, Movable, Path, Point, Polygon, Reference, Text,
+    Transformable, Transformation,
 };
 
-/// A named cell containing polygons, paths, texts, and references to other cells or elements.
+/// A named cell containing polygons, paths, boxes, texts, and references to other cells or elements.
 #[derive(Clone, Debug, PartialEq, Default)]
 pub struct Cell {
     name: String,
     polygons: Vec<Polygon>,
     paths: Vec<Path>,
+    boxes: Vec<GdsBox>,
     texts: Vec<Text>,
     references: Vec<Reference>,
 }
@@ -31,6 +32,7 @@ impl Cell {
             name: name.to_string(),
             polygons: Vec::new(),
             paths: Vec::new(),
+            boxes: Vec::new(),
             texts: Vec::new(),
             references: Vec::new(),
         }
@@ -53,6 +55,11 @@ impl Cell {
     /// Returns the paths in this cell.
     pub const fn paths(&self) -> &Vec<Path> {
         &self.paths
+    }
+
+    /// Returns the boxes in this cell.
+    pub const fn boxes(&self) -> &Vec<GdsBox> {
+        &self.boxes
     }
 
     /// Returns the texts in this cell.
@@ -79,6 +86,7 @@ impl Cell {
         match element.into() {
             Element::Path(path) => self.paths.push(path),
             Element::Polygon(polygon) => self.polygons.push(polygon),
+            Element::Box(gds_box) => self.boxes.push(gds_box),
             Element::Reference(reference) => self.references.push(reference),
             Element::Text(text) => self.texts.push(text),
         }
@@ -94,6 +102,11 @@ impl Cell {
                 .map(Polygon::to_integer_unit)
                 .collect(),
             paths: self.paths.into_iter().map(Path::to_integer_unit).collect(),
+            boxes: self
+                .boxes
+                .into_iter()
+                .map(GdsBox::to_integer_unit)
+                .collect(),
             texts: self.texts.into_iter().map(Text::to_integer_unit).collect(),
             references: self
                 .references
@@ -114,6 +127,7 @@ impl Cell {
                 .map(Polygon::to_float_unit)
                 .collect(),
             paths: self.paths.into_iter().map(Path::to_float_unit).collect(),
+            boxes: self.boxes.into_iter().map(GdsBox::to_float_unit).collect(),
             texts: self.texts.into_iter().map(Text::to_float_unit).collect(),
             references: self
                 .references
@@ -142,6 +156,12 @@ impl Cell {
 
         for path in &self.paths {
             if tx.send(Element::Path(path.clone())).is_err() {
+                return;
+            }
+        }
+
+        for gds_box in &self.boxes {
+            if tx.send(Element::Box(gds_box.clone())).is_err() {
                 return;
             }
         }
@@ -176,6 +196,10 @@ impl Cell {
             elements.push(Element::Path(path.clone()));
         }
 
+        for gds_box in &self.boxes {
+            elements.push(Element::Box(gds_box.clone()));
+        }
+
         for text in &self.texts {
             elements.push(Element::Text(text.clone()));
         }
@@ -195,10 +219,11 @@ impl std::fmt::Display for Cell {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(
             f,
-            "Cell '{}' with {} polygon(s), {} path(s), {} text(s)",
+            "Cell '{}' with {} polygon(s), {} path(s), {} box(es), {} text(s)",
             self.name,
             self.polygons.len(),
             self.paths.len(),
+            self.boxes.len(),
             self.texts.len(),
         )
     }
@@ -216,6 +241,12 @@ impl Transformable for Cell {
             .paths
             .into_iter()
             .map(|path| path.transform_impl(transformation))
+            .collect();
+
+        self.boxes = self
+            .boxes
+            .into_iter()
+            .map(|gds_box| gds_box.transform_impl(transformation))
             .collect();
 
         self.texts = self
@@ -247,6 +278,10 @@ impl Dimensions for Cell {
                 let (min, max) = p.bounding_box();
                 vec![min, max]
             }))
+            .chain(self.boxes.iter().flat_map(|b| {
+                let (min, max) = b.bounding_box();
+                vec![min, max]
+            }))
             .chain(self.texts.iter().flat_map(|t| {
                 let (min, max) = t.bounding_box();
                 vec![min, max]
@@ -269,6 +304,12 @@ impl Movable for Cell {
             .paths
             .into_iter()
             .map(|path| path.move_to(target))
+            .collect();
+
+        self.boxes = self
+            .boxes
+            .into_iter()
+            .map(|gds_box| gds_box.move_to(target))
             .collect();
 
         self.texts = self
@@ -335,6 +376,15 @@ impl ToGds for Cell {
             buffer.extend_from_slice(&b);
         }
 
+        let box_bufs: Result<Vec<_>, _> = self
+            .boxes
+            .par_iter()
+            .map(|b| b.to_gds_impl(database_units))
+            .collect();
+        for b in box_bufs? {
+            buffer.extend_from_slice(&b);
+        }
+
         let text_bufs: Result<Vec<_>, _> = self
             .texts
             .par_iter()
@@ -375,6 +425,7 @@ mod tests {
         assert_eq!(cell.name, "test_cell");
         assert!(cell.polygons().is_empty());
         assert!(cell.paths().is_empty());
+        assert!(cell.boxes().is_empty());
         assert!(cell.texts().is_empty());
         assert!(cell.references().is_empty());
     }
@@ -385,6 +436,7 @@ mod tests {
         assert_eq!(cell.name, "");
         assert!(cell.polygons.is_empty());
         assert!(cell.paths.is_empty());
+        assert!(cell.boxes.is_empty());
         assert!(cell.texts.is_empty());
         assert!(cell.references.is_empty());
     }
@@ -425,7 +477,7 @@ mod tests {
         let polygon = Polygon::default();
         cell.add(polygon);
 
-        insta::assert_snapshot!(cell.to_string(), @"Cell 'test_cell' with 1 polygon(s), 0 path(s), 0 text(s)");
+        insta::assert_snapshot!(cell.to_string(), @"Cell 'test_cell' with 1 polygon(s), 0 path(s), 0 box(es), 0 text(s)");
     }
 
     #[test]

--- a/crates/gdsr/src/elements/element.rs
+++ b/crates/gdsr/src/elements/element.rs
@@ -1,16 +1,18 @@
 use std::sync::Arc;
 
-use crate::elements::{Path, Polygon, Reference, Text};
+use crate::elements::{GdsBox, Path, Polygon, Reference, Text};
 use crate::traits::ToGds;
 use crate::{Dimensions, Instance, Movable, Point, Transformable, Transformation};
 
-/// A GDSII element: one of [`Path`], [`Polygon`], [`Text`], or [`Reference`].
+/// A GDSII element: one of [`Path`], [`Polygon`], [`GdsBox`], [`Text`], or [`Reference`].
 #[derive(Clone, Debug, PartialEq)]
 pub enum Element {
     /// A path element.
     Path(Path),
     /// A polygon element.
     Polygon(Polygon),
+    /// A box element.
+    Box(GdsBox),
     /// A text annotation element.
     Text(Text),
     /// A reference to another cell or element.
@@ -45,6 +47,15 @@ impl Element {
         }
     }
 
+    /// Returns the inner [`GdsBox`] if this is a `Box` variant, or `None`.
+    pub fn as_box(&self) -> Option<&GdsBox> {
+        if let Self::Box(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
     /// Returns the inner [`Reference`] if this is a `Reference` variant, or `None`.
     pub fn as_reference(&self) -> Option<&Reference> {
         if let Self::Reference(v) = self {
@@ -60,6 +71,7 @@ impl Element {
         match self {
             Self::Path(path) => Self::Path(path.to_integer_unit()),
             Self::Polygon(polygon) => Self::Polygon(polygon.to_integer_unit()),
+            Self::Box(gds_box) => Self::Box(gds_box.to_integer_unit()),
             Self::Text(text) => Self::Text(text.to_integer_unit()),
             Self::Reference(reference) => Self::Reference(reference.to_integer_unit()),
         }
@@ -71,6 +83,7 @@ impl Element {
         match self {
             Self::Path(path) => Self::Path(path.to_float_unit()),
             Self::Polygon(polygon) => Self::Polygon(polygon.to_float_unit()),
+            Self::Box(gds_box) => Self::Box(gds_box.to_float_unit()),
             Self::Text(text) => Self::Text(text.to_float_unit()),
             Self::Reference(reference) => Self::Reference(reference.to_float_unit()),
         }
@@ -82,6 +95,7 @@ impl std::fmt::Display for Element {
         match self {
             Self::Path(path) => write!(f, "{path}"),
             Self::Polygon(polygon) => write!(f, "{polygon}"),
+            Self::Box(gds_box) => write!(f, "{gds_box}"),
             Self::Text(text) => write!(f, "{text}"),
             Self::Reference(reference) => write!(f, "{reference}"),
         }
@@ -89,24 +103,31 @@ impl std::fmt::Display for Element {
 }
 
 macro_rules! impl_from_element_reference {
-    ($($type:ident),*) => {
-        $(
-            impl From<$type> for Element {
-                fn from(value: $type) -> Self {
-                    Element::$type(value)
-                }
+    (@impl $type:ident, $variant:ident) => {
+        impl From<$type> for Element {
+            fn from(value: $type) -> Self {
+                Self::$variant(value)
             }
+        }
 
-            impl From<$type> for Instance {
-                fn from(value: $type) -> Self {
-                    Element::from(value).into()
-                }
+        impl From<$type> for Instance {
+            fn from(value: $type) -> Self {
+                Element::from(value).into()
             }
-        )*
+        }
+    };
+    () => {};
+    ($type:ident => $variant:ident $(, $($rest:tt)*)?) => {
+        impl_from_element_reference!(@impl $type, $variant);
+        $(impl_from_element_reference!($($rest)*);)?
+    };
+    ($type:ident $(, $($rest:tt)*)?) => {
+        impl_from_element_reference!(@impl $type, $type);
+        $(impl_from_element_reference!($($rest)*);)?
     };
 }
 
-impl_from_element_reference!(Path, Polygon, Text, Reference);
+impl_from_element_reference!(Path, Polygon, GdsBox => Box, Text, Reference);
 
 impl From<Element> for Instance {
     fn from(v: Element) -> Self {
@@ -119,6 +140,7 @@ impl ToGds for Element {
         match self {
             Self::Path(path) => path.to_gds_impl(scale),
             Self::Polygon(polygon) => polygon.to_gds_impl(scale),
+            Self::Box(gds_box) => gds_box.to_gds_impl(scale),
             Self::Reference(reference) => reference.to_gds_impl(scale),
             Self::Text(text) => text.to_gds_impl(scale),
         }
@@ -130,6 +152,7 @@ impl Transformable for Element {
         match self {
             Self::Path(path) => Self::Path(path.transform_impl(transformation)),
             Self::Polygon(polygon) => Self::Polygon(polygon.transform_impl(transformation)),
+            Self::Box(gds_box) => Self::Box(gds_box.transform_impl(transformation)),
             Self::Reference(reference) => Self::Reference(reference.transform_impl(transformation)),
             Self::Text(text) => Self::Text(text.transform_impl(transformation)),
         }
@@ -141,6 +164,7 @@ impl Movable for Element {
         match self {
             Self::Path(path) => Self::Path(path.move_to(target)),
             Self::Polygon(polygon) => Self::Polygon(polygon.move_to(target)),
+            Self::Box(gds_box) => Self::Box(gds_box.move_to(target)),
             Self::Reference(reference) => Self::Reference(reference.move_to(target)),
             Self::Text(text) => Self::Text(text.move_to(target)),
         }
@@ -152,6 +176,7 @@ impl Dimensions for Element {
         match self {
             Self::Path(path) => path.bounding_box(),
             Self::Polygon(polygon) => polygon.bounding_box(),
+            Self::Box(gds_box) => gds_box.bounding_box(),
             Self::Text(text) => text.bounding_box(),
             Self::Reference(_) => (Point::default(), Point::default()),
         }
@@ -161,7 +186,7 @@ impl Dimensions for Element {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{DataType, Grid, Layer, Point};
+    use crate::{DataType, GdsBox, Grid, Layer, Point};
 
     const UNITS: f64 = 1e-9;
 
@@ -213,10 +238,15 @@ mod tests {
         Text::default()
     }
 
-    fn all_elements() -> [Element; 4] {
+    fn simple_gds_box() -> GdsBox {
+        GdsBox::new(p(0, 0), p(10, 10), Layer::new(1), DataType::new(0))
+    }
+
+    fn all_elements() -> [Element; 5] {
         [
             simple_path().into(),
             simple_polygon().into(),
+            simple_gds_box().into(),
             simple_text().into(),
             simple_reference().with_grid(simple_grid()).into(),
         ]
@@ -254,6 +284,20 @@ mod tests {
         assert_eq!(element.as_text().unwrap(), &text);
 
         insta::assert_snapshot!(element.to_string(), @"Text '' vertical: Middle, horizontal: Centre at Point(0 (1.000e-9), 0 (1.000e-9))");
+    }
+
+    #[test]
+    fn test_element_from_box() {
+        let gds_box = simple_gds_box();
+        let element: Element = gds_box.clone().into();
+
+        assert!(element.as_path().is_none());
+        assert!(element.as_polygon().is_none());
+        assert!(element.as_text().is_none());
+        assert!(element.as_reference().is_none());
+        assert_eq!(element.as_box().unwrap(), &gds_box);
+
+        insta::assert_snapshot!(element.to_string(), @"Box from (0.000000 (1.000e-9), 0.000000 (1.000e-9)) to (10.000000 (1.000e-9), 10.000000 (1.000e-9)) on layer 1, box type 0");
     }
 
     #[test]

--- a/crates/gdsr/src/elements/gds_box.rs
+++ b/crates/gdsr/src/elements/gds_box.rs
@@ -1,0 +1,287 @@
+use crate::config::gds_file_types::{GDSDataType, GDSRecord, combine_record_and_data_type};
+use crate::error::GdsError;
+use crate::traits::ToGds;
+use crate::utils::io::{
+    validate_data_type, validate_layer, write_element_tail_to_file, write_points_to_file,
+    write_u16_array_to_file,
+};
+use crate::{DataType, Dimensions, Layer, Movable, Point, Transformable};
+
+/// A GDS II Box element defined by two diagonal corners on a specific layer.
+///
+/// Internally stores the bottom-left and top-right corners. When written to GDS,
+/// the 5 closed points (4 corners + closing) are generated automatically.
+#[derive(Clone, Debug, PartialEq, Default)]
+pub struct GdsBox {
+    pub(crate) bottom_left: Point,
+    pub(crate) top_right: Point,
+    pub(crate) layer: Layer,
+    pub(crate) box_type: DataType,
+}
+
+impl GdsBox {
+    /// Creates a new box from two diagonal corner points, layer, and box type.
+    /// The corners are normalised so that `bottom_left` holds the minimum
+    /// coordinates and `top_right` holds the maximum.
+    pub fn new(corner1: Point, corner2: Point, layer: Layer, box_type: DataType) -> Self {
+        let (bottom_left, top_right) = Self::normalise_corners(corner1, corner2);
+        Self {
+            bottom_left,
+            top_right,
+            layer,
+            box_type,
+        }
+    }
+
+    fn normalise_corners(a: Point, b: Point) -> (Point, Point) {
+        crate::geometry::bounding_box(&[a, b])
+    }
+
+    /// Returns the bottom-left corner.
+    pub const fn bottom_left(&self) -> Point {
+        self.bottom_left
+    }
+
+    /// Returns the top-right corner.
+    pub const fn top_right(&self) -> Point {
+        self.top_right
+    }
+
+    /// Returns the top-left corner.
+    pub fn top_left(&self) -> Point {
+        Point::new(self.bottom_left.x(), self.top_right.y())
+    }
+
+    /// Returns the bottom-right corner.
+    pub fn bottom_right(&self) -> Point {
+        Point::new(self.top_right.x(), self.bottom_left.y())
+    }
+
+    /// Returns the centre point of the box.
+    pub fn center(&self) -> Point {
+        (self.bottom_left + self.top_right) * 0.5
+    }
+
+    /// Returns the 5 closed points (bottom-left, bottom-right, top-right, top-left, bottom-left)
+    /// as expected by the GDS format.
+    pub fn points(&self) -> [Point; 5] {
+        [
+            self.bottom_left,
+            self.bottom_right(),
+            self.top_right,
+            self.top_left(),
+            self.bottom_left,
+        ]
+    }
+
+    /// Returns the layer number.
+    pub const fn layer(&self) -> Layer {
+        self.layer
+    }
+
+    /// Returns the box type.
+    pub const fn box_type(&self) -> DataType {
+        self.box_type
+    }
+
+    /// Converts all points to integer units.
+    #[must_use]
+    pub fn to_integer_unit(self) -> Self {
+        Self {
+            bottom_left: self.bottom_left.to_integer_unit(),
+            top_right: self.top_right.to_integer_unit(),
+            ..self
+        }
+    }
+
+    /// Converts all points to float units.
+    #[must_use]
+    pub fn to_float_unit(self) -> Self {
+        Self {
+            bottom_left: self.bottom_left.to_float_unit(),
+            top_right: self.top_right.to_float_unit(),
+            ..self
+        }
+    }
+}
+
+impl std::fmt::Display for GdsBox {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "Box from ({}, {}) to ({}, {}) on layer {}, box type {}",
+            self.bottom_left.x(),
+            self.bottom_left.y(),
+            self.top_right.x(),
+            self.top_right.y(),
+            self.layer(),
+            self.box_type()
+        )
+    }
+}
+
+impl Transformable for GdsBox {
+    fn transform_impl(self, transformation: &crate::Transformation) -> Self {
+        let corners = [
+            self.bottom_left.transform(transformation),
+            self.top_right.transform(transformation),
+            self.top_left().transform(transformation),
+            self.bottom_right().transform(transformation),
+        ];
+        let (new_min, new_max) = crate::geometry::bounding_box(&corners);
+        Self {
+            bottom_left: new_min,
+            top_right: new_max,
+            ..self
+        }
+    }
+}
+
+impl Movable for GdsBox {
+    fn move_to(self, target: Point) -> Self {
+        let delta = target - self.bottom_left;
+        self.move_by(delta)
+    }
+}
+
+impl Dimensions for GdsBox {
+    fn bounding_box(&self) -> (Point, Point) {
+        (self.bottom_left, self.top_right)
+    }
+}
+
+impl ToGds for GdsBox {
+    fn to_gds_impl(&self, database_units: f64) -> Result<Vec<u8>, GdsError> {
+        validate_layer(self.layer())?;
+        validate_data_type(self.box_type())?;
+
+        let mut buffer = Vec::new();
+
+        let box_head = [
+            4,
+            combine_record_and_data_type(GDSRecord::Box, GDSDataType::NoData),
+            6,
+            combine_record_and_data_type(GDSRecord::Layer, GDSDataType::TwoByteSignedInteger),
+            self.layer().value(),
+            6,
+            combine_record_and_data_type(GDSRecord::BoxType, GDSDataType::TwoByteSignedInteger),
+            self.box_type().value(),
+        ];
+
+        write_u16_array_to_file(&mut buffer, &box_head)?;
+
+        let points = self.points();
+        write_points_to_file(&mut buffer, &points, database_units)?;
+
+        write_element_tail_to_file(&mut buffer)?;
+
+        Ok(buffer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn p(x: i32, y: i32) -> Point {
+        Point::integer(x, y, 1e-9)
+    }
+
+    #[test]
+    fn creation_normalises_corners() {
+        let gds_box = GdsBox::new(p(10, 10), p(0, 0), Layer::new(1), DataType::new(0));
+        assert_eq!(gds_box.bottom_left(), p(0, 0));
+        assert_eq!(gds_box.top_right(), p(10, 10));
+        assert_eq!(gds_box.layer(), Layer::new(1));
+        assert_eq!(gds_box.box_type(), DataType::new(0));
+    }
+
+    #[test]
+    fn default_is_zero() {
+        let gds_box = GdsBox::default();
+        assert_eq!(gds_box.bottom_left(), Point::default());
+        assert_eq!(gds_box.top_right(), Point::default());
+        assert_eq!(gds_box.layer(), Layer::default());
+        assert_eq!(gds_box.box_type(), DataType::default());
+    }
+
+    #[test]
+    fn corner_accessors() {
+        let gds_box = GdsBox::new(p(0, 0), p(10, 20), Layer::new(1), DataType::new(0));
+
+        insta::assert_snapshot!(format!("bottom_left: {}", gds_box.bottom_left()), @"bottom_left: Point(0.000000 (1.000e-9), 0.000000 (1.000e-9))");
+        insta::assert_snapshot!(format!("bottom_right: {}", gds_box.bottom_right()), @"bottom_right: Point(10.000000 (1.000e-9), 0.000000 (1.000e-9))");
+        insta::assert_snapshot!(format!("top_left: {}", gds_box.top_left()), @"top_left: Point(0.000000 (1.000e-9), 20.000000 (1.000e-9))");
+        insta::assert_snapshot!(format!("top_right: {}", gds_box.top_right()), @"top_right: Point(10.000000 (1.000e-9), 20.000000 (1.000e-9))");
+    }
+
+    #[test]
+    fn center() {
+        let gds_box = GdsBox::new(p(0, 0), p(10, 20), Layer::new(1), DataType::new(0));
+        insta::assert_snapshot!(format!("center: {}", gds_box.center()), @"center: Point(5.000000 (1.000e-9), 10.000000 (1.000e-9))");
+    }
+
+    #[test]
+    fn display() {
+        let gds_box = GdsBox::new(p(0, 0), p(5, 5), Layer::new(2), DataType::new(1));
+        insta::assert_snapshot!(gds_box.to_string(), @"Box from (0.000000 (1.000e-9), 0.000000 (1.000e-9)) to (5.000000 (1.000e-9), 5.000000 (1.000e-9)) on layer 2, box type 1");
+    }
+
+    #[test]
+    fn points_are_closed_rectangle() {
+        let gds_box = GdsBox::new(p(0, 0), p(10, 20), Layer::new(1), DataType::new(0));
+        let pts = gds_box.points();
+        assert_eq!(pts.len(), 5);
+        assert_eq!(pts[0], pts[4]);
+        assert_eq!(pts[0], p(0, 0));
+        assert_eq!(pts[1], p(10, 0));
+        assert_eq!(pts[2], p(10, 20));
+        assert_eq!(pts[3], p(0, 20));
+    }
+
+    #[test]
+    fn bounding_box() {
+        let gds_box = GdsBox::new(p(0, 0), p(10, 10), Layer::new(1), DataType::new(0));
+        let (min, max) = gds_box.bounding_box();
+        assert_eq!(min, p(0, 0));
+        assert_eq!(max, p(10, 10));
+    }
+
+    #[test]
+    fn move_to() {
+        let gds_box = GdsBox::new(p(0, 0), p(10, 10), Layer::new(1), DataType::new(0));
+        let moved = gds_box.move_to(p(5, 5));
+        assert_eq!(moved.bottom_left(), p(5, 5));
+        assert_eq!(moved.top_right(), p(15, 15));
+    }
+
+    #[test]
+    fn to_integer_unit() {
+        let gds_box = GdsBox::new(
+            Point::float(1.5, 2.5, 1e-6),
+            Point::float(10.0, 10.0, 1e-6),
+            Layer::new(1),
+            DataType::new(0),
+        );
+        let converted = gds_box.to_integer_unit();
+        assert_eq!(
+            converted.bottom_left(),
+            converted.bottom_left().to_integer_unit()
+        );
+        assert_eq!(
+            converted.top_right(),
+            converted.top_right().to_integer_unit()
+        );
+    }
+
+    #[test]
+    fn to_float_unit() {
+        let gds_box = GdsBox::new(p(0, 0), p(10, 10), Layer::new(1), DataType::new(0));
+        let converted = gds_box.to_float_unit();
+        assert_eq!(
+            converted.bottom_left(),
+            converted.bottom_left().to_float_unit()
+        );
+        assert_eq!(converted.top_right(), converted.top_right().to_float_unit());
+    }
+}

--- a/crates/gdsr/src/elements/mod.rs
+++ b/crates/gdsr/src/elements/mod.rs
@@ -1,10 +1,12 @@
 pub mod element;
+pub mod gds_box;
 pub mod path;
 pub mod polygon;
 pub mod reference;
 pub mod text;
 
 pub use element::Element;
+pub use gds_box::GdsBox;
 pub use path::{Path, PathType};
 pub use polygon::Polygon;
 pub use reference::{Instance, Reference};

--- a/crates/gdsr/src/elements/reference.rs
+++ b/crates/gdsr/src/elements/reference.rs
@@ -235,7 +235,7 @@ impl Reference {
                 }
             }
             Instance::Element(element) => match element.as_ref().as_ref() {
-                Element::Path(_) | Element::Polygon(_) | Element::Text(_) => {
+                Element::Path(_) | Element::Polygon(_) | Element::Box(_) | Element::Text(_) => {
                     self.send_elements_in_grid(element, tx)?;
                 }
                 Element::Reference(reference) => {
@@ -269,7 +269,7 @@ impl Reference {
                 }
             }
             Instance::Element(element) => match element.as_ref().as_ref() {
-                Element::Path(_) | Element::Polygon(_) | Element::Text(_) => {
+                Element::Path(_) | Element::Polygon(_) | Element::Box(_) | Element::Text(_) => {
                     elements.extend(self.get_elements_in_grid(element));
                 }
 

--- a/crates/gdsr/src/lib.rs
+++ b/crates/gdsr/src/lib.rs
@@ -16,7 +16,7 @@ mod utils;
 
 pub use cell::Cell;
 pub use elements::text::{HorizontalPresentation, VerticalPresentation};
-pub use elements::{Element, Instance, Path, PathType, Polygon, Reference, Text};
+pub use elements::{Element, GdsBox, Instance, Path, PathType, Polygon, Reference, Text};
 pub use error::GdsError;
 pub use grid::Grid;
 pub use library::{DanglingCellReference, Library};

--- a/crates/gdsr/src/property_tests/arbitrary.rs
+++ b/crates/gdsr/src/property_tests/arbitrary.rs
@@ -164,6 +164,25 @@ impl Arbitrary for Transformation {
     }
 }
 
+impl Arbitrary for GdsBox {
+    fn arbitrary(g: &mut Gen) -> Self {
+        let units_options = [1e-9, 1e-8, 1e-7, 1e-6];
+        let units = units_options[usize::arbitrary(g) % units_options.len()];
+        let x1 = (i32::arbitrary(g) % MAX_VALUE).clamp(-MAX_VALUE, MAX_VALUE);
+        let y1 = (i32::arbitrary(g) % MAX_VALUE).clamp(-MAX_VALUE, MAX_VALUE);
+        let x2 = (i32::arbitrary(g) % MAX_VALUE).clamp(-MAX_VALUE, MAX_VALUE);
+        let y2 = (i32::arbitrary(g) % MAX_VALUE).clamp(-MAX_VALUE, MAX_VALUE);
+        let layer = Layer::new(u16::arbitrary(g));
+        let box_type = DataType::new(u16::arbitrary(g));
+        Self::new(
+            Point::integer(x1, y1, units),
+            Point::integer(x2, y2, units),
+            layer,
+            box_type,
+        )
+    }
+}
+
 impl Arbitrary for Polygon {
     fn arbitrary(g: &mut Gen) -> Self {
         let units_options = [1e-9, 1e-8, 1e-7, 1e-6];
@@ -324,6 +343,15 @@ pub(super) fn arb_integer_point(g: &mut Gen) -> Point {
     let x = (i32::arbitrary(g) % MAX_VALUE).clamp(-MAX_VALUE, MAX_VALUE);
     let y = (i32::arbitrary(g) % MAX_VALUE).clamp(-MAX_VALUE, MAX_VALUE);
     Point::integer(x, y, 1e-9)
+}
+
+pub(super) fn arb_gds_box(g: &mut Gen) -> GdsBox {
+    GdsBox::new(
+        arb_integer_point(g),
+        arb_integer_point(g),
+        arb_layer(g),
+        arb_data_type(g),
+    )
 }
 
 pub(super) fn arb_gds_polygon(g: &mut Gen) -> Polygon {

--- a/crates/gdsr/src/property_tests/roundtrip.rs
+++ b/crates/gdsr/src/property_tests/roundtrip.rs
@@ -3,7 +3,7 @@ use quickcheck_macros::quickcheck;
 use tempfile::tempdir;
 
 use super::arbitrary::{
-    arb_gds_path, arb_gds_polygon, arb_gds_text, arb_integer_point, arb_structure_name,
+    arb_gds_box, arb_gds_path, arb_gds_polygon, arb_gds_text, arb_integer_point, arb_structure_name,
 };
 use crate::*;
 
@@ -53,11 +53,21 @@ fn text_roundtrip(_seed: u8) -> bool {
 }
 
 #[quickcheck]
+fn box_roundtrip(_seed: u8) -> bool {
+    let mut g = Gen::new(30);
+    let gds_box = arb_gds_box(&mut g);
+    let library = make_library("cell", vec![gds_box.into()]);
+    assert_roundtrip(&library);
+    true
+}
+
+#[quickcheck]
 fn mixed_elements_roundtrip(_seed: u8) -> bool {
     let mut g = Gen::new(30);
     let elements: Vec<Element> = vec![
         arb_gds_polygon(&mut g).into(),
         arb_gds_path(&mut g).into(),
+        arb_gds_box(&mut g).into(),
         arb_gds_text(&mut g).into(),
     ];
     let library = make_library("cell", elements);

--- a/crates/gdsr/src/utils/io.rs
+++ b/crates/gdsr/src/utils/io.rs
@@ -9,7 +9,7 @@ use crate::config::gds_file_types::{
     GDSDataType, GDSRecord, GDSRecordData, combine_record_and_data_type,
 };
 use crate::elements::text::get_presentations_from_value;
-use crate::elements::{Path, PathType, Polygon, Reference, Text};
+use crate::elements::{GdsBox, Path, PathType, Polygon, Reference, Text};
 use crate::error::GdsError;
 use crate::geometry::round_to_decimals;
 use crate::library::Library;
@@ -302,6 +302,7 @@ pub fn from_gds<P: AsRef<std::path::Path>>(
     let mut cell: Option<Cell> = None;
     let mut path: Option<Path> = None;
     let mut polygon: Option<Polygon> = None;
+    let mut gds_box: Option<GdsBox> = None;
     let mut text: Option<Text> = None;
     let mut reference: Option<Reference> = None;
 
@@ -341,8 +342,11 @@ pub fn from_gds<P: AsRef<std::path::Path>>(
                         library.cells.insert(cell.name().to_string(), cell);
                     }
                 }
-                GDSRecord::Boundary | GDSRecord::Box => {
+                GDSRecord::Boundary => {
                     polygon = Some(Polygon::default());
+                }
+                GDSRecord::Box => {
+                    gds_box = Some(GdsBox::default());
                 }
                 GDSRecord::Path => {
                     path = Some(Path::default());
@@ -358,6 +362,8 @@ pub fn from_gds<P: AsRef<std::path::Path>>(
                         let layer_value = Layer::new(layer[0] as u16);
                         if let Some(polygon) = &mut polygon {
                             polygon.layer = layer_value;
+                        } else if let Some(gds_box) = &mut gds_box {
+                            gds_box.layer = layer_value;
                         } else if let Some(path) = &mut path {
                             path.layer = layer_value;
                         } else if let Some(text) = &mut text {
@@ -365,13 +371,20 @@ pub fn from_gds<P: AsRef<std::path::Path>>(
                         }
                     }
                 }
-                GDSRecord::DataType | GDSRecord::BoxType => {
+                GDSRecord::DataType => {
                     if let GDSRecordData::I16(data_type) = data {
                         let data_type_val = DataType::new(data_type[0] as u16);
                         if let Some(polygon) = &mut polygon {
                             polygon.data_type = data_type_val;
                         } else if let Some(path) = &mut path {
                             path.data_type = data_type_val;
+                        }
+                    }
+                }
+                GDSRecord::BoxType => {
+                    if let GDSRecordData::I16(data_type) = data {
+                        if let Some(gds_box) = &mut gds_box {
+                            gds_box.box_type = DataType::new(data_type[0] as u16);
                         }
                     }
                 }
@@ -399,6 +412,10 @@ pub fn from_gds<P: AsRef<std::path::Path>>(
 
                         if let Some(polygon) = &mut polygon {
                             polygon.points = points;
+                        } else if let Some(gds_box) = &mut gds_box {
+                            let (min, max) = crate::geometry::bounding_box(&points);
+                            gds_box.bottom_left = min;
+                            gds_box.top_right = max;
                         } else if let Some(path) = &mut path {
                             path.points = points;
                         } else if let Some(reference) = &mut reference {
@@ -448,6 +465,8 @@ pub fn from_gds<P: AsRef<std::path::Path>>(
                     if let Some(cell) = &mut cell {
                         if let Some(polygon) = polygon.take() {
                             cell.add(polygon);
+                        } else if let Some(gds_box) = gds_box.take() {
+                            cell.add(gds_box);
                         } else if let Some(path) = path.take() {
                             cell.add(path);
                         } else if let Some(reference) = reference.take() {
@@ -457,6 +476,7 @@ pub fn from_gds<P: AsRef<std::path::Path>>(
                         }
                     }
                     polygon = None;
+                    gds_box = None;
                     path = None;
                     text = None;
                     reference = None;


### PR DESCRIPTION
## Summary

Closes #115

- Add dedicated `GdsBox` struct so GDS II Box elements (record type `0x2D`) are preserved through read/write cycles instead of being collapsed into `Polygon`/`Boundary`
- Parse `GDSRecord::Box` into `GdsBox` (with `BoxType`) separately from `GDSRecord::Boundary` into `Polygon` (with `DataType`)
- Write `GdsBox` back using correct `Box`/`BoxType` record types instead of `Boundary`/`DataType`
- Add `Box(GdsBox)` variant to `Element` enum with full trait support (Display, ToGds, Transformable, Movable, Dimensions)
- Add `boxes` field to `Cell` with accessor and integration into all cell operations
- Add viewer rendering support (same as Polygon — closed filled shape)
- Add property tests for roundtrip and arbitrary generation

## Test plan

- All 618 existing tests pass
- New unit tests for GdsBox creation, display, bounding box, move_to, unit conversions
- Property-based roundtrip test confirms Box elements survive write/read cycle with correct record types
- Mixed elements roundtrip test includes Box alongside Polygon, Path, and Text
- `uvx prek run -a` passes (clippy, fmt, etc.)