### PR TITLE
Add Claude Code commands for agent orchestration

### DIFF
--- a/.claude/commands/audit.md
+++ b/.claude/commands/audit.md
@@ -1,0 +1,33 @@
+---
+allowed-tools: Read, Glob, Grep, Bash(cargo clippy:*), Bash(cargo nextest:*)
+description: Audit the codebase for bugs, code smells, and improvement opportunities
+---
+
+## Context
+
+- Current branch: !`git branch --show-current`
+
+## Your task
+
+Audit the codebase for bugs, unsafe patterns, and code that should be rewritten.
+
+1. Run `cargo clippy --all-targets --all-features -- -D warnings`
+2. Search for problematic patterns: `.unwrap()`, `panic!`, `unreachable!`, `unsafe`, `#[allow(`, `todo!`
+3. Look for duplicated logic that should be shared
+4. Check for error handling that silently swallows failures
+5. Identify dead code, unused imports, or overly complex functions
+6. Check test coverage gaps — modules with logic but no tests
+
+### Output format
+
+Group findings by severity:
+
+**Bugs** — incorrect behavior or likely runtime failures
+
+**Safety** — unwrap/panic in non-test code, unsafe blocks
+
+**Code quality** — duplication, complexity, dead code
+
+**Missing tests** — untested modules or edge cases
+
+For each finding: `file:line` — what's wrong and what to do about it.

--- a/.claude/commands/next-issues.md
+++ b/.claude/commands/next-issues.md
@@ -1,0 +1,32 @@
+---
+allowed-tools: Bash(gh issue *), Bash(git log *), Read, Glob, Grep
+description: Find the best issues to work on next
+---
+
+## Context
+
+- Recent commits: !`git log --oneline -20`
+- Current open PRs: !`gh pr list --limit 10`
+
+## Your task
+
+Find the best GitHub issues to work on next. Analyze and rank them.
+
+### Steps
+
+1. Fetch all open issues: `gh issue list --limit 50 --json number,title,labels,body`
+2. Read the codebase structure to understand what areas are well-developed vs sparse
+3. Filter out:
+   - Issues labeled `needs-decision`
+   - Issues that overlap with any open PRs (already in progress)
+4. Rank remaining issues by:
+   - **Feasibility**: Can this be done in a single session? Does the codebase already have the infrastructure?
+   - **Impact**: Does this unblock other issues? Is it user-facing?
+   - **Clarity**: Is the issue well-specified enough to implement without ambiguity?
+5. Present the top 5-10 issues in a table:
+   - Issue number and title
+   - Why it's a good next pick (one sentence)
+   - Estimated complexity (small / medium / large)
+   - Any prerequisite issues
+
+Flag any issues that should be tackled together as a group.

--- a/.claude/commands/refactor.md
+++ b/.claude/commands/refactor.md
@@ -1,0 +1,20 @@
+---
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, Agent
+description: Refactor a specific area of the codebase
+---
+
+## Context
+
+- Current branch: !`git branch --show-current`
+- Current git status: !`git status`
+
+## Your task
+
+Refactor: **$ARGUMENTS**
+
+1. Explore the relevant area to understand the current structure
+2. Create a feature branch if still on main: `git checkout -b claude/refactor-<short-description>`
+3. Refactor with zero behavior changes — all existing tests must still pass
+4. Run `cargo nextest run` to verify nothing broke
+5. Run `uvx prek run -a` to pass pre-commit checks
+6. Do NOT commit — leave changes staged for review

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,0 +1,26 @@
+---
+allowed-tools: Read, Glob, Grep, Bash(cargo clippy:*), Bash(cargo nextest:*)
+description: Review current branch changes against project standards
+---
+
+## Context
+
+- Current branch: !`git branch --show-current`
+- Diff from main: !`git diff main...HEAD`
+- Unstaged changes: !`git diff`
+
+## Your task
+
+Review ALL changes on this branch against the project's CLAUDE.md standards.
+
+1. Read each changed file in full to understand context (don't rely solely on the diff)
+2. Check that tests exist and are appropriate for the changes
+3. Run `cargo clippy --all-targets --all-features -- -D warnings`
+4. Verify code follows the patterns in neighboring files
+
+### Output format
+
+**VERDICT: APPROVED** or **VERDICT: CHANGES_NEEDED**
+
+If changes needed, list specific actionable items:
+- file:line — what to fix and why

--- a/.claude/commands/work-on-issue.md
+++ b/.claude/commands/work-on-issue.md
@@ -1,0 +1,20 @@
+---
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, Agent
+description: Implement a GitHub issue on a feature branch
+---
+
+## Context
+
+- Current branch: !`git branch --show-current`
+- Current git status: !`git status`
+
+## Your task
+
+Implement GitHub issue **$ARGUMENTS**.
+
+1. Fetch the issue details: `gh issue view $ARGUMENTS`
+2. Explore the relevant area of the codebase to understand existing patterns
+3. Create a feature branch if still on main: `git checkout -b claude/<short-description>`
+4. Implement the feature/fix, write tests, run `cargo nextest run`
+5. Run `uvx prek run -a` to pass pre-commit checks
+6. Do NOT commit — leave changes staged for review


### PR DESCRIPTION
## Summary

- Add custom Claude Code commands for a manager/sub-agent workflow: `/work-on-issue`, `/review`, `/refactor`, `/audit`, `/next-issues`
- Each command has scoped tool permissions (e.g., review and audit are read-only)
- Enables parallel development sessions across multiple terminals

## Test plan

- Verify each command loads correctly in Claude Code
- Run `/next-issues` to confirm issue fetching works
- Run `/audit` to confirm codebase scanning works

Generated with [Claude Code](https://claude.com/claude-code)