### PR TITLE
Add color picker & fix render cache bug.

### DIFF
--- a/crates/gdsr-viewer/src/app.rs
+++ b/crates/gdsr-viewer/src/app.rs
@@ -310,6 +310,7 @@ impl eframe::App for ViewerApp {
         });
 
         let mut cell_changed = false;
+        let mut color_changed = false;
         let cell = &mut self.cell;
         let layer_state = &mut self.layer_state;
         egui::SidePanel::left("side_panel")
@@ -321,6 +322,7 @@ impl eframe::App for ViewerApp {
                         &cell.cell_tree,
                         &mut cell.selected_cell,
                         &mut cell_changed,
+                        &mut color_changed,
                         &mut cell.expand_state,
                         &cell.layers,
                         layer_state,
@@ -334,6 +336,11 @@ impl eframe::App for ViewerApp {
             if let Some(name) = self.cell.as_ref().and_then(|c| c.selected_cell.clone()) {
                 self.select_cell(&name);
             }
+        }
+
+        // Clearing render cache after changing color fixes the bug when color is not updated until user zooms out and back in.
+        if color_changed {
+            self.render_cache.clear();
         }
 
         let cell = &mut self.cell;

--- a/crates/gdsr-viewer/src/colors.rs
+++ b/crates/gdsr-viewer/src/colors.rs
@@ -38,6 +38,11 @@ impl LayerColorMap {
             color
         })
     }
+
+    /// Sets the color for the given layer/datatype pair.
+    pub fn set(&mut self, layer: Layer, datatype: DataType, color: Color32) {
+        self.map.insert((layer, datatype), color);
+    }
 }
 
 #[cfg(test)]

--- a/crates/gdsr-viewer/src/panels.rs
+++ b/crates/gdsr-viewer/src/panels.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeSet;
 
-use egui::{Ui, Vec2};
+use egui::Ui;
 use gdsr::{CellStats, DataType, Layer};
 
 use crate::hierarchy::{self, CellTreeNode, ExpandState};
@@ -12,6 +12,7 @@ pub fn draw_side_panel(
     cell_tree: &[CellTreeNode],
     selected_cell: &mut Option<String>,
     cell_changed: &mut bool,
+    color_changed: &mut bool,
     expand_state: &mut ExpandState,
     layers: &BTreeSet<(Layer, DataType)>,
     layer_state: &mut LayerState,
@@ -137,13 +138,15 @@ pub fn draw_side_panel(
         .max_height(ui.available_height() - 40.0)
         .show(ui, |ui| {
             for &(layer, dt) in layers {
-                let color = layer_state.layer_colors.get(layer, dt);
+                let mut color = layer_state.layer_colors.get(layer, dt);
                 let visible = !layer_state.hidden_layers.contains(&(layer, dt));
 
                 ui.horizontal(|ui| {
-                    let (response, painter) =
-                        ui.allocate_painter(Vec2::new(14.0, 14.0), egui::Sense::hover());
-                    painter.rect_filled(response.rect, 2.0, color);
+                    let response = ui.color_edit_button_srgba(&mut color);
+                    if response.changed() {
+                        layer_state.layer_colors.set(layer, dt, color);
+                        *color_changed = true;
+                    }
 
                     let mut checked = visible;
                     if ui

--- a/crates/gdsr-viewer/src/state.rs
+++ b/crates/gdsr-viewer/src/state.rs
@@ -174,6 +174,10 @@ impl RenderCache {
         self.populated = true;
     }
 
+    pub fn clear(&mut self) {
+        self.populated = false;
+    }
+
     pub fn layer_meshes(&self) -> &[((Layer, DataType), Mesh)] {
         &self.layer_meshes
     }


### PR DESCRIPTION
## Summary
<!-- What's the purpose of the change? What does it do, and why? -->
Resolves #159 by adding the color picker and fixing render cache bug.

Render Cache bug:
After implementing color picker, I've noticed that color does not change immediately. It only changed when user zoomed out/in. After some debugging, I've noticed that render cache is not updated after changing color. I've fixed it by creating a .clear() method in RenderCache struct and calling it after changing color.

**🚨New bug:**
If .gds file contains multiple inner layers, square's color will shimmer/flicker (I don't know how to call it) while changing color. It stabilizes once user chose the color. I think this bug have something to do with hidden_layers in LayerState being a HashMap.

## Test Plan

<!-- How was it tested? -->
Tested with two files. One contained 1 layer. 2nd contained 3 layers. Colors are changing but the flickering bug occurs when there are multiple inner layers.

Ran clippy without warnings and nexttest.
`     Summary [   6.499s] 739 tests run: 739 passed, 0 skipped`
