### PR TITLE
Add cell search/filter to viewer side panel

### DIFF
--- a/crates/gdsr-viewer/src/app.rs
+++ b/crates/gdsr-viewer/src/app.rs
@@ -257,6 +257,7 @@ impl eframe::App for ViewerApp {
                         &cell.layers,
                         layer_state,
                         cell.cell_stats.as_ref(),
+                        &mut cell.search_query,
                     );
                 }
             });

--- a/crates/gdsr-viewer/src/hierarchy.rs
+++ b/crates/gdsr-viewer/src/hierarchy.rs
@@ -72,6 +72,37 @@ fn build_node<'a>(
     }
 }
 
+/// Returns a filtered copy of the tree containing only nodes whose name matches
+/// the query (case-insensitive substring) or that have a matching descendant.
+/// An empty query returns a clone of the full tree.
+pub fn filter_tree(tree: &[CellTreeNode], query: &str) -> Vec<CellTreeNode> {
+    if query.is_empty() {
+        return tree.to_vec();
+    }
+    let query_lower = query.to_lowercase();
+    tree.iter()
+        .filter_map(|node| filter_node(node, &query_lower))
+        .collect()
+}
+
+fn filter_node(node: &CellTreeNode, query_lower: &str) -> Option<CellTreeNode> {
+    let name_matches = node.name.to_lowercase().contains(query_lower);
+    let filtered_children: Vec<CellTreeNode> = node
+        .children
+        .iter()
+        .filter_map(|child| filter_node(child, query_lower))
+        .collect();
+
+    if name_matches || !filtered_children.is_empty() {
+        Some(CellTreeNode {
+            name: node.name.clone(),
+            children: filtered_children,
+        })
+    } else {
+        None
+    }
+}
+
 /// Tracks which nodes in the hierarchy tree are expanded.
 #[derive(Clone, Debug, Default)]
 pub struct ExpandState {
@@ -552,6 +583,88 @@ mod tests {
     fn node_depth_empty_tree() {
         let tree: Vec<CellTreeNode> = vec![];
         assert_eq!(node_depth(&tree, "anything"), None);
+    }
+
+    #[test]
+    fn filter_tree_empty_query_returns_full_tree() {
+        let library = make_library(vec![
+            ("top", vec!["mid"]),
+            ("mid", vec!["bot"]),
+            ("bot", vec![]),
+        ]);
+        let tree = build_cell_tree(&library);
+        let filtered = filter_tree(&tree, "");
+        assert_eq!(filtered, tree);
+    }
+
+    #[test]
+    fn filter_tree_partial_match() {
+        let library = make_library(vec![
+            ("top", vec!["mid"]),
+            ("mid", vec!["bot"]),
+            ("bot", vec![]),
+        ]);
+        let tree = build_cell_tree(&library);
+        let filtered = filter_tree(&tree, "mi");
+        insta::assert_debug_snapshot!(filtered, @r#"
+        [
+            CellTreeNode {
+                name: "top",
+                children: [
+                    CellTreeNode {
+                        name: "mid",
+                        children: [],
+                    },
+                ],
+            },
+        ]
+        "#);
+    }
+
+    #[test]
+    fn filter_tree_no_match_returns_empty() {
+        let library = make_library(vec![("top", vec!["child"]), ("child", vec![])]);
+        let tree = build_cell_tree(&library);
+        let filtered = filter_tree(&tree, "xyz");
+        assert!(filtered.is_empty());
+    }
+
+    #[test]
+    fn filter_tree_deep_match_keeps_ancestors() {
+        let library = make_library(vec![
+            ("top", vec!["mid"]),
+            ("mid", vec!["deep_target"]),
+            ("deep_target", vec![]),
+        ]);
+        let tree = build_cell_tree(&library);
+        let filtered = filter_tree(&tree, "deep");
+        insta::assert_debug_snapshot!(filtered, @r#"
+        [
+            CellTreeNode {
+                name: "top",
+                children: [
+                    CellTreeNode {
+                        name: "mid",
+                        children: [
+                            CellTreeNode {
+                                name: "deep_target",
+                                children: [],
+                            },
+                        ],
+                    },
+                ],
+            },
+        ]
+        "#);
+    }
+
+    #[test]
+    fn filter_tree_case_insensitive() {
+        let library = make_library(vec![("MyCell", vec![])]);
+        let tree = build_cell_tree(&library);
+        let filtered = filter_tree(&tree, "mycell");
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].name, "MyCell");
     }
 
     #[test]

--- a/crates/gdsr-viewer/src/panels.rs
+++ b/crates/gdsr-viewer/src/panels.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeSet;
 use egui::{Ui, Vec2};
 use gdsr::{CellStats, DataType, Layer};
 
-use crate::hierarchy::{CellTreeNode, ExpandState};
+use crate::hierarchy::{self, CellTreeNode, ExpandState};
 use crate::state::LayerState;
 
 /// Draws the side panel with cell hierarchy tree, statistics, and layer toggles.
@@ -16,25 +16,43 @@ pub fn draw_side_panel(
     layers: &BTreeSet<(Layer, DataType)>,
     layer_state: &mut LayerState,
     cell_stats: Option<&CellStats>,
+    search_query: &mut String,
 ) {
     ui.heading("Cells");
 
+    ui.add(egui::TextEdit::singleline(search_query).hint_text("Search cells..."));
+
+    ui.add_space(4.0);
+
+    let is_filtering = !search_query.is_empty();
+    let filtered;
+    let display_tree = if is_filtering {
+        filtered = hierarchy::filter_tree(cell_tree, search_query);
+        &filtered
+    } else {
+        cell_tree
+    };
+
     ui.horizontal(|ui| {
         if ui.small_button("Expand All").clicked() {
-            expand_state.expand_all(cell_tree);
+            expand_state.expand_all(display_tree);
         }
         if ui.small_button("Collapse All").clicked() {
-            expand_state.collapse_all(cell_tree);
+            expand_state.collapse_all(display_tree);
         }
     });
 
     ui.add_space(4.0);
 
+    if is_filtering {
+        expand_state.expand_all(display_tree);
+    }
+
     egui::ScrollArea::vertical()
         .id_salt("cell_tree")
         .max_height(ui.available_height() * 0.5)
         .show(ui, |ui| {
-            for node in cell_tree {
+            for node in display_tree {
                 draw_tree_node(ui, node, selected_cell, cell_changed, expand_state);
             }
         });

--- a/crates/gdsr-viewer/src/state.rs
+++ b/crates/gdsr-viewer/src/state.rs
@@ -33,6 +33,7 @@ pub struct CellState {
     pub spatial_grid: Option<SpatialGrid>,
     pub tessellation_cache: HashMap<u32, Vec<usize>>,
     pub cell_stats: Option<CellStats>,
+    pub search_query: String,
 }
 
 impl CellState {
@@ -55,6 +56,7 @@ impl CellState {
             spatial_grid: None,
             tessellation_cache: HashMap::new(),
             cell_stats: None,
+            search_query: String::new(),
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add a search text field at the top of the Cells section in the viewer side panel
- Filter the cell tree by case-insensitive substring match as the user types
- Preserve ancestor nodes of matches so hierarchy context remains visible
- Auto-expand all nodes in the filtered tree so matches are immediately visible
- Add `filter_tree` function with 5 tests covering empty query, partial match, no match, deep match, and case insensitivity

Closes #148

## Test plan
- `cargo nextest run -p gdsr-viewer` — all 100 tests pass including 5 new filter tests
- `cargo nextest run` — full test suite passes
- `uvx prek run -a` — all pre-commit checks pass
- Manual: open a GDS file, type in the search box, verify tree filters and selecting a result loads the cell