### PR TITLE
Redesign viewer UI with Zed-like panels and command palette

### DIFF
--- a/crates/gdsr-viewer/src/app.rs
+++ b/crates/gdsr-viewer/src/app.rs
@@ -4,9 +4,11 @@ use std::thread;
 
 use crate::drawable::Drawable;
 use crate::panels;
+use crate::quick_pick::{QuickPick, QuickPickResult};
+use crate::recent::RecentProjects;
 use crate::ruler::RulerState;
 use crate::spatial::SpatialGrid;
-use crate::state::{CellState, FileLoadState, LayerState, RenderCache};
+use crate::state::{CellState, CellViewMode, FileLoadState, LayerState, RenderCache, SidePanelTab};
 use crate::viewport::{self, Viewport};
 
 /// Returns shortcut text with the platform-appropriate modifier (⌘ on macOS, Ctrl on others).
@@ -31,6 +33,12 @@ pub struct ViewerApp {
     hovered_element: Option<usize>,
     /// Reusable scratch buffer for spatial grid point queries.
     query_buf: Vec<u32>,
+    side_panel_tab: SidePanelTab,
+    cell_view_mode: CellViewMode,
+    scroll_to_selected: bool,
+    recent_projects: RecentProjects,
+    cell_picker: QuickPick,
+    recent_picker: QuickPick,
 }
 
 impl Default for ViewerApp {
@@ -46,6 +54,12 @@ impl Default for ViewerApp {
             show_grid: true,
             hovered_element: None,
             query_buf: Vec::new(),
+            side_panel_tab: SidePanelTab::default(),
+            cell_view_mode: CellViewMode::default(),
+            scroll_to_selected: false,
+            recent_projects: RecentProjects::load(),
+            cell_picker: QuickPick::new("Search cells…"),
+            recent_picker: QuickPick::new("Recent projects…"),
         }
     }
 }
@@ -78,15 +92,13 @@ impl ViewerApp {
     /// Called when the background file loader completes successfully. Populates cell
     /// names and auto-selects the first cell.
     fn on_library_loaded(&mut self, library: gdsr::Library, path: PathBuf) {
+        self.recent_projects.add(&path);
+        self.recent_projects.save();
+
         let cell_state = CellState::new(library);
-        let first_cell = cell_state.cell_names.first().cloned();
         self.cell = Some(cell_state);
         self.file_load.file_path = Some(path);
         self.file_load.loading = false;
-
-        if let Some(name) = first_cell {
-            self.select_cell(&name);
-        }
     }
 
     /// Switches to a new cell, cancelling any in-flight element streaming and starting
@@ -94,6 +106,8 @@ impl ViewerApp {
     fn select_cell(&mut self, name: &str) {
         if let Some(cell) = self.cell.as_mut() {
             cell.selected_cell = Some(name.to_string());
+            cell.expand_state.set_expanded(name, true);
+            self.scroll_to_selected = true;
             cell.element_receiver = None;
             cell.elements.clear();
             cell.layers.clear();
@@ -124,6 +138,14 @@ impl ViewerApp {
                 self.viewport.zoom_to_fit(&bounds, rect);
             }
         }
+    }
+
+    /// Loads a file from a path (used by recent projects).
+    fn load_path(&mut self, path: &Path) {
+        let (path, rx) = crate::loader::load_request(path);
+        self.file_load.load_receiver = Some((path, rx));
+        self.file_load.loading = true;
+        self.file_load.error_message = None;
     }
 }
 
@@ -196,15 +218,24 @@ impl eframe::App for ViewerApp {
         if ctx.input(|i| i.key_pressed(egui::Key::G)) {
             self.show_grid = !self.show_grid;
         }
-        if ctx.input(|i| i.modifiers.command && i.key_pressed(egui::Key::O)) {
+        if ctx.input(|i| i.modifiers.command && i.key_pressed(egui::Key::O) && !i.modifiers.alt) {
             self.open_file_dialog();
+        }
+        if ctx.input(|i| i.modifiers.command && i.modifiers.alt && i.key_pressed(egui::Key::O)) {
+            self.recent_picker.toggle();
+        }
+        if ctx.input(|i| i.modifiers.command && i.key_pressed(egui::Key::P)) {
+            self.cell_picker.toggle();
         }
         if ctx.input(|i| i.modifiers.command && i.key_pressed(egui::Key::R)) {
             self.ruler.clear_all();
         } else if ctx.input(|i| i.key_pressed(egui::Key::R)) {
             self.ruler.toggle();
         }
-        if ctx.input(|i| i.key_pressed(egui::Key::Escape)) {
+        if ctx.input(|i| i.key_pressed(egui::Key::Escape))
+            && !self.cell_picker.is_open()
+            && !self.recent_picker.is_open()
+        {
             self.ruler.cancel();
         }
         if self.ruler.start.is_some() {
@@ -220,6 +251,16 @@ impl eframe::App for ViewerApp {
                     {
                         ui.close_kind(egui::UiKind::Menu);
                         self.open_file_dialog();
+                    }
+                    if ui
+                        .add(
+                            egui::Button::new("Recent Projects...")
+                                .shortcut_text(shortcut_text("⌥O")),
+                        )
+                        .clicked()
+                    {
+                        ui.close_kind(egui::UiKind::Menu);
+                        self.recent_picker.open();
                     }
                 });
                 ui.menu_button("View", |ui| {
@@ -279,8 +320,48 @@ impl eframe::App for ViewerApp {
             });
         });
 
+        // Bottom activity bar
         egui::TopBottomPanel::bottom("status_bar").show(ctx, |ui| {
             ui.horizontal(|ui| {
+                let is_tree = self.side_panel_tab == SidePanelTab::Cells
+                    && self.cell_view_mode == CellViewMode::Tree;
+                if ui
+                    .selectable_label(is_tree, "Tree")
+                    .on_hover_text("Cell hierarchy")
+                    .clicked()
+                {
+                    self.side_panel_tab = SidePanelTab::Cells;
+                    self.cell_view_mode = CellViewMode::Tree;
+                }
+
+                let is_flat = self.side_panel_tab == SidePanelTab::Cells
+                    && self.cell_view_mode == CellViewMode::Flat;
+                if ui
+                    .selectable_label(is_flat, "Cells")
+                    .on_hover_text("All cells")
+                    .clicked()
+                {
+                    self.side_panel_tab = SidePanelTab::Cells;
+                    self.cell_view_mode = CellViewMode::Flat;
+                    if self
+                        .cell
+                        .as_ref()
+                        .and_then(|c| c.selected_cell.as_ref())
+                        .is_some()
+                    {
+                        self.scroll_to_selected = true;
+                    }
+                }
+
+                if ui
+                    .selectable_label(self.side_panel_tab == SidePanelTab::Layers, "Layers")
+                    .clicked()
+                {
+                    self.side_panel_tab = SidePanelTab::Layers;
+                }
+
+                ui.separator();
+
                 if self.file_load.loading {
                     ui.label("Loading...");
                 } else if self.cell.as_ref().is_some_and(|c| c.elements_loading) {
@@ -305,29 +386,63 @@ impl eframe::App for ViewerApp {
                     if self.ruler.active {
                         ui.label("Ruler: click to place point (Esc to cancel)");
                     }
+                    if let Some(stats) = self.cell.as_ref().and_then(|c| c.cell_stats.as_ref()) {
+                        panels::draw_stats_bar(ui, stats);
+                    }
                 });
             });
         });
+
+        // Cell picker (⌘P)
+        let cell_names: Vec<String> = self
+            .cell
+            .as_ref()
+            .map(|c| c.cell_names.clone())
+            .unwrap_or_default();
+        if let QuickPickResult::Selected(idx) = self.cell_picker.show(ctx, &cell_names, true) {
+            self.select_cell(&cell_names[idx]);
+        }
+
+        // Recent projects picker (⌘⌥O)
+        let recent_labels: Vec<String> = self
+            .recent_projects
+            .paths()
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect();
+        if let QuickPickResult::Selected(idx) = self.recent_picker.show(ctx, &recent_labels, false)
+        {
+            let path = self.recent_projects.paths()[idx].clone();
+            self.load_path(&path);
+        }
 
         let mut cell_changed = false;
         let mut color_changed = false;
         let cell = &mut self.cell;
         let layer_state = &mut self.layer_state;
+        let active_tab = self.side_panel_tab;
+        let view_mode = self.cell_view_mode;
+        let scroll_to_selected = &mut self.scroll_to_selected;
         egui::SidePanel::left("side_panel")
             .default_width(200.0)
+            .width_range(40.0..=800.0)
+            .resizable(true)
             .show(ctx, |ui| {
+                ui.allocate_at_least(egui::vec2(ui.available_width(), 0.0), egui::Sense::hover());
                 if let Some(cell) = cell.as_mut() {
                     panels::draw_side_panel(
                         ui,
+                        active_tab,
                         &cell.cell_tree,
+                        &cell.flat_tree,
+                        view_mode,
                         &mut cell.selected_cell,
                         &mut cell_changed,
                         &mut color_changed,
                         &mut cell.expand_state,
+                        scroll_to_selected,
                         &cell.layers,
                         layer_state,
-                        cell.cell_stats.as_ref(),
-                        &mut cell.search_query,
                     );
                 }
             });

--- a/crates/gdsr-viewer/src/hierarchy.rs
+++ b/crates/gdsr-viewer/src/hierarchy.rs
@@ -72,9 +72,34 @@ fn build_node<'a>(
     }
 }
 
+/// Builds a flat cell list where every cell in the library is a top-level node,
+/// each with its direct children (references) as subtree entries.
+pub fn build_flat_cell_tree(library: &Library) -> Vec<CellTreeNode> {
+    let cells = library.cells();
+
+    let mut children_of: BTreeMap<&str, BTreeSet<&str>> = BTreeMap::new();
+    for (name, cell) in cells {
+        let entry = children_of.entry(name.as_str()).or_default();
+        for ref_name in cell.referenced_cell_names() {
+            if cells.contains_key(ref_name) {
+                entry.insert(ref_name);
+            }
+        }
+    }
+
+    let mut names: Vec<&str> = cells.keys().map(String::as_str).collect();
+    names.sort_unstable();
+
+    names
+        .into_iter()
+        .map(|name| build_node(name, &children_of, &mut HashSet::new()))
+        .collect()
+}
+
 /// Returns a filtered copy of the tree containing only nodes whose name matches
 /// the query (case-insensitive substring) or that have a matching descendant.
 /// An empty query returns a clone of the full tree.
+#[cfg(test)]
 pub fn filter_tree(tree: &[CellTreeNode], query: &str) -> Vec<CellTreeNode> {
     if query.is_empty() {
         return tree.to_vec();
@@ -85,6 +110,7 @@ pub fn filter_tree(tree: &[CellTreeNode], query: &str) -> Vec<CellTreeNode> {
         .collect()
 }
 
+#[cfg(test)]
 fn filter_node(node: &CellTreeNode, query_lower: &str) -> Option<CellTreeNode> {
     let name_matches = node.name.to_lowercase().contains(query_lower);
     let filtered_children: Vec<CellTreeNode> = node
@@ -124,6 +150,7 @@ impl ExpandState {
         self.expanded.insert(name.to_string(), expanded);
     }
 
+    #[cfg(test)]
     pub fn expand_all(&mut self, tree: &[CellTreeNode]) {
         for node in tree {
             self.set_expanded(&node.name, true);
@@ -131,6 +158,7 @@ impl ExpandState {
         }
     }
 
+    #[cfg(test)]
     pub fn collapse_all(&mut self, tree: &[CellTreeNode]) {
         for node in tree {
             self.set_expanded(&node.name, false);
@@ -678,5 +706,26 @@ mod tests {
 
         let tree = build_cell_tree(&library);
         assert_eq!(tree[0].children.len(), 1);
+    }
+
+    #[test]
+    fn flat_tree_lists_all_cells_as_roots() {
+        let library = make_library(vec![
+            ("top", vec!["mid"]),
+            ("mid", vec!["bot"]),
+            ("bot", vec![]),
+        ]);
+        let flat = build_flat_cell_tree(&library);
+        let root_names: Vec<&str> = flat.iter().map(|n| n.name.as_str()).collect();
+        insta::assert_debug_snapshot!(root_names, @r#"
+        [
+            "bot",
+            "mid",
+            "top",
+        ]
+        "#);
+        assert!(flat[0].children.is_empty());
+        assert_eq!(flat[1].children.len(), 1);
+        assert_eq!(flat[2].children.len(), 1);
     }
 }

--- a/crates/gdsr-viewer/src/main.rs
+++ b/crates/gdsr-viewer/src/main.rs
@@ -9,6 +9,8 @@ mod loader;
 mod panels;
 #[cfg(test)]
 mod property_tests;
+mod quick_pick;
+mod recent;
 mod ruler;
 mod spatial;
 mod state;

--- a/crates/gdsr-viewer/src/panels.rs
+++ b/crates/gdsr-viewer/src/panels.rs
@@ -1,141 +1,84 @@
 use std::collections::BTreeSet;
 
-use egui::Ui;
+use egui::{Color32, Pos2, Stroke, Ui};
 use gdsr::{CellStats, DataType, Layer};
 
-use crate::hierarchy::{self, CellTreeNode, ExpandState};
-use crate::state::LayerState;
+use crate::hierarchy::{CellTreeNode, ExpandState};
+use crate::state::{CellViewMode, LayerState, SidePanelTab};
 
-/// Draws the side panel with cell hierarchy tree, statistics, and layer toggles.
+const INDENT_PX: f32 = 16.0;
+const GUIDE_COLOR: Color32 = Color32::from_gray(60);
+const EXPANDED_COLOR: Color32 = Color32::from_gray(140);
+
+/// Draws the side panel content, dispatching to cell or layer panel based on active tab.
 pub fn draw_side_panel(
     ui: &mut Ui,
+    active_tab: SidePanelTab,
     cell_tree: &[CellTreeNode],
+    flat_tree: &[CellTreeNode],
+    view_mode: CellViewMode,
     selected_cell: &mut Option<String>,
     cell_changed: &mut bool,
     color_changed: &mut bool,
     expand_state: &mut ExpandState,
+    scroll_to_selected: &mut bool,
     layers: &BTreeSet<(Layer, DataType)>,
     layer_state: &mut LayerState,
-    cell_stats: Option<&CellStats>,
-    search_query: &mut String,
 ) {
-    ui.heading("Cells");
-
-    ui.add(egui::TextEdit::singleline(search_query).hint_text("Search cells..."));
-
-    ui.add_space(4.0);
-
-    let is_filtering = !search_query.is_empty();
-    let filtered;
-    let display_tree = if is_filtering {
-        filtered = hierarchy::filter_tree(cell_tree, search_query);
-        &filtered
-    } else {
-        cell_tree
-    };
-
-    ui.horizontal(|ui| {
-        if ui.small_button("Expand All").clicked() {
-            expand_state.expand_all(display_tree);
+    match active_tab {
+        SidePanelTab::Cells => {
+            let tree = match view_mode {
+                CellViewMode::Tree => cell_tree,
+                CellViewMode::Flat => flat_tree,
+            };
+            draw_cell_panel(
+                ui,
+                tree,
+                selected_cell,
+                cell_changed,
+                expand_state,
+                scroll_to_selected,
+            );
         }
-        if ui.small_button("Collapse All").clicked() {
-            expand_state.collapse_all(display_tree);
+        SidePanelTab::Layers => {
+            draw_layer_panel(ui, layers, layer_state, color_changed);
         }
-    });
-
-    ui.add_space(4.0);
-
-    if is_filtering {
-        expand_state.expand_all(display_tree);
     }
+}
 
+fn draw_cell_panel(
+    ui: &mut Ui,
+    cell_tree: &[CellTreeNode],
+    selected_cell: &mut Option<String>,
+    cell_changed: &mut bool,
+    expand_state: &mut ExpandState,
+    scroll_to_selected: &mut bool,
+) {
     egui::ScrollArea::vertical()
         .id_salt("cell_tree")
-        .max_height(ui.available_height() * 0.5)
         .show(ui, |ui| {
-            for node in display_tree {
-                draw_tree_node(ui, node, selected_cell, cell_changed, expand_state);
+            for node in cell_tree {
+                draw_tree_node(
+                    ui,
+                    node,
+                    selected_cell,
+                    cell_changed,
+                    expand_state,
+                    0,
+                    scroll_to_selected,
+                );
             }
         });
+}
 
-    if let Some(stats) = cell_stats {
-        ui.add_space(12.0);
-        ui.separator();
-        ui.add_space(4.0);
-
-        ui.collapsing("Statistics", |ui| {
-            ui.strong("Elements");
-            egui::Grid::new("stats_grid")
-                .num_columns(2)
-                .spacing([8.0, 2.0])
-                .show(ui, |ui| {
-                    let rows: &[(&str, usize)] = &[
-                        ("Polygons", stats.polygon_count),
-                        ("Paths", stats.path_count),
-                        ("Boxes", stats.box_count),
-                        ("Texts", stats.text_count),
-                        ("References", stats.reference_count),
-                    ];
-                    for &(label, count) in rows {
-                        if count > 0 {
-                            ui.label(label);
-                            ui.label(count.to_string());
-                            ui.end_row();
-                        }
-                    }
-
-                    ui.label("Total");
-                    ui.label(stats.total_elements().to_string());
-                    ui.end_row();
-                });
-
-            ui.separator();
-
-            if !stats.elements_per_layer.is_empty() {
-                ui.strong("Elements per layer");
-                egui::Grid::new("layer_stats_grid")
-                    .num_columns(2)
-                    .spacing([8.0, 2.0])
-                    .show(ui, |ui| {
-                        for (&(layer, dt), &count) in &stats.elements_per_layer {
-                            ui.label(format!("L{layer} D{dt}"));
-                            ui.label(count.to_string());
-                            ui.end_row();
-                        }
-                    });
-            }
-
-            if !stats.references_per_cell.is_empty() {
-                ui.add_space(4.0);
-                ui.strong("References per cell");
-                egui::Grid::new("ref_stats_grid")
-                    .num_columns(2)
-                    .spacing([8.0, 2.0])
-                    .show(ui, |ui| {
-                        for (name, &count) in &stats.references_per_cell {
-                            ui.label(name.as_str());
-                            ui.label(count.to_string());
-                            ui.end_row();
-                        }
-
-                        ui.label("Total");
-                        ui.label(stats.reference_count.to_string());
-                        ui.end_row();
-                    });
-
-                ui.separator();
-            }
-        });
-    }
-
-    ui.add_space(12.0);
-    ui.separator();
-    ui.add_space(4.0);
-
-    ui.heading("Layers");
+fn draw_layer_panel(
+    ui: &mut Ui,
+    layers: &BTreeSet<(Layer, DataType)>,
+    layer_state: &mut LayerState,
+    color_changed: &mut bool,
+) {
     egui::ScrollArea::vertical()
         .id_salt("layers")
-        .max_height(ui.available_height() - 40.0)
         .show(ui, |ui| {
             for &(layer, dt) in layers {
                 let mut color = layer_state.layer_colors.get(layer, dt);
@@ -164,53 +107,99 @@ pub fn draw_side_panel(
         });
 }
 
+/// Draws the statistics detail panel in the bottom bar.
+pub fn draw_stats_bar(ui: &mut Ui, stats: &CellStats) {
+    ui.separator();
+
+    let parts: Vec<String> = [
+        ("P", stats.polygon_count),
+        ("Pa", stats.path_count),
+        ("B", stats.box_count),
+        ("T", stats.text_count),
+        ("R", stats.reference_count),
+    ]
+    .iter()
+    .filter(|(_, c)| *c > 0)
+    .map(|(label, count)| format!("{label}:{count}"))
+    .collect();
+
+    let summary = format!("{} el  {}", stats.total_elements(), parts.join(" "));
+    ui.label(summary);
+}
+
 fn draw_tree_node(
     ui: &mut Ui,
     node: &CellTreeNode,
     selected_cell: &mut Option<String>,
     cell_changed: &mut bool,
     expand_state: &mut ExpandState,
+    depth: usize,
+    scroll_to_selected: &mut bool,
 ) {
     let has_children = !node.children.is_empty();
     let is_selected = selected_cell.as_deref() == Some(&node.name);
+    let is_expanded = has_children && expand_state.is_expanded(&node.name);
+    let indent = depth as f32 * INDENT_PX;
 
-    if has_children {
-        let open = expand_state.is_expanded(&node.name);
-        let id = ui.make_persistent_id(&node.name);
-        let mut state =
-            egui::collapsing_header::CollapsingState::load_with_default_open(ui.ctx(), id, open);
+    let max_width = ui.available_width();
+    ui.horizontal(|ui| {
+        ui.set_max_width(max_width);
 
-        if state.is_open() != open {
-            state.set_open(open);
+        let base_x = ui.cursor().left();
+        let top_y = ui.cursor().top();
+        let row_height = ui.spacing().interact_size.y;
+        let painter = ui.painter();
+
+        for level in 0..depth {
+            let x = base_x + level as f32 * INDENT_PX + INDENT_PX * 0.5;
+            painter.line_segment(
+                [Pos2::new(x, top_y), Pos2::new(x, top_y + row_height)],
+                Stroke::new(1.0, GUIDE_COLOR),
+            );
         }
 
-        ui.spacing_mut().indent = 10.0;
-        state
-            .show_header(ui, |ui| {
-                if ui.selectable_label(is_selected, &node.name).clicked() && !is_selected {
-                    *selected_cell = Some(node.name.clone());
-                    *cell_changed = true;
-                }
-            })
-            .body(|ui| {
-                for child in &node.children {
-                    draw_tree_node(ui, child, selected_cell, cell_changed, expand_state);
-                }
-            });
+        ui.add_space(indent);
 
-        if let Some(persisted) = egui::collapsing_header::CollapsingState::load(ui.ctx(), id) {
-            let new_open = persisted.is_open();
-            if new_open != open {
-                expand_state.set_expanded(&node.name, new_open);
+        let label = if is_expanded {
+            egui::RichText::new(&node.name).color(EXPANDED_COLOR)
+        } else {
+            egui::RichText::new(&node.name)
+        };
+
+        let response = ui.add(
+            egui::Button::selectable(is_selected, label)
+                .truncate()
+                .frame(false),
+        );
+        if is_selected && *scroll_to_selected {
+            response.scroll_to_me(Some(egui::Align::Center));
+            *scroll_to_selected = false;
+        }
+        if response.clicked() {
+            if has_children && is_expanded {
+                expand_state.set_expanded(&node.name, false);
             }
-        }
-    } else {
-        ui.horizontal(|ui| {
-            ui.add_space(14.0);
-            if ui.selectable_label(is_selected, &node.name).clicked() && !is_selected {
+            if !is_selected {
                 *selected_cell = Some(node.name.clone());
                 *cell_changed = true;
+                if has_children {
+                    expand_state.set_expanded(&node.name, true);
+                }
             }
-        });
+        }
+    });
+
+    if is_expanded {
+        for child in &node.children {
+            draw_tree_node(
+                ui,
+                child,
+                selected_cell,
+                cell_changed,
+                expand_state,
+                depth + 1,
+                scroll_to_selected,
+            );
+        }
     }
 }

--- a/crates/gdsr-viewer/src/quick_pick.rs
+++ b/crates/gdsr-viewer/src/quick_pick.rs
@@ -1,0 +1,162 @@
+/// A filterable floating picker dialog, similar to VS Code's Quick Pick or Zed's command palette.
+pub struct QuickPick {
+    open: bool,
+    query: String,
+    hint: String,
+    /// Index into the filtered list (not the original items).
+    cursor: usize,
+    scroll_to_cursor: bool,
+}
+
+/// The result of showing a `QuickPick` for a single frame.
+pub enum QuickPickResult {
+    /// No selection was made this frame.
+    None,
+    /// The user selected an item (by click or Enter). The value is the index into the
+    /// original items slice.
+    Selected(usize),
+    /// The user dismissed the picker (Escape or close button).
+    Dismissed,
+}
+
+impl QuickPick {
+    pub fn new(hint: impl Into<String>) -> Self {
+        Self {
+            open: false,
+            query: String::new(),
+            hint: hint.into(),
+            cursor: 0,
+            scroll_to_cursor: false,
+        }
+    }
+
+    pub fn is_open(&self) -> bool {
+        self.open
+    }
+
+    pub fn open(&mut self) {
+        self.open = true;
+        self.query.clear();
+        self.cursor = 0;
+        self.scroll_to_cursor = false;
+    }
+
+    pub fn close(&mut self) {
+        self.open = false;
+        self.query.clear();
+        self.cursor = 0;
+        self.scroll_to_cursor = false;
+    }
+
+    pub fn toggle(&mut self) {
+        if self.open {
+            self.close();
+        } else {
+            self.open();
+        }
+    }
+
+    /// Shows the picker and returns the outcome for this frame.
+    ///
+    /// `items` is the full list of display labels. The picker filters them by the query
+    /// (case-insensitive substring match). When `filterable` is false, all items are
+    /// shown regardless of the query (useful for recent projects where the search box
+    /// still provides focus but items aren't filtered).
+    pub fn show(
+        &mut self,
+        ctx: &egui::Context,
+        items: &[String],
+        filterable: bool,
+    ) -> QuickPickResult {
+        if !self.open {
+            return QuickPickResult::None;
+        }
+
+        let mut result = QuickPickResult::None;
+        let query_lower = self.query.to_lowercase();
+
+        let filtered_indices: Vec<usize> = items
+            .iter()
+            .enumerate()
+            .filter(|(_, label)| {
+                !filterable || query_lower.is_empty() || label.to_lowercase().contains(&query_lower)
+            })
+            .map(|(i, _)| i)
+            .collect();
+
+        // Clamp cursor to valid range when the filtered list changes.
+        if !filtered_indices.is_empty() {
+            self.cursor = self.cursor.min(filtered_indices.len() - 1);
+        } else {
+            self.cursor = 0;
+        }
+
+        egui::Window::new(&self.hint)
+            .title_bar(false)
+            .resizable(false)
+            .fixed_size([400.0, 300.0])
+            .anchor(egui::Align2::CENTER_TOP, [0.0, 80.0])
+            .show(ctx, |ui| {
+                let prev_query = self.query.clone();
+                let response = ui.add(
+                    egui::TextEdit::singleline(&mut self.query)
+                        .hint_text(&self.hint)
+                        .desired_width(f32::INFINITY),
+                );
+                response.request_focus();
+
+                // Reset cursor to top when the query changes.
+                if self.query != prev_query {
+                    self.cursor = 0;
+                    self.scroll_to_cursor = true;
+                }
+
+                // Arrow key navigation (consumed so the text cursor doesn't move).
+                if ui.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowDown)) {
+                    if !filtered_indices.is_empty() {
+                        self.cursor = (self.cursor + 1).min(filtered_indices.len() - 1);
+                        self.scroll_to_cursor = true;
+                    }
+                }
+                if ui.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowUp)) {
+                    self.cursor = self.cursor.saturating_sub(1);
+                    self.scroll_to_cursor = true;
+                }
+
+                if ui.input(|i| i.key_pressed(egui::Key::Enter)) {
+                    if let Some(&idx) = filtered_indices.get(self.cursor) {
+                        result = QuickPickResult::Selected(idx);
+                    }
+                }
+
+                ui.add_space(4.0);
+
+                egui::ScrollArea::vertical().show(ui, |ui| {
+                    for (pos, &idx) in filtered_indices.iter().enumerate() {
+                        let highlighted = pos == self.cursor;
+                        let response = ui.selectable_label(highlighted, &items[idx]);
+                        if highlighted && self.scroll_to_cursor {
+                            response.scroll_to_me(Some(egui::Align::Center));
+                            self.scroll_to_cursor = false;
+                        }
+                        if response.clicked() {
+                            result = QuickPickResult::Selected(idx);
+                        }
+                    }
+                });
+            });
+
+        if ctx.input(|i| i.key_pressed(egui::Key::Escape)) {
+            result = QuickPickResult::Dismissed;
+        }
+
+        if matches!(
+            result,
+            QuickPickResult::Selected(_) | QuickPickResult::Dismissed
+        ) {
+            self.close();
+        }
+
+        result
+    }
+}

--- a/crates/gdsr-viewer/src/recent.rs
+++ b/crates/gdsr-viewer/src/recent.rs
@@ -1,0 +1,113 @@
+use std::path::{Path, PathBuf};
+
+const MAX_ENTRIES: usize = 10;
+
+/// Persists a list of recently opened file paths.
+#[derive(Default)]
+pub struct RecentProjects {
+    paths: Vec<PathBuf>,
+}
+
+impl RecentProjects {
+    pub fn load() -> Self {
+        let Some(path) = config_path() else {
+            return Self::default();
+        };
+        let Ok(contents) = std::fs::read_to_string(&path) else {
+            return Self::default();
+        };
+        let paths: Vec<PathBuf> = contents
+            .lines()
+            .map(PathBuf::from)
+            .filter(|p| p.exists())
+            .collect();
+        Self { paths }
+    }
+
+    pub fn save(&self) {
+        let Some(path) = config_path() else {
+            return;
+        };
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let contents: String = self
+            .paths
+            .iter()
+            .filter_map(|p| p.to_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        let _ = std::fs::write(&path, contents);
+    }
+
+    pub fn add(&mut self, path: &Path) {
+        self.paths.retain(|p| p != path);
+        self.paths.insert(0, path.to_path_buf());
+        self.paths.truncate(MAX_ENTRIES);
+    }
+
+    pub fn paths(&self) -> &[PathBuf] {
+        &self.paths
+    }
+}
+
+fn config_path() -> Option<PathBuf> {
+    #[cfg(target_os = "macos")]
+    {
+        dirs_config_macos()
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        dirs_config_other()
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn dirs_config_macos() -> Option<PathBuf> {
+    let home = std::env::var("HOME").ok()?;
+    Some(PathBuf::from(home).join("Library/Application Support/gdsr-viewer/recent.txt"))
+}
+
+#[cfg(not(target_os = "macos"))]
+fn dirs_config_other() -> Option<PathBuf> {
+    let config_dir = std::env::var("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .or_else(|_| std::env::var("APPDATA").map(PathBuf::from))
+        .or_else(|_| std::env::var("HOME").map(|h| PathBuf::from(h).join(".config")))
+        .ok()?;
+    Some(config_dir.join("gdsr-viewer/recent.txt"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_deduplicates_and_prepends() {
+        let mut rp = RecentProjects::default();
+        rp.add(Path::new("/a"));
+        rp.add(Path::new("/b"));
+        rp.add(Path::new("/a"));
+        insta::assert_debug_snapshot!(rp.paths, @r#"
+        [
+            "/a",
+            "/b",
+        ]
+        "#);
+    }
+
+    #[test]
+    fn add_truncates_to_max() {
+        let mut rp = RecentProjects::default();
+        for i in 0..15 {
+            rp.add(Path::new(&format!("/file{i}")));
+        }
+        assert_eq!(rp.paths.len(), MAX_ENTRIES);
+        assert_eq!(rp.paths[0], PathBuf::from("/file14"));
+    }
+
+    #[test]
+    fn config_path_returns_some() {
+        assert!(config_path().is_some());
+    }
+}

--- a/crates/gdsr-viewer/src/state.rs
+++ b/crates/gdsr-viewer/src/state.rs
@@ -24,6 +24,7 @@ pub struct CellState {
     pub library: Library,
     pub cell_names: Vec<String>,
     pub cell_tree: Vec<CellTreeNode>,
+    pub flat_tree: Vec<CellTreeNode>,
     pub expand_state: ExpandState,
     pub selected_cell: Option<String>,
     pub elements: Vec<Element>,
@@ -33,7 +34,6 @@ pub struct CellState {
     pub spatial_grid: Option<SpatialGrid>,
     pub tessellation_cache: HashMap<u32, Vec<usize>>,
     pub cell_stats: Option<CellStats>,
-    pub search_query: String,
 }
 
 impl CellState {
@@ -41,12 +41,13 @@ impl CellState {
         let mut cell_names: Vec<String> = library.cells().keys().cloned().collect();
         cell_names.sort();
         let cell_tree = hierarchy::build_cell_tree(&library);
-        let mut expand_state = ExpandState::default();
-        expand_state.expand_all(&cell_tree);
+        let flat_tree = hierarchy::build_flat_cell_tree(&library);
+        let expand_state = ExpandState::default();
         Self {
             library,
             cell_names,
             cell_tree,
+            flat_tree,
             expand_state,
             selected_cell: None,
             elements: Vec::new(),
@@ -56,7 +57,6 @@ impl CellState {
             spatial_grid: None,
             tessellation_cache: HashMap::new(),
             cell_stats: None,
-            search_query: String::new(),
         }
     }
 }
@@ -366,6 +366,20 @@ mod tests {
         assert_eq!(first, second);
         assert!(!first.is_empty());
     }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum SidePanelTab {
+    #[default]
+    Cells,
+    Layers,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum CellViewMode {
+    #[default]
+    Tree,
+    Flat,
 }
 
 /// Groups layer visibility and color state.


### PR DESCRIPTION
## Summary

- Split the monolithic side panel into tabbed **Tree / Cells / Layers** views with a bottom activity bar for switching between them
- Replace `CollapsingState`-based tree with custom rendering featuring indent guides, expanded color highlighting, truncated labels, and a freely resizable panel (40–800px)
- Add **QuickPick** component — a filterable floating dialog with arrow key navigation, used for cell search (⌘P) and recent projects (⌘⌥O)
- Add **RecentProjects** persistence with platform-aware config paths (macOS, Linux, Windows) and max 10 entries
- Add **flat cell view** listing all cells alphabetically, each expandable to show children
- Move statistics summary to bottom status bar; remove inline search bar and verbose stats panel
- Cells start collapsed on file open with no auto-selection of the first cell
- Auto-scroll to selected cell when switching to flat view or selecting via command palette

## Test plan

- `cargo nextest run -p gdsr-viewer` — all 138 tests pass (including new `flat_tree_lists_all_cells_as_roots`)
- `uvx prek run -a` — all pre-commit checks pass
- Manual testing: verify Tree/Cells/Layers tab switching, QuickPick arrow navigation and selection, recent projects persistence, panel resizing, scroll-to-selected behavior