### PR TITLE
Expand paths to true width for rendering

### DIFF
--- a/crates/gdsr-viewer/src/drawable.rs
+++ b/crates/gdsr-viewer/src/drawable.rs
@@ -333,20 +333,66 @@ impl Drawable for gdsr::Path {
             return;
         }
 
+        if let Some(poly_pts) = self.to_polygon_points(16) {
+            ctx.screen_pts_buf.clear();
+            ctx.screen_pts_buf.extend(poly_pts.iter().map(|p| {
+                ctx.viewport.world_to_screen(
+                    p.x().absolute_value(),
+                    p.y().absolute_value(),
+                    ctx.rect,
+                )
+            }));
+
+            let open_len = if ctx.screen_pts_buf.len() >= 2
+                && ctx.screen_pts_buf.first() == ctx.screen_pts_buf.last()
+            {
+                ctx.screen_pts_buf.len() - 1
+            } else {
+                ctx.screen_pts_buf.len()
+            };
+
+            if open_len >= 3 {
+                let fill = Color32::from_rgba_unmultiplied(color.r(), color.g(), color.b(), 80);
+
+                let coords: Vec<f64> = ctx.screen_pts_buf[..open_len]
+                    .iter()
+                    .flat_map(|p| [f64::from(p.x), f64::from(p.y)])
+                    .collect();
+
+                let indices = earcutr::earcut(&coords, &[], 2).unwrap_or_default();
+
+                let mut mesh = Mesh::default();
+                for pt in &ctx.screen_pts_buf[..open_len] {
+                    mesh.vertices.push(egui::epaint::Vertex {
+                        pos: *pt,
+                        uv: egui::epaint::WHITE_UV,
+                        color: fill,
+                    });
+                }
+                for idx in indices {
+                    mesh.indices.push(idx as u32);
+                }
+                ctx.merge_mesh(key, &mesh);
+
+                let outline = stroke_polyline_to_mesh(
+                    &ctx.screen_pts_buf[..open_len],
+                    Stroke::new(1.0, color),
+                    true,
+                );
+                ctx.merge_mesh(key, &outline);
+                return;
+            }
+        }
+
+        // Fallback: render as 1px centerline stroke
         ctx.screen_pts_buf.clear();
         ctx.screen_pts_buf.extend(points.iter().map(|p| {
             ctx.viewport
                 .world_to_screen(p.x().absolute_value(), p.y().absolute_value(), ctx.rect)
         }));
 
-        let width_px = self
-            .width()
-            .map(|w| (w.absolute_value() * ctx.viewport.zoom) as f32)
-            .unwrap_or(1.0)
-            .clamp(1.0, 20.0);
-
         let stroke_mesh =
-            stroke_polyline_to_mesh(ctx.screen_pts_buf, Stroke::new(width_px, color), false);
+            stroke_polyline_to_mesh(ctx.screen_pts_buf, Stroke::new(1.0, color), false);
         ctx.merge_mesh(key, &stroke_mesh);
     }
 }

--- a/crates/gdsr/src/elements/path.rs
+++ b/crates/gdsr/src/elements/path.rs
@@ -125,6 +125,57 @@ impl Path {
         }
     }
 
+    /// Expands this path to the polygon vertices representing its filled area.
+    ///
+    /// Returns `None` if the path has no width or fewer than 2 points.
+    /// `arc_segments` controls the number of segments used for round end caps.
+    pub fn to_polygon_points(&self, arc_segments: usize) -> Option<Vec<Point>> {
+        let width = self.width?;
+        if self.points.len() < 2 {
+            return None;
+        }
+
+        let half_width = width.absolute_value() / 2.0;
+        if half_width <= 0.0 {
+            return None;
+        }
+
+        let path_type = self.r#type.unwrap_or_default();
+        let begin_ext = self.begin_extension.map_or(0.0, |u| u.absolute_value());
+        let end_ext = self.end_extension.map_or(0.0, |u| u.absolute_value());
+
+        let units = self.points[0].units().0;
+        let centerline: Vec<(f64, f64)> = self
+            .points
+            .iter()
+            .map(|p| (p.x().float_value(), p.y().float_value()))
+            .collect();
+
+        let half_width_scaled = half_width / units;
+        let begin_ext_scaled = begin_ext / units;
+        let end_ext_scaled = end_ext / units;
+
+        let expanded = crate::geometry::expand_path_to_polygon(
+            &centerline,
+            half_width_scaled,
+            path_type,
+            begin_ext_scaled,
+            end_ext_scaled,
+            arc_segments,
+        );
+
+        if expanded.is_empty() {
+            return None;
+        }
+
+        Some(
+            expanded
+                .into_iter()
+                .map(|(x, y)| Point::float(x, y, units))
+                .collect(),
+        )
+    }
+
     /// Converts all points, width, and extensions to float units.
     #[must_use]
     pub fn to_float_unit(self) -> Self {

--- a/crates/gdsr/src/geometry/mod.rs
+++ b/crates/gdsr/src/geometry/mod.rs
@@ -2,6 +2,7 @@ mod area;
 mod bounding_box;
 mod is_point_inside;
 mod is_point_on_edge;
+pub(crate) mod path_expansion;
 mod perimeter;
 mod round;
 
@@ -9,6 +10,7 @@ pub use area::area;
 pub use bounding_box::bounding_box;
 pub use is_point_inside::is_point_inside;
 pub use is_point_on_edge::is_point_on_edge;
+pub use path_expansion::expand_path_to_polygon;
 pub use perimeter::perimeter;
 pub use round::round_to_decimals;
 

--- a/crates/gdsr/src/geometry/path_expansion.rs
+++ b/crates/gdsr/src/geometry/path_expansion.rs
@@ -1,0 +1,354 @@
+use crate::PathType;
+
+/// Expands a centerline path into a closed polygon outline.
+///
+/// Returns the polygon vertices that represent the filled area of the path,
+/// accounting for the path width and end-cap type. Returns an empty vec if
+/// fewer than 2 centerline points or non-positive `half_width`.
+pub fn expand_path_to_polygon(
+    centerline: &[(f64, f64)],
+    half_width: f64,
+    path_type: PathType,
+    begin_extension: f64,
+    end_extension: f64,
+    arc_segments: usize,
+) -> Vec<(f64, f64)> {
+    if centerline.len() < 2 || half_width <= 0.0 {
+        return Vec::new();
+    }
+
+    let pts = apply_extensions(centerline, path_type, begin_extension, end_extension);
+    let n = pts.len();
+
+    let normals: Vec<(f64, f64)> = (0..n - 1)
+        .map(|i| segment_normal(pts[i], pts[i + 1]))
+        .collect();
+
+    let mut left = Vec::with_capacity(n);
+    let mut right = Vec::with_capacity(n);
+
+    // First point
+    left.push(offset(pts[0], normals[0], half_width));
+    right.push(offset(pts[0], normals[0], -half_width));
+
+    // Interior points: miter join with bevel fallback
+    for i in 1..n - 1 {
+        miter_or_bevel(
+            pts[i],
+            normals[i - 1],
+            normals[i],
+            half_width,
+            &mut left,
+            &mut right,
+        );
+    }
+
+    // Last point
+    left.push(offset(pts[n - 1], normals[n - 2], half_width));
+    right.push(offset(pts[n - 1], normals[n - 2], -half_width));
+
+    // Build closed polygon: left forward + end cap + right reversed + begin cap
+    let mut polygon = Vec::with_capacity(left.len() + right.len() + 2 * arc_segments);
+
+    match path_type {
+        PathType::Round => {
+            polygon.extend_from_slice(&left);
+            polygon.extend(semicircle_cap(
+                pts[n - 1],
+                normals[n - 2],
+                half_width,
+                false,
+                arc_segments,
+            ));
+            polygon.extend(right.into_iter().rev());
+            polygon.extend(semicircle_cap(
+                pts[0],
+                normals[0],
+                half_width,
+                true,
+                arc_segments,
+            ));
+        }
+        PathType::Square | PathType::Overlap => {
+            polygon.extend_from_slice(&left);
+            right.reverse();
+            polygon.extend_from_slice(&right);
+        }
+    }
+
+    polygon
+}
+
+fn apply_extensions(
+    centerline: &[(f64, f64)],
+    path_type: PathType,
+    begin_ext: f64,
+    end_ext: f64,
+) -> Vec<(f64, f64)> {
+    let mut pts: Vec<(f64, f64)> = centerline.to_vec();
+    if path_type != PathType::Overlap {
+        return pts;
+    }
+    let n = pts.len();
+
+    // Extend first point backward along first segment
+    if begin_ext.abs() > f64::EPSILON {
+        let (dx, dy) = direction(pts[0], pts[1]);
+        pts[0].0 -= dx * begin_ext;
+        pts[0].1 -= dy * begin_ext;
+    }
+
+    // Extend last point forward along last segment
+    if end_ext.abs() > f64::EPSILON {
+        let (dx, dy) = direction(pts[n - 2], pts[n - 1]);
+        pts[n - 1].0 += dx * end_ext;
+        pts[n - 1].1 += dy * end_ext;
+    }
+
+    pts
+}
+
+fn direction(a: (f64, f64), b: (f64, f64)) -> (f64, f64) {
+    let dx = b.0 - a.0;
+    let dy = b.1 - a.1;
+    let len = (dx * dx + dy * dy).sqrt();
+    if len < f64::EPSILON {
+        return (0.0, 0.0);
+    }
+    (dx / len, dy / len)
+}
+
+fn segment_normal(a: (f64, f64), b: (f64, f64)) -> (f64, f64) {
+    let (dx, dy) = direction(a, b);
+    (-dy, dx)
+}
+
+fn offset(p: (f64, f64), normal: (f64, f64), dist: f64) -> (f64, f64) {
+    (p.0 + normal.0 * dist, p.1 + normal.1 * dist)
+}
+
+/// Computes miter join at an interior vertex, pushing results into left/right buffers.
+/// Falls back to bevel when the miter ratio exceeds 2.0.
+fn miter_or_bevel(
+    p: (f64, f64),
+    n0: (f64, f64),
+    n1: (f64, f64),
+    half_width: f64,
+    left: &mut Vec<(f64, f64)>,
+    right: &mut Vec<(f64, f64)>,
+) {
+    let avg_x = n0.0 + n1.0;
+    let avg_y = n0.1 + n1.1;
+    let dot = avg_x * avg_x + avg_y * avg_y;
+
+    if dot < 1e-10 || 1.0 / dot.sqrt() > 2.0 {
+        // Nearly opposite normals or miter too long — use bevel
+        left.push(offset(p, n0, half_width));
+        left.push(offset(p, n1, half_width));
+        right.push(offset(p, n1, -half_width));
+        right.push(offset(p, n0, -half_width));
+        return;
+    }
+
+    let scale = half_width * 2.0 / dot;
+    let miter = (avg_x * scale, avg_y * scale);
+    let s = dot.sqrt();
+
+    left.push((p.0 + miter.0 / 2.0 * s, p.1 + miter.1 / 2.0 * s));
+    right.push((p.0 - miter.0 / 2.0 * s, p.1 - miter.1 / 2.0 * s));
+}
+
+fn semicircle_cap(
+    center: (f64, f64),
+    normal: (f64, f64),
+    half_width: f64,
+    is_begin: bool,
+    segments: usize,
+) -> Vec<(f64, f64)> {
+    let segments = segments.max(4);
+    let mut pts = Vec::with_capacity(segments + 1);
+
+    // The cap goes from one side of the normal to the other, sweeping π radians
+    let start_angle = normal.1.atan2(normal.0);
+    let sweep = if is_begin {
+        std::f64::consts::PI
+    } else {
+        -std::f64::consts::PI
+    };
+
+    for i in 0..=segments {
+        let t = i as f64 / segments as f64;
+        let angle = start_angle + sweep * t;
+        pts.push((
+            center.0 + half_width * angle.cos(),
+            center.1 + half_width * angle.sin(),
+        ));
+    }
+
+    pts
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn horizontal_segment_square() {
+        let pts = expand_path_to_polygon(
+            &[(0.0, 0.0), (10.0, 0.0)],
+            1.0,
+            PathType::Square,
+            0.0,
+            0.0,
+            8,
+        );
+        insta::assert_debug_snapshot!(pts, @r"
+        [
+            (
+                0.0,
+                1.0,
+            ),
+            (
+                10.0,
+                1.0,
+            ),
+            (
+                10.0,
+                -1.0,
+            ),
+            (
+                0.0,
+                -1.0,
+            ),
+        ]
+        ");
+    }
+
+    #[test]
+    fn horizontal_segment_overlap() {
+        let pts = expand_path_to_polygon(
+            &[(0.0, 0.0), (10.0, 0.0)],
+            1.0,
+            PathType::Overlap,
+            2.0,
+            3.0,
+            8,
+        );
+        insta::assert_debug_snapshot!(pts, @r"
+        [
+            (
+                -2.0,
+                1.0,
+            ),
+            (
+                13.0,
+                1.0,
+            ),
+            (
+                13.0,
+                -1.0,
+            ),
+            (
+                -2.0,
+                -1.0,
+            ),
+        ]
+        ");
+    }
+
+    #[test]
+    fn horizontal_segment_round() {
+        let pts = expand_path_to_polygon(
+            &[(0.0, 0.0), (10.0, 0.0)],
+            1.0,
+            PathType::Round,
+            0.0,
+            0.0,
+            4,
+        );
+        // Left side + end semicircle + right side reversed + begin semicircle
+        assert!(pts.len() > 4, "Round cap should produce more points");
+        // First and last left-side points
+        assert!((pts[0].0 - 0.0).abs() < 1e-10);
+        assert!((pts[0].1 - 1.0).abs() < 1e-10);
+        assert!((pts[1].0 - 10.0).abs() < 1e-10);
+        assert!((pts[1].1 - 1.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn ninety_degree_corner() {
+        let pts = expand_path_to_polygon(
+            &[(0.0, 0.0), (10.0, 0.0), (10.0, 10.0)],
+            1.0,
+            PathType::Square,
+            0.0,
+            0.0,
+            8,
+        );
+        // Should produce a closed polygon with miter at the corner
+        assert!(pts.len() >= 6);
+    }
+
+    #[test]
+    fn collinear_segments() {
+        let pts = expand_path_to_polygon(
+            &[(0.0, 0.0), (5.0, 0.0), (10.0, 0.0)],
+            1.0,
+            PathType::Square,
+            0.0,
+            0.0,
+            8,
+        );
+        insta::assert_debug_snapshot!(pts, @r"
+        [
+            (
+                0.0,
+                1.0,
+            ),
+            (
+                5.0,
+                1.0,
+            ),
+            (
+                10.0,
+                1.0,
+            ),
+            (
+                10.0,
+                -1.0,
+            ),
+            (
+                5.0,
+                -1.0,
+            ),
+            (
+                0.0,
+                -1.0,
+            ),
+        ]
+        ");
+    }
+
+    #[test]
+    fn too_few_points_returns_empty() {
+        assert!(
+            expand_path_to_polygon(&[(0.0, 0.0)], 1.0, PathType::Square, 0.0, 0.0, 8).is_empty()
+        );
+        assert!(expand_path_to_polygon(&[], 1.0, PathType::Square, 0.0, 0.0, 8).is_empty());
+    }
+
+    #[test]
+    fn zero_width_returns_empty() {
+        assert!(
+            expand_path_to_polygon(
+                &[(0.0, 0.0), (10.0, 0.0)],
+                0.0,
+                PathType::Square,
+                0.0,
+                0.0,
+                8
+            )
+            .is_empty()
+        );
+    }
+}

--- a/crates/gdsr/src/property_tests/path.rs
+++ b/crates/gdsr/src/property_tests/path.rs
@@ -1,6 +1,7 @@
 use quickcheck_macros::quickcheck;
 
 use crate::config::gds_file_types::GDSRecord;
+use crate::geometry;
 use crate::traits::ToGds;
 use crate::utils::io::RecordReader;
 use crate::*;
@@ -54,4 +55,76 @@ fn serialized_path_contains_extension_records(path: Path) -> bool {
 
     has_bgn_extn == path.begin_extension().is_some()
         && has_end_extn == path.end_extension().is_some()
+}
+
+#[quickcheck]
+fn to_polygon_returns_none_without_width(path: Path) -> bool {
+    let no_width = Path::new(
+        path.points().to_vec(),
+        path.layer(),
+        path.data_type(),
+        *path.path_type(),
+        None,
+        path.begin_extension(),
+        path.end_extension(),
+    );
+    no_width.to_polygon_points(8).is_none()
+}
+
+/// For a straight-line path with Square type, expanded polygon area ≈ length × width.
+#[quickcheck]
+fn straight_path_area_matches_length_times_width(x_end: i16, width: u8) -> bool {
+    let x_end = i32::from(x_end).max(1);
+    let width = i32::from(width).max(1);
+    let units = 1e-6;
+
+    let path = Path::new(
+        vec![Point::integer(0, 0, units), Point::integer(x_end, 0, units)],
+        Layer::new(0),
+        DataType::new(0),
+        Some(PathType::Square),
+        Some(Unit::integer(width, units)),
+        None,
+        None,
+    );
+
+    let Some(poly_pts) = path.to_polygon_points(8) else {
+        return false;
+    };
+
+    // area() returns Unit::float(value, units) where value is in scaled coords
+    let computed_area = geometry::area(&poly_pts).float_value();
+    // In scaled coordinates: length = x_end, width = width
+    let expected = f64::from(x_end) * f64::from(width);
+    let rel_err = (computed_area - expected).abs() / expected.max(1e-10);
+    rel_err < 1e-6
+}
+
+/// All centerline points of a straight horizontal path should be inside the expanded polygon.
+#[quickcheck]
+fn centerline_points_inside_expanded_straight_path(x_end: i16, width: u8) -> bool {
+    let x_end = i32::from(x_end).max(1);
+    let width = i32::from(width).max(1);
+    let units = 1e-6;
+
+    let path = Path::new(
+        vec![Point::integer(0, 0, units), Point::integer(x_end, 0, units)],
+        Layer::new(0),
+        DataType::new(0),
+        Some(PathType::Square),
+        Some(Unit::integer(width, units)),
+        None,
+        None,
+    );
+
+    let Some(poly_pts) = path.to_polygon_points(16) else {
+        return false;
+    };
+    if poly_pts.len() < 3 {
+        return true;
+    }
+
+    path.points().iter().all(|p| {
+        geometry::is_point_inside(p, &poly_pts) || geometry::is_point_on_edge(p, &poly_pts)
+    })
 }


### PR DESCRIPTION
## Summary

- Add `expand_path_to_polygon()` algorithm in `geometry/path_expansion.rs` that converts path centerlines into closed polygon outlines with miter/bevel joins and support for Square, Round, and Overlap end caps
- Add `Path::to_polygon_points()` method that uses the expansion algorithm with proper unit handling
- Update viewer `Path::draw()` to render expanded paths as filled polygons (earcut triangulation + outline) matching the existing `Polygon::draw()` pipeline, with 1px centerline fallback for paths without width
- Add property tests verifying expanded area matches length×width for straight paths, centerline containment, and None return for widthless paths
- Add unit tests for horizontal segments, 90° corners, collinear segments, and edge cases

Closes #145

## Test plan
- `cargo nextest run` — all 690 tests pass
- `uvx prek run -a` — all linting/formatting checks pass
- Manual verification: open viewer with GDS files containing paths with width to confirm filled polygon rendering with correct end caps