### PR TITLE
Fix watch-merge command to use current branch PR

### DIFF
--- a/.claude/commands/watch-merge.md
+++ b/.claude/commands/watch-merge.md
@@ -6,12 +6,12 @@ description: Watch PR checks, fix failures, and squash merge
 ## Context
 
 - Current branch: !`git branch --show-current`
-- Latest PR: !`gh pr list --author @me --limit 1 --json number,title,url --jq '.[] | "#\(.number) \(.title) \(.url)"'`
+- Current PR: !`gh pr view --json number,title,url --jq '"#\(.number) \(.title) \(.url)"'`
 
 ## Your task
 
-1. Watch the most recent PR's checks using `gh pr checks <number> --watch` until they all complete
-2. If all checks pass, squash merge the PR with `gh pr merge <number> --squash --delete-branch`, then `git pull`
+1. Watch the current branch's PR checks using `gh pr checks --watch` until they all complete
+2. If all checks pass, squash merge the PR with `gh pr merge --squash --delete-branch`, then `git pull`
 3. If any checks fail:
    a. Inspect the failed check logs using `gh run view` to understand what went wrong
    b. Fix the issue in the code


### PR DESCRIPTION
## Summary

- Updated the watch-merge command to resolve the PR for the current branch (`gh pr view`) instead of fetching the most recent PR (`gh pr list --limit 1`)
- Removed explicit `<number>` arguments from `gh pr checks` and `gh pr merge` since they default to the current branch's PR

## Test plan

- Run `/watch-merge` from a branch with an open PR and verify it watches the correct PR