### PR TITLE
Add first-class Node element type

### DIFF
--- a/crates/gdsr-viewer/src/drawable.rs
+++ b/crates/gdsr-viewer/src/drawable.rs
@@ -504,6 +504,56 @@ impl Drawable for gdsr::GdsBox {
     }
 }
 
+impl Drawable for gdsr::Node {
+    fn layer_keys(&self) -> Vec<(Layer, DataType)> {
+        vec![(self.layer(), self.node_type())]
+    }
+
+    fn world_bbox(&self) -> Option<WorldBBox> {
+        let (min_pt, max_pt) = self.bounding_box();
+        Some(WorldBBox::new(
+            min_pt.x().absolute_value(),
+            min_pt.y().absolute_value(),
+            max_pt.x().absolute_value(),
+            max_pt.y().absolute_value(),
+        ))
+    }
+
+    fn draw(&self, ctx: &mut DrawContext) {
+        let key = (self.layer(), self.node_type());
+        if ctx.layer_state.hidden_layers.contains(&key) {
+            return;
+        }
+
+        let points = self.points();
+        if points.is_empty() {
+            return;
+        }
+
+        let Some(bbox) = self.world_bbox() else {
+            return;
+        };
+        if !bbox.overlaps(ctx.visible) {
+            return;
+        }
+
+        let color = ctx.layer_state.layer_colors.get(key.0, key.1);
+        let marker_size = 3.0_f32;
+
+        for point in points {
+            let screen = ctx.viewport.world_to_screen(
+                point.x().absolute_value(),
+                point.y().absolute_value(),
+                ctx.rect,
+            );
+            if ctx.rect.contains(screen) {
+                let rect = Rect::from_center_size(screen, egui::Vec2::splat(marker_size * 2.0));
+                ctx.rect_filled(rect, 0.0, color);
+            }
+        }
+    }
+}
+
 impl Drawable for gdsr::Reference {
     fn layer_keys(&self) -> Vec<(Layer, DataType)> {
         match self.instance().as_element() {
@@ -549,6 +599,11 @@ impl Drawable for gdsr::Reference {
                             el.draw(ctx);
                         }
                     }
+                    for node in cell.nodes() {
+                        for el in self.get_elements_in_grid(&Element::Node(node.clone())) {
+                            el.draw(ctx);
+                        }
+                    }
                     for text in cell.texts() {
                         for el in self.get_elements_in_grid(&Element::Text(text.clone())) {
                             el.draw(ctx);
@@ -571,6 +626,7 @@ impl Drawable for Element {
         match self {
             Self::Polygon(p) => p.layer_keys(),
             Self::Box(b) => b.layer_keys(),
+            Self::Node(n) => n.layer_keys(),
             Self::Path(p) => p.layer_keys(),
             Self::Text(t) => t.layer_keys(),
             Self::Reference(r) => r.layer_keys(),
@@ -581,6 +637,7 @@ impl Drawable for Element {
         match self {
             Self::Polygon(p) => p.world_bbox(),
             Self::Box(b) => b.world_bbox(),
+            Self::Node(n) => n.world_bbox(),
             Self::Path(p) => p.world_bbox(),
             Self::Text(t) => t.world_bbox(),
             Self::Reference(r) => r.world_bbox(),
@@ -591,6 +648,7 @@ impl Drawable for Element {
         match self {
             Self::Polygon(p) => p.draw(ctx),
             Self::Box(b) => b.draw(ctx),
+            Self::Node(n) => n.draw(ctx),
             Self::Path(p) => p.draw(ctx),
             Self::Text(t) => t.draw(ctx),
             Self::Reference(r) => r.draw(ctx),

--- a/crates/gdsr/src/cell.rs
+++ b/crates/gdsr/src/cell.rs
@@ -10,17 +10,18 @@ use crate::utils::io::{
     validate_structure_name, write_string_with_record_to_file, write_u16_array_to_file,
 };
 use crate::{
-    Dimensions, Element, GdsBox, Library, Movable, Path, Point, Polygon, Reference, Text,
+    Dimensions, Element, GdsBox, Library, Movable, Node, Path, Point, Polygon, Reference, Text,
     Transformable, Transformation,
 };
 
-/// A named cell containing polygons, paths, boxes, texts, and references to other cells or elements.
+/// A named cell containing polygons, paths, boxes, nodes, texts, and references to other cells or elements.
 #[derive(Clone, Debug, PartialEq, Default)]
 pub struct Cell {
     name: String,
     polygons: Vec<Polygon>,
     paths: Vec<Path>,
     boxes: Vec<GdsBox>,
+    nodes: Vec<Node>,
     texts: Vec<Text>,
     references: Vec<Reference>,
 }
@@ -33,6 +34,7 @@ impl Cell {
             polygons: Vec::new(),
             paths: Vec::new(),
             boxes: Vec::new(),
+            nodes: Vec::new(),
             texts: Vec::new(),
             references: Vec::new(),
         }
@@ -62,6 +64,11 @@ impl Cell {
         &self.boxes
     }
 
+    /// Returns the nodes in this cell.
+    pub const fn nodes(&self) -> &Vec<Node> {
+        &self.nodes
+    }
+
     /// Returns the texts in this cell.
     pub const fn texts(&self) -> &Vec<Text> {
         &self.texts
@@ -87,6 +94,7 @@ impl Cell {
             Element::Path(path) => self.paths.push(path),
             Element::Polygon(polygon) => self.polygons.push(polygon),
             Element::Box(gds_box) => self.boxes.push(gds_box),
+            Element::Node(node) => self.nodes.push(node),
             Element::Reference(reference) => self.references.push(reference),
             Element::Text(text) => self.texts.push(text),
         }
@@ -107,6 +115,7 @@ impl Cell {
                 .into_iter()
                 .map(GdsBox::to_integer_unit)
                 .collect(),
+            nodes: self.nodes.into_iter().map(Node::to_integer_unit).collect(),
             texts: self.texts.into_iter().map(Text::to_integer_unit).collect(),
             references: self
                 .references
@@ -128,6 +137,7 @@ impl Cell {
                 .collect(),
             paths: self.paths.into_iter().map(Path::to_float_unit).collect(),
             boxes: self.boxes.into_iter().map(GdsBox::to_float_unit).collect(),
+            nodes: self.nodes.into_iter().map(Node::to_float_unit).collect(),
             texts: self.texts.into_iter().map(Text::to_float_unit).collect(),
             references: self
                 .references
@@ -166,6 +176,12 @@ impl Cell {
             }
         }
 
+        for node in &self.nodes {
+            if tx.send(Element::Node(node.clone())).is_err() {
+                return;
+            }
+        }
+
         for text in &self.texts {
             if tx.send(Element::Text(text.clone())).is_err() {
                 return;
@@ -200,6 +216,10 @@ impl Cell {
             elements.push(Element::Box(gds_box.clone()));
         }
 
+        for node in &self.nodes {
+            elements.push(Element::Node(node.clone()));
+        }
+
         for text in &self.texts {
             elements.push(Element::Text(text.clone()));
         }
@@ -219,11 +239,12 @@ impl std::fmt::Display for Cell {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(
             f,
-            "Cell '{}' with {} polygon(s), {} path(s), {} box(es), {} text(s)",
+            "Cell '{}' with {} polygon(s), {} path(s), {} box(es), {} node(s), {} text(s)",
             self.name,
             self.polygons.len(),
             self.paths.len(),
             self.boxes.len(),
+            self.nodes.len(),
             self.texts.len(),
         )
     }
@@ -247,6 +268,12 @@ impl Transformable for Cell {
             .boxes
             .into_iter()
             .map(|gds_box| gds_box.transform_impl(transformation))
+            .collect();
+
+        self.nodes = self
+            .nodes
+            .into_iter()
+            .map(|node| node.transform_impl(transformation))
             .collect();
 
         self.texts = self
@@ -282,6 +309,10 @@ impl Dimensions for Cell {
                 let (min, max) = b.bounding_box();
                 vec![min, max]
             }))
+            .chain(self.nodes.iter().flat_map(|n| {
+                let (min, max) = n.bounding_box();
+                vec![min, max]
+            }))
             .chain(self.texts.iter().flat_map(|t| {
                 let (min, max) = t.bounding_box();
                 vec![min, max]
@@ -310,6 +341,12 @@ impl Movable for Cell {
             .boxes
             .into_iter()
             .map(|gds_box| gds_box.move_to(target))
+            .collect();
+
+        self.nodes = self
+            .nodes
+            .into_iter()
+            .map(|node| node.move_to(target))
             .collect();
 
         self.texts = self
@@ -385,6 +422,15 @@ impl ToGds for Cell {
             buffer.extend_from_slice(&b);
         }
 
+        let node_bufs: Result<Vec<_>, _> = self
+            .nodes
+            .par_iter()
+            .map(|n| n.to_gds_impl(database_units))
+            .collect();
+        for b in node_bufs? {
+            buffer.extend_from_slice(&b);
+        }
+
         let text_bufs: Result<Vec<_>, _> = self
             .texts
             .par_iter()
@@ -426,6 +472,7 @@ mod tests {
         assert!(cell.polygons().is_empty());
         assert!(cell.paths().is_empty());
         assert!(cell.boxes().is_empty());
+        assert!(cell.nodes().is_empty());
         assert!(cell.texts().is_empty());
         assert!(cell.references().is_empty());
     }
@@ -437,6 +484,7 @@ mod tests {
         assert!(cell.polygons.is_empty());
         assert!(cell.paths.is_empty());
         assert!(cell.boxes.is_empty());
+        assert!(cell.nodes.is_empty());
         assert!(cell.texts.is_empty());
         assert!(cell.references.is_empty());
     }
@@ -477,7 +525,7 @@ mod tests {
         let polygon = Polygon::default();
         cell.add(polygon);
 
-        insta::assert_snapshot!(cell.to_string(), @"Cell 'test_cell' with 1 polygon(s), 0 path(s), 0 box(es), 0 text(s)");
+        insta::assert_snapshot!(cell.to_string(), @"Cell 'test_cell' with 1 polygon(s), 0 path(s), 0 box(es), 0 node(s), 0 text(s)");
     }
 
     #[test]

--- a/crates/gdsr/src/elements/element.rs
+++ b/crates/gdsr/src/elements/element.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
-use crate::elements::{GdsBox, Path, Polygon, Reference, Text};
+use crate::elements::{GdsBox, Node, Path, Polygon, Reference, Text};
 use crate::traits::ToGds;
 use crate::{Dimensions, Instance, Movable, Point, Transformable, Transformation};
 
-/// A GDSII element: one of [`Path`], [`Polygon`], [`GdsBox`], [`Text`], or [`Reference`].
+/// A GDSII element: one of [`Path`], [`Polygon`], [`GdsBox`], [`Node`], [`Text`], or [`Reference`].
 #[derive(Clone, Debug, PartialEq)]
 pub enum Element {
     /// A path element.
@@ -13,6 +13,8 @@ pub enum Element {
     Polygon(Polygon),
     /// A box element.
     Box(GdsBox),
+    /// A node element.
+    Node(Node),
     /// A text annotation element.
     Text(Text),
     /// A reference to another cell or element.
@@ -56,6 +58,15 @@ impl Element {
         }
     }
 
+    /// Returns the inner [`Node`] if this is a `Node` variant, or `None`.
+    pub fn as_node(&self) -> Option<&Node> {
+        if let Self::Node(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
     /// Returns the inner [`Reference`] if this is a `Reference` variant, or `None`.
     pub fn as_reference(&self) -> Option<&Reference> {
         if let Self::Reference(v) = self {
@@ -72,6 +83,7 @@ impl Element {
             Self::Path(path) => Self::Path(path.to_integer_unit()),
             Self::Polygon(polygon) => Self::Polygon(polygon.to_integer_unit()),
             Self::Box(gds_box) => Self::Box(gds_box.to_integer_unit()),
+            Self::Node(node) => Self::Node(node.to_integer_unit()),
             Self::Text(text) => Self::Text(text.to_integer_unit()),
             Self::Reference(reference) => Self::Reference(reference.to_integer_unit()),
         }
@@ -84,6 +96,7 @@ impl Element {
             Self::Path(path) => Self::Path(path.to_float_unit()),
             Self::Polygon(polygon) => Self::Polygon(polygon.to_float_unit()),
             Self::Box(gds_box) => Self::Box(gds_box.to_float_unit()),
+            Self::Node(node) => Self::Node(node.to_float_unit()),
             Self::Text(text) => Self::Text(text.to_float_unit()),
             Self::Reference(reference) => Self::Reference(reference.to_float_unit()),
         }
@@ -96,6 +109,7 @@ impl std::fmt::Display for Element {
             Self::Path(path) => write!(f, "{path}"),
             Self::Polygon(polygon) => write!(f, "{polygon}"),
             Self::Box(gds_box) => write!(f, "{gds_box}"),
+            Self::Node(node) => write!(f, "{node}"),
             Self::Text(text) => write!(f, "{text}"),
             Self::Reference(reference) => write!(f, "{reference}"),
         }
@@ -127,7 +141,7 @@ macro_rules! impl_from_element_reference {
     };
 }
 
-impl_from_element_reference!(Path, Polygon, GdsBox => Box, Text, Reference);
+impl_from_element_reference!(Path, Polygon, GdsBox => Box, Node, Text, Reference);
 
 impl From<Element> for Instance {
     fn from(v: Element) -> Self {
@@ -141,6 +155,7 @@ impl ToGds for Element {
             Self::Path(path) => path.to_gds_impl(scale),
             Self::Polygon(polygon) => polygon.to_gds_impl(scale),
             Self::Box(gds_box) => gds_box.to_gds_impl(scale),
+            Self::Node(node) => node.to_gds_impl(scale),
             Self::Reference(reference) => reference.to_gds_impl(scale),
             Self::Text(text) => text.to_gds_impl(scale),
         }
@@ -153,6 +168,7 @@ impl Transformable for Element {
             Self::Path(path) => Self::Path(path.transform_impl(transformation)),
             Self::Polygon(polygon) => Self::Polygon(polygon.transform_impl(transformation)),
             Self::Box(gds_box) => Self::Box(gds_box.transform_impl(transformation)),
+            Self::Node(node) => Self::Node(node.transform_impl(transformation)),
             Self::Reference(reference) => Self::Reference(reference.transform_impl(transformation)),
             Self::Text(text) => Self::Text(text.transform_impl(transformation)),
         }
@@ -165,6 +181,7 @@ impl Movable for Element {
             Self::Path(path) => Self::Path(path.move_to(target)),
             Self::Polygon(polygon) => Self::Polygon(polygon.move_to(target)),
             Self::Box(gds_box) => Self::Box(gds_box.move_to(target)),
+            Self::Node(node) => Self::Node(node.move_to(target)),
             Self::Reference(reference) => Self::Reference(reference.move_to(target)),
             Self::Text(text) => Self::Text(text.move_to(target)),
         }
@@ -177,6 +194,7 @@ impl Dimensions for Element {
             Self::Path(path) => path.bounding_box(),
             Self::Polygon(polygon) => polygon.bounding_box(),
             Self::Box(gds_box) => gds_box.bounding_box(),
+            Self::Node(node) => node.bounding_box(),
             Self::Text(text) => text.bounding_box(),
             Self::Reference(_) => (Point::default(), Point::default()),
         }
@@ -186,7 +204,7 @@ impl Dimensions for Element {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{DataType, GdsBox, Grid, Layer, Point};
+    use crate::{DataType, GdsBox, Grid, Layer, Node, Point};
 
     const UNITS: f64 = 1e-9;
 
@@ -242,11 +260,16 @@ mod tests {
         GdsBox::new(p(0, 0), p(10, 10), Layer::new(1), DataType::new(0))
     }
 
-    fn all_elements() -> [Element; 5] {
+    fn simple_node() -> Node {
+        Node::new(vec![p(0, 0), p(5, 5)], Layer::new(1), DataType::new(0))
+    }
+
+    fn all_elements() -> [Element; 6] {
         [
             simple_path().into(),
             simple_polygon().into(),
             simple_gds_box().into(),
+            simple_node().into(),
             simple_text().into(),
             simple_reference().with_grid(simple_grid()).into(),
         ]
@@ -298,6 +321,21 @@ mod tests {
         assert_eq!(element.as_box().unwrap(), &gds_box);
 
         insta::assert_snapshot!(element.to_string(), @"Box from (0.000000 (1.000e-9), 0.000000 (1.000e-9)) to (10.000000 (1.000e-9), 10.000000 (1.000e-9)) on layer 1, box type 0");
+    }
+
+    #[test]
+    fn test_element_from_node() {
+        let node = simple_node();
+        let element: Element = node.clone().into();
+
+        assert!(element.as_path().is_none());
+        assert!(element.as_polygon().is_none());
+        assert!(element.as_box().is_none());
+        assert!(element.as_text().is_none());
+        assert!(element.as_reference().is_none());
+        assert_eq!(element.as_node().unwrap(), &node);
+
+        insta::assert_snapshot!(element.to_string(), @"Node with 2 point(s) on layer 1, node type 0");
     }
 
     #[test]

--- a/crates/gdsr/src/elements/mod.rs
+++ b/crates/gdsr/src/elements/mod.rs
@@ -1,5 +1,6 @@
 pub mod element;
 pub mod gds_box;
+pub mod node;
 pub mod path;
 pub mod polygon;
 pub mod reference;
@@ -7,6 +8,7 @@ pub mod text;
 
 pub use element::Element;
 pub use gds_box::GdsBox;
+pub use node::Node;
 pub use path::{Path, PathType};
 pub use polygon::Polygon;
 pub use reference::{Instance, Reference};

--- a/crates/gdsr/src/elements/node.rs
+++ b/crates/gdsr/src/elements/node.rs
@@ -1,0 +1,228 @@
+use crate::config::gds_file_types::{GDSDataType, GDSRecord, combine_record_and_data_type};
+use crate::error::GdsError;
+use crate::traits::ToGds;
+use crate::utils::io::{
+    validate_data_type, validate_layer, write_element_tail_to_file, write_points_to_file,
+    write_u16_array_to_file,
+};
+use crate::{DataType, Dimensions, Layer, Movable, Point, Transformable};
+
+/// Maximum number of points allowed in a GDS II Node element.
+pub const MAX_NODE_POINTS: usize = 50;
+
+/// A GDS II Node element used as a point-like marker for design verification (DRC/LVS).
+///
+/// Nodes contain 1–50 points on a specific layer with a node type qualifier.
+#[derive(Clone, Debug, PartialEq, Default)]
+#[expect(clippy::struct_field_names)]
+pub struct Node {
+    pub(crate) points: Vec<Point>,
+    pub(crate) layer: Layer,
+    pub(crate) node_type: DataType,
+}
+
+impl Node {
+    /// Creates a new node from points, layer, and node type.
+    /// Points beyond 50 are silently truncated to comply with the GDS spec.
+    pub fn new(points: impl Into<Vec<Point>>, layer: Layer, node_type: DataType) -> Self {
+        let mut points = points.into();
+        points.truncate(MAX_NODE_POINTS);
+        Self {
+            points,
+            layer,
+            node_type,
+        }
+    }
+
+    /// Returns the points in this node.
+    pub fn points(&self) -> &[Point] {
+        &self.points
+    }
+
+    /// Returns the layer number.
+    pub const fn layer(&self) -> Layer {
+        self.layer
+    }
+
+    /// Returns the node type.
+    pub const fn node_type(&self) -> DataType {
+        self.node_type
+    }
+
+    /// Converts all points to integer units.
+    #[must_use]
+    pub fn to_integer_unit(self) -> Self {
+        Self {
+            points: self
+                .points
+                .into_iter()
+                .map(|p| p.to_integer_unit())
+                .collect(),
+            ..self
+        }
+    }
+
+    /// Converts all points to float units.
+    #[must_use]
+    pub fn to_float_unit(self) -> Self {
+        Self {
+            points: self.points.into_iter().map(|p| p.to_float_unit()).collect(),
+            ..self
+        }
+    }
+}
+
+impl std::fmt::Display for Node {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "Node with {} point(s) on layer {}, node type {}",
+            self.points.len(),
+            self.layer(),
+            self.node_type()
+        )
+    }
+}
+
+impl Transformable for Node {
+    fn transform_impl(self, transformation: &crate::Transformation) -> Self {
+        Self {
+            points: self
+                .points
+                .into_iter()
+                .map(|p| p.transform(transformation))
+                .collect(),
+            ..self
+        }
+    }
+}
+
+impl Movable for Node {
+    fn move_to(self, target: Point) -> Self {
+        if let Some(&first) = self.points.first() {
+            let delta = target - first;
+            self.move_by(delta)
+        } else {
+            self
+        }
+    }
+}
+
+impl Dimensions for Node {
+    fn bounding_box(&self) -> (Point, Point) {
+        crate::geometry::bounding_box(&self.points)
+    }
+}
+
+impl ToGds for Node {
+    fn to_gds_impl(&self, database_units: f64) -> Result<Vec<u8>, GdsError> {
+        validate_layer(self.layer())?;
+        validate_data_type(self.node_type())?;
+
+        let mut buffer = Vec::new();
+
+        let node_head = [
+            4,
+            combine_record_and_data_type(GDSRecord::Node, GDSDataType::NoData),
+            6,
+            combine_record_and_data_type(GDSRecord::Layer, GDSDataType::TwoByteSignedInteger),
+            self.layer().value(),
+            6,
+            combine_record_and_data_type(GDSRecord::NodeType, GDSDataType::TwoByteSignedInteger),
+            self.node_type().value(),
+        ];
+
+        write_u16_array_to_file(&mut buffer, &node_head)?;
+        write_points_to_file(&mut buffer, &self.points, database_units)?;
+        write_element_tail_to_file(&mut buffer)?;
+
+        Ok(buffer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn p(x: i32, y: i32) -> Point {
+        Point::integer(x, y, 1e-9)
+    }
+
+    #[test]
+    fn creation() {
+        let node = Node::new(vec![p(1, 2), p(3, 4)], Layer::new(5), DataType::new(7));
+        assert_eq!(node.points().len(), 2);
+        assert_eq!(node.layer(), Layer::new(5));
+        assert_eq!(node.node_type(), DataType::new(7));
+    }
+
+    #[test]
+    fn truncates_beyond_max_points() {
+        let points: Vec<Point> = (0..60).map(|i| p(i, i)).collect();
+        let node = Node::new(points, Layer::new(0), DataType::new(0));
+        assert_eq!(node.points().len(), MAX_NODE_POINTS);
+    }
+
+    #[test]
+    fn default_is_empty() {
+        let node = Node::default();
+        assert!(node.points().is_empty());
+        assert_eq!(node.layer(), Layer::default());
+        assert_eq!(node.node_type(), DataType::default());
+    }
+
+    #[test]
+    fn display() {
+        let node = Node::new(vec![p(0, 0), p(5, 5)], Layer::new(2), DataType::new(1));
+        insta::assert_snapshot!(node.to_string(), @"Node with 2 point(s) on layer 2, node type 1");
+    }
+
+    #[test]
+    fn bounding_box() {
+        let node = Node::new(
+            vec![p(0, 0), p(10, 5), p(3, 20)],
+            Layer::new(1),
+            DataType::new(0),
+        );
+        let (min, max) = node.bounding_box();
+        assert_eq!(min, p(0, 0));
+        assert_eq!(max, p(10, 20));
+    }
+
+    #[test]
+    fn move_to() {
+        let node = Node::new(vec![p(0, 0), p(10, 10)], Layer::new(1), DataType::new(0));
+        let moved = node.move_to(p(5, 5));
+        assert_eq!(moved.points()[0], p(5, 5));
+        assert_eq!(moved.points()[1], p(15, 15));
+    }
+
+    #[test]
+    fn move_to_empty_is_noop() {
+        let node = Node::new(Vec::<Point>::new(), Layer::new(1), DataType::new(0));
+        let moved = node.clone().move_to(p(5, 5));
+        assert_eq!(moved, node);
+    }
+
+    #[test]
+    fn to_integer_unit() {
+        let node = Node::new(
+            vec![Point::float(1.5, 2.5, 1e-6), Point::float(10.0, 10.0, 1e-6)],
+            Layer::new(1),
+            DataType::new(0),
+        );
+        let converted = node.to_integer_unit();
+        for point in converted.points() {
+            assert_eq!(*point, point.to_integer_unit());
+        }
+    }
+
+    #[test]
+    fn to_float_unit() {
+        let node = Node::new(vec![p(0, 0), p(10, 10)], Layer::new(1), DataType::new(0));
+        let converted = node.to_float_unit();
+        for point in converted.points() {
+            assert_eq!(*point, point.to_float_unit());
+        }
+    }
+}

--- a/crates/gdsr/src/elements/reference.rs
+++ b/crates/gdsr/src/elements/reference.rs
@@ -235,7 +235,11 @@ impl Reference {
                 }
             }
             Instance::Element(element) => match element.as_ref().as_ref() {
-                Element::Path(_) | Element::Polygon(_) | Element::Box(_) | Element::Text(_) => {
+                Element::Path(_)
+                | Element::Polygon(_)
+                | Element::Box(_)
+                | Element::Node(_)
+                | Element::Text(_) => {
                     self.send_elements_in_grid(element, tx)?;
                 }
                 Element::Reference(reference) => {
@@ -269,7 +273,11 @@ impl Reference {
                 }
             }
             Instance::Element(element) => match element.as_ref().as_ref() {
-                Element::Path(_) | Element::Polygon(_) | Element::Box(_) | Element::Text(_) => {
+                Element::Path(_)
+                | Element::Polygon(_)
+                | Element::Box(_)
+                | Element::Node(_)
+                | Element::Text(_) => {
                     elements.extend(self.get_elements_in_grid(element));
                 }
 

--- a/crates/gdsr/src/lib.rs
+++ b/crates/gdsr/src/lib.rs
@@ -16,7 +16,7 @@ mod utils;
 
 pub use cell::Cell;
 pub use elements::text::{HorizontalPresentation, VerticalPresentation};
-pub use elements::{Element, GdsBox, Instance, Path, PathType, Polygon, Reference, Text};
+pub use elements::{Element, GdsBox, Instance, Node, Path, PathType, Polygon, Reference, Text};
 pub use error::GdsError;
 pub use grid::Grid;
 pub use library::{DanglingCellReference, Library};

--- a/crates/gdsr/src/property_tests/arbitrary.rs
+++ b/crates/gdsr/src/property_tests/arbitrary.rs
@@ -183,6 +183,24 @@ impl Arbitrary for GdsBox {
     }
 }
 
+impl Arbitrary for Node {
+    fn arbitrary(g: &mut Gen) -> Self {
+        let units_options = [1e-9, 1e-8, 1e-7, 1e-6];
+        let units = units_options[usize::arbitrary(g) % units_options.len()];
+        let num_points = 1 + (usize::arbitrary(g) % 50);
+        let points: Vec<Point> = (0..num_points)
+            .map(|_| {
+                let x = (i32::arbitrary(g) % MAX_VALUE).clamp(-MAX_VALUE, MAX_VALUE);
+                let y = (i32::arbitrary(g) % MAX_VALUE).clamp(-MAX_VALUE, MAX_VALUE);
+                Point::integer(x, y, units)
+            })
+            .collect();
+        let layer = Layer::new(u16::arbitrary(g));
+        let node_type = DataType::new(u16::arbitrary(g));
+        Self::new(points, layer, node_type)
+    }
+}
+
 impl Arbitrary for Polygon {
     fn arbitrary(g: &mut Gen) -> Self {
         let units_options = [1e-9, 1e-8, 1e-7, 1e-6];
@@ -343,6 +361,12 @@ pub(super) fn arb_integer_point(g: &mut Gen) -> Point {
     let x = (i32::arbitrary(g) % MAX_VALUE).clamp(-MAX_VALUE, MAX_VALUE);
     let y = (i32::arbitrary(g) % MAX_VALUE).clamp(-MAX_VALUE, MAX_VALUE);
     Point::integer(x, y, 1e-9)
+}
+
+pub(super) fn arb_gds_node(g: &mut Gen) -> Node {
+    let num_points = 1 + (usize::arbitrary(g) % 50);
+    let points: Vec<Point> = (0..num_points).map(|_| arb_integer_point(g)).collect();
+    Node::new(points, arb_layer(g), arb_data_type(g))
 }
 
 pub(super) fn arb_gds_box(g: &mut Gen) -> GdsBox {

--- a/crates/gdsr/src/property_tests/roundtrip.rs
+++ b/crates/gdsr/src/property_tests/roundtrip.rs
@@ -3,7 +3,8 @@ use quickcheck_macros::quickcheck;
 use tempfile::tempdir;
 
 use super::arbitrary::{
-    arb_gds_box, arb_gds_path, arb_gds_polygon, arb_gds_text, arb_integer_point, arb_structure_name,
+    arb_gds_box, arb_gds_node, arb_gds_path, arb_gds_polygon, arb_gds_text, arb_integer_point,
+    arb_structure_name,
 };
 use crate::*;
 
@@ -62,12 +63,22 @@ fn box_roundtrip(_seed: u8) -> bool {
 }
 
 #[quickcheck]
+fn node_roundtrip(_seed: u8) -> bool {
+    let mut g = Gen::new(30);
+    let node = arb_gds_node(&mut g);
+    let library = make_library("cell", vec![node.into()]);
+    assert_roundtrip(&library);
+    true
+}
+
+#[quickcheck]
 fn mixed_elements_roundtrip(_seed: u8) -> bool {
     let mut g = Gen::new(30);
     let elements: Vec<Element> = vec![
         arb_gds_polygon(&mut g).into(),
         arb_gds_path(&mut g).into(),
         arb_gds_box(&mut g).into(),
+        arb_gds_node(&mut g).into(),
         arb_gds_text(&mut g).into(),
     ];
     let library = make_library("cell", elements);

--- a/crates/gdsr/src/utils/io.rs
+++ b/crates/gdsr/src/utils/io.rs
@@ -9,7 +9,7 @@ use crate::config::gds_file_types::{
     GDSDataType, GDSRecord, GDSRecordData, combine_record_and_data_type,
 };
 use crate::elements::text::get_presentations_from_value;
-use crate::elements::{GdsBox, Path, PathType, Polygon, Reference, Text};
+use crate::elements::{GdsBox, Node, Path, PathType, Polygon, Reference, Text};
 use crate::error::GdsError;
 use crate::geometry::round_to_decimals;
 use crate::library::Library;
@@ -303,6 +303,7 @@ pub fn from_gds<P: AsRef<std::path::Path>>(
     let mut path: Option<Path> = None;
     let mut polygon: Option<Polygon> = None;
     let mut gds_box: Option<GdsBox> = None;
+    let mut node: Option<Node> = None;
     let mut text: Option<Text> = None;
     let mut reference: Option<Reference> = None;
 
@@ -348,6 +349,9 @@ pub fn from_gds<P: AsRef<std::path::Path>>(
                 GDSRecord::Box => {
                     gds_box = Some(GdsBox::default());
                 }
+                GDSRecord::Node => {
+                    node = Some(Node::default());
+                }
                 GDSRecord::Path => {
                     path = Some(Path::default());
                 }
@@ -364,6 +368,8 @@ pub fn from_gds<P: AsRef<std::path::Path>>(
                             polygon.layer = layer_value;
                         } else if let Some(gds_box) = &mut gds_box {
                             gds_box.layer = layer_value;
+                        } else if let Some(node) = &mut node {
+                            node.layer = layer_value;
                         } else if let Some(path) = &mut path {
                             path.layer = layer_value;
                         } else if let Some(text) = &mut text {
@@ -385,6 +391,13 @@ pub fn from_gds<P: AsRef<std::path::Path>>(
                     if let GDSRecordData::I16(data_type) = data {
                         if let Some(gds_box) = &mut gds_box {
                             gds_box.box_type = DataType::new(data_type[0] as u16);
+                        }
+                    }
+                }
+                GDSRecord::NodeType => {
+                    if let GDSRecordData::I16(data_type) = data {
+                        if let Some(node) = &mut node {
+                            node.node_type = DataType::new(data_type[0] as u16);
                         }
                     }
                 }
@@ -416,6 +429,8 @@ pub fn from_gds<P: AsRef<std::path::Path>>(
                             let (min, max) = crate::geometry::bounding_box(&points);
                             gds_box.bottom_left = min;
                             gds_box.top_right = max;
+                        } else if let Some(node) = &mut node {
+                            node.points = points;
                         } else if let Some(path) = &mut path {
                             path.points = points;
                         } else if let Some(reference) = &mut reference {
@@ -467,6 +482,8 @@ pub fn from_gds<P: AsRef<std::path::Path>>(
                             cell.add(polygon);
                         } else if let Some(gds_box) = gds_box.take() {
                             cell.add(gds_box);
+                        } else if let Some(node) = node.take() {
+                            cell.add(node);
                         } else if let Some(path) = path.take() {
                             cell.add(path);
                         } else if let Some(reference) = reference.take() {
@@ -477,6 +494,7 @@ pub fn from_gds<P: AsRef<std::path::Path>>(
                     }
                     polygon = None;
                     gds_box = None;
+                    node = None;
                     path = None;
                     text = None;
                     reference = None;


### PR DESCRIPTION
## Summary

Closes #114

- Add a public `Node` struct with `points`, `layer`, and `node_type` fields
- Implement `ToGds`, `Transformable`, `Movable`, and `Dimensions` traits
- Add `Node` variant to the `Element` enum with full trait delegation
- Parse `GDSRecord::Node` and `GDSRecord::NodeType` during file reading instead of silently ignoring them
- Serialize Node elements during file writing
- Add `nodes: Vec<Node>` field to `Cell` with accessor and integration in all cell operations (stream, flatten, transform, move, bounding box, serialization)
- Add `Drawable` impl for the viewer (renders node points as small square markers)
- Add `Arbitrary` impl and property-based roundtrip tests
- Add unit tests with inline snapshots

## Test plan

- All 640 existing tests pass
- New unit tests for Node struct (creation, truncation, display, bounding box, move, unit conversion)
- New `node_roundtrip` property test verifies write/read roundtrip
- Updated `mixed_elements_roundtrip` includes Node elements
- `cargo nextest run` passes
- `uvx prek run -a` passes (clippy, fmt, all hooks)