### PR TITLE
Disable benchmarks in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,8 @@ jobs:
 
     needs: determine_changes
 
-    if: ${{ (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
+    # Disabled until benchmarks are stabilized and actively maintained
+    if: false
 
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Disable the benchmarks CI job by setting `if: false` until benchmarks are stabilized and actively maintained
- The job definition is preserved so it can be easily re-enabled later

Closes #193

## Test plan
- Verify the benchmarks job is skipped in CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)