### PR TITLE
Fix integer overflow panics in spatial grid and add viewer stress tests

### DIFF
--- a/crates/gdsr-viewer/src/drawable.rs
+++ b/crates/gdsr-viewer/src/drawable.rs
@@ -1007,6 +1007,233 @@ mod tests {
     }
 
     #[test]
+    fn gds_box_layer_keys() {
+        let b = gdsr::GdsBox::new(
+            gdsr::Point::default_integer(0, 0),
+            gdsr::Point::default_integer(100, 100),
+            Layer::new(3),
+            DataType::new(5),
+        );
+        assert_eq!(b.layer_keys(), vec![(Layer::new(3), DataType::new(5))]);
+    }
+
+    #[test]
+    fn gds_box_world_bbox() {
+        let b = gdsr::GdsBox::new(
+            gdsr::Point::default_integer(10, 20),
+            gdsr::Point::default_integer(30, 40),
+            Layer::new(1),
+            DataType::new(0),
+        );
+        let bbox = b.world_bbox().expect("should have bbox");
+        assert!((bbox.min_x - 10.0 * SCALE).abs() < 1e-15);
+        assert!((bbox.min_y - 20.0 * SCALE).abs() < 1e-15);
+        assert!((bbox.max_x - 30.0 * SCALE).abs() < 1e-15);
+        assert!((bbox.max_y - 40.0 * SCALE).abs() < 1e-15);
+    }
+
+    #[test]
+    fn node_layer_keys() {
+        let n = gdsr::Node::new(
+            vec![gdsr::Point::default_integer(0, 0)],
+            Layer::new(7),
+            DataType::new(2),
+        );
+        assert_eq!(n.layer_keys(), vec![(Layer::new(7), DataType::new(2))]);
+    }
+
+    #[test]
+    fn node_world_bbox() {
+        let n = gdsr::Node::new(
+            vec![
+                gdsr::Point::default_integer(10, 20),
+                gdsr::Point::default_integer(30, 40),
+            ],
+            Layer::new(1),
+            DataType::new(0),
+        );
+        let bbox = n.world_bbox().expect("should have bbox");
+        assert!((bbox.min_x - 10.0 * SCALE).abs() < 1e-15);
+        assert!((bbox.min_y - 20.0 * SCALE).abs() < 1e-15);
+        assert!((bbox.max_x - 30.0 * SCALE).abs() < 1e-15);
+        assert!((bbox.max_y - 40.0 * SCALE).abs() < 1e-15);
+    }
+
+    #[test]
+    fn gds_box_hit_near_edge() {
+        let b = gdsr::GdsBox::new(
+            gdsr::Point::default_integer(0, 0),
+            gdsr::Point::default_integer(100, 100),
+            Layer::new(1),
+            DataType::new(0),
+        );
+        let el = Element::Box(b);
+        assert!(el.hit_test(0.0, 50.0 * SCALE, ZOOM));
+    }
+
+    #[test]
+    fn node_hit_multiple_points() {
+        let n = gdsr::Node::new(
+            vec![
+                gdsr::Point::default_integer(0, 0),
+                gdsr::Point::default_integer(100, 100),
+                gdsr::Point::default_integer(200, 0),
+            ],
+            Layer::new(1),
+            DataType::new(0),
+        );
+        let el = Element::Node(n);
+        assert!(el.hit_test(0.0, 0.0, ZOOM));
+        assert!(el.hit_test(100.0 * SCALE, 100.0 * SCALE, ZOOM));
+        assert!(el.hit_test(200.0 * SCALE, 0.0, ZOOM));
+        assert!(!el.hit_test(500.0 * SCALE, 500.0 * SCALE, ZOOM));
+    }
+
+    #[test]
+    fn reference_with_element_layer_keys() {
+        let poly = gdsr::Polygon::new(
+            vec![
+                gdsr::Point::default_integer(0, 0),
+                gdsr::Point::default_integer(10, 0),
+                gdsr::Point::default_integer(10, 10),
+            ],
+            Layer::new(3),
+            DataType::new(1),
+        );
+        let r = gdsr::Reference::new(poly);
+        assert_eq!(r.layer_keys(), vec![(Layer::new(3), DataType::new(1))]);
+    }
+
+    #[test]
+    fn reference_empty_layer_keys() {
+        let r = gdsr::Reference::default();
+        assert!(r.layer_keys().is_empty());
+    }
+
+    #[test]
+    fn reference_empty_world_bbox() {
+        let r = gdsr::Reference::default();
+        assert!(r.world_bbox().is_none());
+    }
+
+    #[test]
+    fn reference_with_element_world_bbox() {
+        let poly = gdsr::Polygon::new(
+            vec![
+                gdsr::Point::default_integer(0, 0),
+                gdsr::Point::default_integer(100, 0),
+                gdsr::Point::default_integer(100, 100),
+            ],
+            Layer::new(1),
+            DataType::new(0),
+        );
+        let r = gdsr::Reference::new(poly);
+        let bbox = r.world_bbox().expect("should have bbox");
+        assert!((bbox.min_x - 0.0).abs() < 1e-15);
+        assert!((bbox.max_x - 100.0 * SCALE).abs() < 1e-15);
+    }
+
+    #[test]
+    fn reference_with_element_hit_test() {
+        let poly = gdsr::Polygon::new(
+            vec![
+                gdsr::Point::default_integer(0, 0),
+                gdsr::Point::default_integer(100, 0),
+                gdsr::Point::default_integer(100, 100),
+                gdsr::Point::default_integer(0, 100),
+            ],
+            Layer::new(1),
+            DataType::new(0),
+        );
+        let r = gdsr::Reference::new(poly);
+        assert!(r.hit_test(50.0 * SCALE, 50.0 * SCALE, ZOOM));
+        assert!(!r.hit_test(500.0 * SCALE, 500.0 * SCALE, ZOOM));
+    }
+
+    #[test]
+    fn element_dispatch_layer_keys() {
+        let el = polygon(vec![(0, 0), (10, 0), (10, 10)], 5, 3);
+        assert_eq!(el.layer_keys(), vec![(Layer::new(5), DataType::new(3))]);
+
+        let el = path(vec![(0, 0), (10, 0)], 7, 2, None);
+        assert_eq!(el.layer_keys(), vec![(Layer::new(7), DataType::new(2))]);
+
+        let el = text("t", 0, 0, 4);
+        assert_eq!(el.layer_keys(), vec![(Layer::new(4), DataType::new(0))]);
+
+        let b = gdsr::GdsBox::new(
+            gdsr::Point::default_integer(0, 0),
+            gdsr::Point::default_integer(10, 10),
+            Layer::new(8),
+            DataType::new(1),
+        );
+        assert_eq!(
+            Element::Box(b).layer_keys(),
+            vec![(Layer::new(8), DataType::new(1))]
+        );
+
+        let n = gdsr::Node::new(
+            vec![gdsr::Point::default_integer(0, 0)],
+            Layer::new(9),
+            DataType::new(4),
+        );
+        assert_eq!(
+            Element::Node(n).layer_keys(),
+            vec![(Layer::new(9), DataType::new(4))]
+        );
+    }
+
+    #[test]
+    fn element_dispatch_world_bbox() {
+        let el = polygon(vec![(0, 0), (100, 0), (100, 100)], 1, 0);
+        assert!(el.world_bbox().is_some());
+
+        let el = path(vec![(0, 0), (100, 100)], 1, 0, None);
+        assert!(el.world_bbox().is_some());
+
+        let el = text("hi", 50, 50, 1);
+        assert!(el.world_bbox().is_some());
+
+        let b = gdsr::GdsBox::new(
+            gdsr::Point::default_integer(0, 0),
+            gdsr::Point::default_integer(10, 10),
+            Layer::new(1),
+            DataType::new(0),
+        );
+        assert!(Element::Box(b).world_bbox().is_some());
+
+        let n = gdsr::Node::new(
+            vec![gdsr::Point::default_integer(0, 0)],
+            Layer::new(1),
+            DataType::new(0),
+        );
+        assert!(Element::Node(n).world_bbox().is_some());
+
+        let el = reference();
+        assert!(el.world_bbox().is_none());
+    }
+
+    #[test]
+    fn element_dispatch_hit_test() {
+        let b = gdsr::GdsBox::new(
+            gdsr::Point::default_integer(0, 0),
+            gdsr::Point::default_integer(100, 100),
+            Layer::new(1),
+            DataType::new(0),
+        );
+        assert!(Element::Box(b).hit_test(50.0 * SCALE, 50.0 * SCALE, ZOOM));
+
+        let n = gdsr::Node::new(
+            vec![gdsr::Point::default_integer(50, 50)],
+            Layer::new(1),
+            DataType::new(0),
+        );
+        assert!(Element::Node(n).hit_test(50.0 * SCALE, 50.0 * SCALE, ZOOM));
+
+        assert!(!reference().hit_test(0.0, 0.0, ZOOM));
+    }
+
+    #[test]
     fn point_in_polygon_triangle() {
         let tri = [(0.0, 0.0), (10.0, 0.0), (5.0, 10.0)];
         assert!(point_in_polygon(5.0, 3.0, &tri));
@@ -1017,6 +1244,239 @@ mod tests {
     fn point_to_segment_dist_on_segment() {
         let d = point_to_segment_dist_sq(5.0, 0.0, 0.0, 0.0, 10.0, 0.0);
         assert!(d < 1e-20);
+    }
+
+    #[test]
+    fn polygon_hit_degenerate_single_point() {
+        let el = polygon(vec![(50, 50), (50, 50), (50, 50)], 1, 0);
+        // Exactly at the vertex — edge proximity returns true
+        assert!(el.hit_test(50.0 * SCALE, 50.0 * SCALE, ZOOM));
+        // Far away should miss
+        assert!(!el.hit_test(500.0 * SCALE, 500.0 * SCALE, ZOOM));
+    }
+
+    #[test]
+    fn polygon_hit_collinear_points() {
+        let el = polygon(vec![(0, 0), (50, 0), (100, 0)], 1, 0);
+        assert!(el.hit_test(50.0 * SCALE, 0.0, ZOOM));
+    }
+
+    #[test]
+    fn polygon_hit_extreme_zoom_far() {
+        let el = polygon(vec![(0, 0), (100, 0), (100, 100), (0, 100)], 1, 0);
+        assert!(el.hit_test(50.0 * SCALE, 50.0 * SCALE, 1e-3));
+    }
+
+    #[test]
+    fn polygon_hit_extreme_zoom_close() {
+        let el = polygon(vec![(0, 0), (100, 0), (100, 100), (0, 100)], 1, 0);
+        assert!(el.hit_test(50.0 * SCALE, 50.0 * SCALE, 1e15));
+    }
+
+    #[test]
+    fn polygon_hit_at_edge() {
+        let el = polygon(vec![(0, 0), (100, 0), (100, 100), (0, 100)], 1, 0);
+        assert!(el.hit_test(0.0, 50.0 * SCALE, ZOOM));
+    }
+
+    #[test]
+    fn polygon_hit_at_vertex() {
+        let el = polygon(vec![(0, 0), (100, 0), (100, 100), (0, 100)], 1, 0);
+        assert!(el.hit_test(0.0, 0.0, ZOOM));
+    }
+
+    #[test]
+    fn polygon_with_two_points_no_panic() {
+        let el = polygon(vec![(0, 0), (100, 0)], 1, 0);
+        // Near the line segment — edge proximity hits
+        assert!(el.hit_test(50.0 * SCALE, 0.0, ZOOM));
+        // Far away should miss
+        assert!(!el.hit_test(50.0 * SCALE, 500.0 * SCALE, ZOOM));
+    }
+
+    #[test]
+    fn path_hit_zero_width() {
+        let el = path(vec![(0, 0), (100, 0)], 1, 0, None);
+        assert!(el.hit_test(50.0 * SCALE, 0.0, ZOOM));
+    }
+
+    #[test]
+    fn path_hit_single_point_no_panic() {
+        let el = path(vec![(50, 50)], 1, 0, Some(10));
+        assert!(!el.hit_test(50.0 * SCALE, 50.0 * SCALE, ZOOM));
+    }
+
+    #[test]
+    fn path_hit_empty_no_panic() {
+        let el = path(vec![], 1, 0, Some(10));
+        assert!(!el.hit_test(0.0, 0.0, ZOOM));
+    }
+
+    #[test]
+    fn node_hit_empty_points_no_panic() {
+        let n = gdsr::Node::new(vec![], Layer::new(1), DataType::new(0));
+        let el = Element::Node(n);
+        assert!(!el.hit_test(0.0, 0.0, ZOOM));
+    }
+
+    #[test]
+    fn text_hit_extreme_zoom() {
+        let el = text("hello", 500, 600, 1);
+        assert!(el.hit_test(500.0 * SCALE, 600.0 * SCALE, 1e-3));
+    }
+
+    #[test]
+    fn reference_empty_hit_test() {
+        let el = reference();
+        assert!(!el.hit_test(0.0, 0.0, ZOOM));
+    }
+
+    #[test]
+    fn bbox_overlaps_identical() {
+        let a = WorldBBox::new(1.0, 2.0, 3.0, 4.0);
+        assert!(a.overlaps(&a));
+    }
+
+    #[test]
+    fn bbox_merge_with_itself() {
+        let a = WorldBBox::new(1.0, 2.0, 3.0, 4.0);
+        let merged = a.merge(&a);
+        assert!((merged.min_x - a.min_x).abs() < 1e-15);
+        assert!((merged.max_x - a.max_x).abs() < 1e-15);
+    }
+
+    #[test]
+    fn bbox_merge_disjoint() {
+        let a = WorldBBox::new(0.0, 0.0, 1.0, 1.0);
+        let b = WorldBBox::new(10.0, 10.0, 11.0, 11.0);
+        let merged = a.merge(&b);
+        assert!((merged.min_x - 0.0).abs() < 1e-15);
+        assert!((merged.min_y - 0.0).abs() < 1e-15);
+        assert!((merged.max_x - 11.0).abs() < 1e-15);
+        assert!((merged.max_y - 11.0).abs() < 1e-15);
+    }
+
+    #[test]
+    fn point_in_polygon_degenerate_less_than_3() {
+        assert!(!point_in_polygon(0.0, 0.0, &[]));
+        assert!(!point_in_polygon(0.0, 0.0, &[(0.0, 0.0)]));
+        assert!(!point_in_polygon(0.0, 0.0, &[(0.0, 0.0), (1.0, 0.0)]));
+    }
+
+    #[test]
+    fn point_in_polygon_concave() {
+        let concave = [
+            (0.0, 0.0),
+            (10.0, 0.0),
+            (10.0, 10.0),
+            (5.0, 5.0),
+            (0.0, 10.0),
+        ];
+        assert!(point_in_polygon(2.0, 2.0, &concave));
+        assert!(!point_in_polygon(5.0, 8.0, &concave));
+    }
+
+    #[test]
+    fn point_to_segment_dist_zero_length_segment() {
+        let d = point_to_segment_dist_sq(3.0, 4.0, 0.0, 0.0, 0.0, 0.0);
+        assert!((d - 25.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn point_to_segment_dist_at_endpoint() {
+        let d = point_to_segment_dist_sq(0.0, 0.0, 0.0, 0.0, 10.0, 0.0);
+        assert!(d < 1e-20);
+    }
+
+    #[test]
+    fn point_to_segment_dist_beyond_endpoint() {
+        let d = point_to_segment_dist_sq(15.0, 0.0, 0.0, 0.0, 10.0, 0.0);
+        assert!((d - 25.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn stroke_polyline_empty() {
+        let stroke = Stroke::new(2.0, Color32::WHITE);
+        let mesh = stroke_polyline_to_mesh(&[], stroke, false);
+        assert!(mesh.vertices.is_empty());
+        assert!(mesh.indices.is_empty());
+    }
+
+    #[test]
+    fn stroke_polyline_single_point() {
+        let stroke = Stroke::new(2.0, Color32::WHITE);
+        let mesh = stroke_polyline_to_mesh(&[Pos2::new(5.0, 5.0)], stroke, false);
+        assert!(mesh.vertices.is_empty());
+        assert!(mesh.indices.is_empty());
+    }
+
+    #[test]
+    fn stroke_polyline_coincident_points() {
+        let stroke = Stroke::new(2.0, Color32::WHITE);
+        let pts = vec![
+            Pos2::new(5.0, 5.0),
+            Pos2::new(5.0, 5.0),
+            Pos2::new(5.0, 5.0),
+        ];
+        let mesh = stroke_polyline_to_mesh(&pts, stroke, false);
+        assert!(
+            mesh.vertices.is_empty(),
+            "coincident points should produce no edges"
+        );
+    }
+
+    #[test]
+    fn stroke_polyline_closed_vs_open() {
+        let stroke = Stroke::new(2.0, Color32::WHITE);
+        let pts = vec![
+            Pos2::new(0.0, 0.0),
+            Pos2::new(10.0, 0.0),
+            Pos2::new(10.0, 10.0),
+        ];
+        let open = stroke_polyline_to_mesh(&pts, stroke, false);
+        let closed = stroke_polyline_to_mesh(&pts, stroke, true);
+        assert!(
+            closed.vertices.len() > open.vertices.len(),
+            "closed should have more vertices from closing edge"
+        );
+    }
+
+    #[test]
+    fn polygon_bbox_with_extreme_coords() {
+        let max = i32::MAX / 2;
+        let el = polygon(vec![(0, 0), (max, 0), (max, max), (0, max)], 1, 0);
+        let bbox = el.world_bbox().expect("should have bbox");
+        assert!(bbox.min_x.is_finite());
+        assert!(bbox.max_x.is_finite());
+        assert!(bbox.min_y.is_finite());
+        assert!(bbox.max_y.is_finite());
+        assert!(bbox.max_x > bbox.min_x);
+        assert!(bbox.max_y > bbox.min_y);
+    }
+
+    #[test]
+    fn path_bbox_with_extreme_coords() {
+        let max = i32::MAX / 2;
+        let el = path(vec![(0, 0), (max, max)], 1, 0, Some(100));
+        let bbox = el.world_bbox().expect("should have bbox");
+        assert!(bbox.min_x.is_finite());
+        assert!(bbox.max_x.is_finite());
+    }
+
+    #[test]
+    fn polygon_many_vertices_no_panic() {
+        let pts: Vec<(i32, i32)> = (0..1000)
+            .map(|i| {
+                let angle = f64::from(i) * 2.0 * std::f64::consts::PI / 1000.0;
+                let x = (angle.cos() * 1000.0) as i32;
+                let y = (angle.sin() * 1000.0) as i32;
+                (x, y)
+            })
+            .collect();
+        let el = polygon(pts, 1, 0);
+        let bbox = el.world_bbox().expect("should have bbox");
+        assert!(bbox.max_x > bbox.min_x);
+        assert!(el.hit_test(0.0, 0.0, ZOOM));
     }
 
     #[test]

--- a/crates/gdsr-viewer/src/grid.rs
+++ b/crates/gdsr-viewer/src/grid.rs
@@ -137,6 +137,58 @@ mod tests {
     }
 
     #[test]
+    fn grid_spacing_at_min_zoom() {
+        let spacing = grid_spacing(1e-3);
+        assert!(spacing > 0.0);
+        assert!(spacing.is_finite());
+        let screen_px = spacing * 1e-3;
+        assert!((40.0..=200.0).contains(&screen_px));
+    }
+
+    #[test]
+    fn grid_spacing_at_max_zoom() {
+        let spacing = grid_spacing(1e15);
+        assert!(spacing > 0.0);
+        assert!(spacing.is_finite());
+        let screen_px = spacing * 1e15;
+        assert!((40.0..=200.0).contains(&screen_px));
+    }
+
+    #[test]
+    fn grid_spacing_very_small_zoom() {
+        let spacing = grid_spacing(1e-10);
+        assert!(spacing > 0.0);
+        assert!(spacing.is_finite());
+    }
+
+    #[test]
+    fn grid_spacing_very_large_zoom() {
+        let spacing = grid_spacing(1e12);
+        assert!(spacing > 0.0);
+        assert!(spacing.is_finite());
+    }
+
+    #[test]
+    fn first_line_large_negative() {
+        let result = first_line(-1e15, 100.0);
+        assert!(result.is_finite());
+        assert!(result <= -1e15);
+    }
+
+    #[test]
+    fn first_line_large_positive() {
+        let result = first_line(1e15, 100.0);
+        assert!(result.is_finite());
+        assert!(result <= 1e15);
+    }
+
+    #[test]
+    fn first_line_tiny_spacing() {
+        let result = first_line(1.0, 1e-12);
+        assert!(result.is_finite());
+    }
+
+    #[test]
     fn first_line_exact_multiple() {
         assert!((first_line(20.0, 10.0) - 20.0).abs() < 1e-10);
         assert!((first_line(-20.0, 10.0) - (-20.0)).abs() < 1e-10);

--- a/crates/gdsr-viewer/src/property_tests.rs
+++ b/crates/gdsr-viewer/src/property_tests.rs
@@ -360,6 +360,112 @@ fn dedup_bitset_prevents_duplicates(x1: i8, y1: i8) -> bool {
     draw_counts.iter().all(|&c| c <= 1)
 }
 
+/// Hit-testing a point inside a polygon's bbox but outside the polygon itself
+/// should not panic, and a point known to be inside should always hit.
+#[quickcheck]
+fn polygon_hit_test_never_panics(x1: i8, y1: i8, x2: i8, y2: i8, x3: i8, y3: i8) -> bool {
+    let elem = helpers::polygon(
+        vec![
+            (i32::from(x1), i32::from(y1)),
+            (i32::from(x2), i32::from(y2)),
+            (i32::from(x3), i32::from(y3)),
+        ],
+        1,
+        0,
+    );
+    let scale = 1e-9;
+    // Just ensure these don't panic at various zoom levels
+    let _ = elem.hit_test(f64::from(x1) * scale, f64::from(y1) * scale, 1e-3);
+    let _ = elem.hit_test(f64::from(x2) * scale, f64::from(y2) * scale, 1e9);
+    let _ = elem.hit_test(f64::from(x3) * scale, f64::from(y3) * scale, 1e15);
+    let _ = elem.hit_test(0.0, 0.0, 1.0);
+    true
+}
+
+/// Path `hit_test` should never panic regardless of input.
+#[quickcheck]
+fn path_hit_test_never_panics(x1: i8, y1: i8, x2: i8, y2: i8, w: u8) -> bool {
+    let elem = helpers::path(
+        vec![
+            (i32::from(x1), i32::from(y1)),
+            (i32::from(x2), i32::from(y2)),
+        ],
+        1,
+        0,
+        if w > 0 { Some(i32::from(w)) } else { None },
+    );
+    let scale = 1e-9;
+    let _ = elem.hit_test(f64::from(x1) * scale, f64::from(y1) * scale, 1e-3);
+    let _ = elem.hit_test(f64::from(x2) * scale, f64::from(y2) * scale, 1e15);
+    let _ = elem.hit_test(0.0, 0.0, 1.0);
+    true
+}
+
+/// The visible world rect should always have max > min (non-degenerate)
+/// for any valid viewport configuration.
+#[quickcheck]
+fn visible_world_rect_is_non_degenerate(cx: f64, cy: f64, zoom: f64) -> bool {
+    let Some(vp) = clamp_viewport(cx, cy, zoom) else {
+        return true;
+    };
+    let rect = test_rect();
+    let vis = vp.visible_world_rect(rect);
+    vis.max_x > vis.min_x && vis.max_y > vis.min_y
+}
+
+/// The spatial grid `query_point` should never panic even with extreme inputs.
+#[quickcheck]
+fn spatial_grid_query_point_never_panics(x: f64, y: f64) -> bool {
+    if !x.is_finite() || !y.is_finite() {
+        return true;
+    }
+    let scale = 1e-9;
+    let elems = vec![helpers::polygon(vec![(0, 0), (100, 0), (100, 100)], 1, 0)];
+    let bounds = WorldBBox::new(0.0, 0.0, 100.0 * scale, 100.0 * scale);
+    let grid = SpatialGrid::build(&elems, &bounds);
+    let mut buf = Vec::new();
+    let _ = grid.query_point(x, y, &mut buf);
+    true
+}
+
+/// Zoom-to-fit should always produce a finite zoom and center for valid bounds.
+#[quickcheck]
+fn zoom_to_fit_produces_finite_state(min_x: f64, min_y: f64, w: f64, h: f64) -> bool {
+    if !is_finite(min_x) || !is_finite(min_y) || !is_finite(w) || !is_finite(h) {
+        return true;
+    }
+    let min_x = min_x.clamp(-1e6, 1e6);
+    let min_y = min_y.clamp(-1e6, 1e6);
+    let w = w.abs().clamp(1e-12, 1e6);
+    let h = h.abs().clamp(1e-12, 1e6);
+
+    let mut vp = Viewport::default();
+    let rect = test_rect();
+    let bounds = WorldBBox::new(min_x, min_y, min_x + w, min_y + h);
+    vp.zoom_to_fit(&bounds, rect);
+    vp.center_x.is_finite() && vp.center_y.is_finite() && vp.zoom.is_finite() && vp.zoom > 0.0
+}
+
+/// The spatial grid `query_visible` should never panic even with extreme bounds.
+#[quickcheck]
+fn spatial_grid_query_visible_never_panics(min_x: f64, min_y: f64, max_x: f64, max_y: f64) -> bool {
+    if !min_x.is_finite() || !min_y.is_finite() || !max_x.is_finite() || !max_y.is_finite() {
+        return true;
+    }
+    let scale = 1e-9;
+    let elems = vec![helpers::polygon(vec![(0, 0), (100, 0), (100, 100)], 1, 0)];
+    let bounds = WorldBBox::new(0.0, 0.0, 100.0 * scale, 100.0 * scale);
+    let grid = SpatialGrid::build(&elems, &bounds);
+
+    let min_x = min_x.clamp(-1e18, 1e18);
+    let min_y = min_y.clamp(-1e18, 1e18);
+    let max_x = max_x.clamp(min_x, 1e18);
+    let max_y = max_y.clamp(min_y, 1e18);
+    let visible = WorldBBox::new(min_x, min_y, max_x, max_y);
+    let _: Vec<_> = grid.query_visible(&visible).collect();
+    true
+}
+
 /// Counts edges that have non-zero length (matching the 1e-6 threshold in the function).
 fn count_nonzero_edges(points: &[Pos2], closed: bool) -> usize {
     if points.len() < 2 {

--- a/crates/gdsr-viewer/src/ruler.rs
+++ b/crates/gdsr-viewer/src/ruler.rs
@@ -302,6 +302,62 @@ mod tests {
     }
 
     #[test]
+    fn format_distance_very_large() {
+        let s = format_distance(1.0);
+        assert!(s.contains("mm"));
+    }
+
+    #[test]
+    fn format_distance_negative() {
+        let s = format_distance(-5e-8);
+        assert!(s.contains("nm"));
+    }
+
+    #[test]
+    fn measurement_distance_zero() {
+        let m = Measurement {
+            start: (0.0, 0.0),
+            end: (0.0, 0.0),
+        };
+        assert!((m.distance() - 0.0).abs() < 1e-20);
+    }
+
+    #[test]
+    fn measurement_distance_extreme_coords() {
+        let m = Measurement {
+            start: (-1e6, -1e6),
+            end: (1e6, 1e6),
+        };
+        let d = m.distance();
+        assert!(d.is_finite());
+        assert!(d > 0.0);
+    }
+
+    #[test]
+    fn ruler_many_measurements() {
+        let mut ruler = RulerState {
+            active: true,
+            ..Default::default()
+        };
+        for i in 0..100 {
+            ruler.handle_click(f64::from(i), 0.0);
+            ruler.handle_click(f64::from(i) + 0.5, 0.0);
+        }
+        assert_eq!(ruler.measurements.len(), 100);
+        ruler.clear_all();
+        assert!(ruler.measurements.is_empty());
+    }
+
+    #[test]
+    fn toggle_twice_returns_to_original_state() {
+        let mut ruler = RulerState::default();
+        ruler.toggle();
+        ruler.toggle();
+        assert!(!ruler.active);
+        assert!(ruler.start.is_none());
+    }
+
+    #[test]
     fn click_ignored_when_inactive() {
         let mut ruler = RulerState::default();
         assert!(!ruler.handle_click(0.0, 0.0));

--- a/crates/gdsr-viewer/src/spatial.rs
+++ b/crates/gdsr-viewer/src/spatial.rs
@@ -103,8 +103,8 @@ impl SpatialGrid {
         let gs = GRID_SIZE as isize;
         for dr in -1..=1 {
             for dc in -1..=1 {
-                let r = row + dr;
-                let c = col + dc;
+                let r = row.saturating_add(dr);
+                let c = col.saturating_add(dc);
                 if r < 0 || c < 0 || r >= gs || c >= gs {
                     continue;
                 }
@@ -121,10 +121,14 @@ impl SpatialGrid {
 
     /// Returns an iterator over grid cells that overlap the given visible world-space rectangle.
     pub fn query_visible(&self, visible: &WorldBBox) -> impl Iterator<Item = &GridCell> {
-        let col_min = ((visible.min_x - self.world_min_x) / self.cell_width).floor() as isize - 1;
-        let col_max = ((visible.max_x - self.world_min_x) / self.cell_width).ceil() as isize + 1;
-        let row_min = ((visible.min_y - self.world_min_y) / self.cell_height).floor() as isize - 1;
-        let row_max = ((visible.max_y - self.world_min_y) / self.cell_height).ceil() as isize + 1;
+        let col_min = ((visible.min_x - self.world_min_x) / self.cell_width).floor() as isize;
+        let col_max = ((visible.max_x - self.world_min_x) / self.cell_width).ceil() as isize;
+        let row_min = ((visible.min_y - self.world_min_y) / self.cell_height).floor() as isize;
+        let row_max = ((visible.max_y - self.world_min_y) / self.cell_height).ceil() as isize;
+        let col_min = col_min.saturating_sub(1);
+        let col_max = col_max.saturating_add(1);
+        let row_min = row_min.saturating_sub(1);
+        let row_max = row_max.saturating_add(1);
 
         let col_min = col_min.clamp(0, GRID_SIZE as isize - 1) as usize;
         let col_max = col_max.clamp(0, GRID_SIZE as isize - 1) as usize;
@@ -449,6 +453,107 @@ mod tests {
         assert!((bbox.min_y - 0.0).abs() < 1e-15);
         assert!((bbox.max_x - 100.0 * scale).abs() < 1e-15);
         assert!((bbox.max_y - 200.0 * scale).abs() < 1e-15);
+    }
+
+    #[test]
+    fn build_degenerate_zero_area_bounds() {
+        let poly = polygon(vec![(500, 500), (500, 500), (500, 500)], 1, 0);
+        let bounds = WorldBBox::new(500e-9, 500e-9, 500e-9, 500e-9);
+        let grid = SpatialGrid::build(&[poly], &bounds);
+        let all = query_element_indices(&grid, &bounds);
+        assert!(all.contains(&0));
+    }
+
+    #[test]
+    fn build_many_elements_same_location() {
+        let scale = 1e-9;
+        let elems: Vec<Element> = (0..1000)
+            .map(|_| polygon(vec![(0, 0), (10, 0), (10, 10)], 1, 0))
+            .collect();
+        let bounds = WorldBBox::new(0.0, 0.0, 10.0 * scale, 10.0 * scale);
+        let grid = SpatialGrid::build(&elems, &bounds);
+        let all = query_element_indices(&grid, &bounds);
+        assert_eq!(all.len(), 1000);
+    }
+
+    #[test]
+    fn build_element_spanning_entire_grid() {
+        let scale = 1e-9;
+        let large = polygon(vec![(0, 0), (10000, 0), (10000, 10000), (0, 10000)], 1, 0);
+        let small = polygon(vec![(100, 100), (200, 100), (200, 200)], 2, 0);
+        let bounds = WorldBBox::new(0.0, 0.0, 10000.0 * scale, 10000.0 * scale);
+        let grid = SpatialGrid::build(&[large, small], &bounds);
+        let visible = WorldBBox::new(50.0 * scale, 50.0 * scale, 250.0 * scale, 250.0 * scale);
+        let indices = query_element_indices(&grid, &visible);
+        assert!(indices.contains(&0), "large spanning element must be found");
+        assert!(
+            indices.contains(&1),
+            "small element in visible area must be found"
+        );
+    }
+
+    #[test]
+    fn query_point_at_grid_boundary() {
+        let scale = 1e-9;
+        let poly = polygon(vec![(0, 0), (1000, 0), (1000, 1000), (0, 1000)], 1, 0);
+        let bounds = WorldBBox::new(0.0, 0.0, 1000.0 * scale, 1000.0 * scale);
+        let grid = SpatialGrid::build(&[poly], &bounds);
+        let mut buf = Vec::new();
+        let indices = grid.query_point(0.0, 0.0, &mut buf);
+        assert!(indices.contains(&0), "element at grid origin must be found");
+    }
+
+    #[test]
+    fn query_visible_beyond_grid_extent() {
+        let scale = 1e-9;
+        let poly = polygon(vec![(0, 0), (100, 0), (100, 100)], 1, 0);
+        let bounds = WorldBBox::new(0.0, 0.0, 100.0 * scale, 100.0 * scale);
+        let grid = SpatialGrid::build(&[poly], &bounds);
+        let huge_visible = WorldBBox::new(-1.0, -1.0, 1.0, 1.0);
+        let indices = query_element_indices(&grid, &huge_visible);
+        assert!(indices.contains(&0));
+    }
+
+    #[test]
+    fn build_with_extreme_coordinates() {
+        let max = i32::MAX / 2;
+        let min = i32::MIN / 2;
+        let scale = 1e-9;
+        let p1 = polygon(
+            vec![(min, min), (min + 100, min), (min + 100, min + 100)],
+            1,
+            0,
+        );
+        let p2 = polygon(
+            vec![(max - 100, max - 100), (max, max - 100), (max, max)],
+            2,
+            0,
+        );
+        let bounds = WorldBBox::new(
+            f64::from(min) * scale,
+            f64::from(min) * scale,
+            f64::from(max) * scale,
+            f64::from(max) * scale,
+        );
+        let grid = SpatialGrid::build(&[p1, p2], &bounds);
+        let all = query_element_indices(&grid, &bounds);
+        assert_eq!(all, vec![0, 1]);
+    }
+
+    #[test]
+    fn query_point_reuses_buffer() {
+        let scale = 1e-9;
+        let poly = polygon(vec![(0, 0), (100, 0), (100, 100)], 1, 0);
+        let bounds = WorldBBox::new(0.0, 0.0, 1000.0 * scale, 1000.0 * scale);
+        let grid = SpatialGrid::build(&[poly], &bounds);
+        let mut buf = Vec::new();
+        let _ = grid.query_point(50.0 * scale, 50.0 * scale, &mut buf);
+        let first_len = buf.len();
+        let _ = grid.query_point(900.0 * scale, 900.0 * scale, &mut buf);
+        assert!(
+            buf.len() != first_len || first_len == 0,
+            "buffer should be reused and cleared between queries"
+        );
     }
 
     #[test]

--- a/crates/gdsr-viewer/src/state.rs
+++ b/crates/gdsr-viewer/src/state.rs
@@ -349,6 +349,77 @@ mod tests {
     }
 
     #[test]
+    fn no_rerender_at_zoom_ratio_boundary_low() {
+        let cache = populated_cache();
+        let rect = test_rect();
+        assert!(!cache.needs_full_render(&[], 42, 0.0, 0.0, 0.5, rect));
+    }
+
+    #[test]
+    fn rerender_just_below_zoom_ratio_boundary() {
+        let cache = populated_cache();
+        let rect = test_rect();
+        assert!(cache.needs_full_render(&[], 42, 0.0, 0.0, 0.49, rect));
+    }
+
+    #[test]
+    fn no_rerender_at_zoom_ratio_boundary_high() {
+        let cache = populated_cache();
+        let rect = test_rect();
+        assert!(!cache.needs_full_render(&[], 42, 0.0, 0.0, 2.0, rect));
+    }
+
+    #[test]
+    fn rerender_just_above_zoom_ratio_boundary() {
+        let cache = populated_cache();
+        let rect = test_rect();
+        assert!(cache.needs_full_render(&[], 42, 0.0, 0.0, 2.01, rect));
+    }
+
+    #[test]
+    fn no_rerender_at_exact_margin() {
+        let cache = populated_cache();
+        let rect = test_rect();
+        // margin_x = 800 * 0.8 = 640, dx_screen = |0 - 640| = 640, NOT > 640
+        assert!(!cache.needs_full_render(&[], 42, 640.0, 0.0, 1.0, rect));
+    }
+
+    #[test]
+    fn rerender_just_beyond_margin() {
+        let cache = populated_cache();
+        let rect = test_rect();
+        assert!(cache.needs_full_render(&[], 42, 641.0, 0.0, 1.0, rect));
+    }
+
+    #[test]
+    fn delta_transform_extreme_zoom_ratio() {
+        let cache = populated_cache();
+        let rect = test_rect();
+        let tsf = cache.delta_transform(0.0, 0.0, 2.0, rect.center());
+        assert!(tsf.scaling.is_finite());
+        assert!(tsf.translation.x.is_finite());
+        assert!(tsf.translation.y.is_finite());
+    }
+
+    #[test]
+    fn delta_transform_large_pan() {
+        let cache = populated_cache();
+        let rect = test_rect();
+        let tsf = cache.delta_transform(1e6, 1e6, 1.0, rect.center());
+        assert!(tsf.translation.x.is_finite());
+        assert!(tsf.translation.y.is_finite());
+    }
+
+    #[test]
+    fn clear_forces_rerender() {
+        let mut cache = populated_cache();
+        let rect = test_rect();
+        assert!(!cache.needs_full_render(&[], 42, 0.0, 0.0, 1.0, rect));
+        cache.clear();
+        assert!(cache.needs_full_render(&[], 42, 0.0, 0.0, 1.0, rect));
+    }
+
+    #[test]
     fn tessellation_cache_returns_same_indices() {
         let coords: Vec<f64> = vec![0.0, 0.0, 100.0, 0.0, 100.0, 100.0, 0.0, 100.0];
         let mut cache: HashMap<u32, Vec<usize>> = HashMap::new();

--- a/crates/gdsr-viewer/src/viewport/bounds.rs
+++ b/crates/gdsr-viewer/src/viewport/bounds.rs
@@ -97,6 +97,67 @@ mod tests {
     }
 
     #[test]
+    fn compute_bounds_single_element_with_extreme_coords() {
+        let max = i32::MAX / 2;
+        let elem = polygon(vec![(0, 0), (max, 0), (max, max)], 1, 0);
+        let bounds = compute_bounds(&[elem]).expect("should have bounds");
+        assert!(bounds.min_x.is_finite());
+        assert!(bounds.max_x.is_finite());
+        assert!(bounds.max_x > bounds.min_x);
+    }
+
+    #[test]
+    fn compute_bounds_many_elements() {
+        let elems: Vec<gdsr::Element> = (0..100)
+            .map(|i| {
+                polygon(
+                    vec![
+                        (i * 10, i * 10),
+                        (i * 10 + 5, i * 10),
+                        (i * 10 + 5, i * 10 + 5),
+                    ],
+                    1,
+                    0,
+                )
+            })
+            .collect();
+        let bounds = compute_bounds(&elems).expect("should have bounds");
+        assert!(bounds.min_x.is_finite());
+        assert!(bounds.max_x > bounds.min_x);
+        assert!(bounds.max_y > bounds.min_y);
+    }
+
+    #[test]
+    fn compute_bounds_with_node() {
+        let n = gdsr::Node::new(
+            vec![
+                gdsr::Point::default_integer(100, 200),
+                gdsr::Point::default_integer(300, 400),
+            ],
+            gdsr::Layer::new(1),
+            gdsr::DataType::new(0),
+        );
+        let bounds = compute_bounds(&[gdsr::Element::Node(n)]).expect("should have bounds");
+        let scale = 1e-9;
+        assert!((bounds.min_x - 100.0 * scale).abs() < EPSILON);
+        assert!((bounds.min_y - 200.0 * scale).abs() < EPSILON);
+    }
+
+    #[test]
+    fn compute_bounds_with_gds_box() {
+        let b = gdsr::GdsBox::new(
+            gdsr::Point::default_integer(10, 20),
+            gdsr::Point::default_integer(30, 40),
+            gdsr::Layer::new(1),
+            gdsr::DataType::new(0),
+        );
+        let bounds = compute_bounds(&[gdsr::Element::Box(b)]).expect("should have bounds");
+        let scale = 1e-9;
+        assert!((bounds.min_x - 10.0 * scale).abs() < EPSILON);
+        assert!((bounds.max_x - 30.0 * scale).abs() < EPSILON);
+    }
+
+    #[test]
     fn bbox_overlaps_is_symmetric() {
         let a = WorldBBox::new(0.0, 0.0, 2.0, 2.0);
         let b = WorldBBox::new(1.0, 1.0, 3.0, 3.0);

--- a/crates/gdsr-viewer/src/viewport/mod.rs
+++ b/crates/gdsr-viewer/src/viewport/mod.rs
@@ -525,6 +525,150 @@ mod tests {
     }
 
     #[test]
+    fn world_to_screen_extreme_zoom_min() {
+        let vp = Viewport {
+            center_x: 0.0,
+            center_y: 0.0,
+            zoom: 1e-3,
+        };
+        let rect = test_rect();
+        let screen = vp.world_to_screen(1e6, 1e6, rect);
+        assert!(screen.x.is_finite());
+        assert!(screen.y.is_finite());
+    }
+
+    #[test]
+    fn world_to_screen_extreme_zoom_max() {
+        let vp = Viewport {
+            center_x: 0.0,
+            center_y: 0.0,
+            zoom: 1e15,
+        };
+        let rect = test_rect();
+        let screen = vp.world_to_screen(1e-15, 1e-15, rect);
+        assert!(screen.x.is_finite());
+        assert!(screen.y.is_finite());
+    }
+
+    #[test]
+    fn world_to_screen_large_world_coordinates() {
+        let vp = Viewport {
+            center_x: 2.0,
+            center_y: 2.0,
+            zoom: 1.0,
+        };
+        let rect = test_rect();
+        let screen = vp.world_to_screen(2.147e9 * 1e-9, 2.147e9 * 1e-9, rect);
+        assert!(screen.x.is_finite());
+        assert!(screen.y.is_finite());
+    }
+
+    #[test]
+    fn zoom_to_fit_zero_area_bounds() {
+        let mut vp = Viewport::default();
+        let rect = test_rect();
+        let bounds = WorldBBox::new(5.0, 5.0, 5.0, 5.0);
+        vp.zoom_to_fit(&bounds, rect);
+        assert!((vp.center_x - 5.0).abs() < EPSILON);
+        assert!((vp.center_y - 5.0).abs() < EPSILON);
+        assert!(
+            (vp.zoom - 1.0).abs() < EPSILON,
+            "zoom should stay at default for zero-area bounds"
+        );
+    }
+
+    #[test]
+    fn zoom_to_fit_zero_width() {
+        let mut vp = Viewport::default();
+        let rect = test_rect();
+        let bounds = WorldBBox::new(5.0, 0.0, 5.0, 10.0);
+        vp.zoom_to_fit(&bounds, rect);
+        assert!((vp.center_x - 5.0).abs() < EPSILON);
+        assert!(
+            (vp.zoom - 1.0).abs() < EPSILON,
+            "zoom should stay at default for zero-width bounds"
+        );
+    }
+
+    #[test]
+    fn zoom_to_fit_huge_bounds() {
+        let mut vp = Viewport::default();
+        let rect = test_rect();
+        let bounds = WorldBBox::new(-1e6, -1e6, 1e6, 1e6);
+        vp.zoom_to_fit(&bounds, rect);
+        assert!(vp.zoom > 0.0);
+        assert!(vp.zoom.is_finite());
+    }
+
+    #[test]
+    fn zoom_to_fit_tiny_bounds() {
+        let mut vp = Viewport::default();
+        let rect = test_rect();
+        let bounds = WorldBBox::new(0.0, 0.0, 1e-12, 1e-12);
+        vp.zoom_to_fit(&bounds, rect);
+        assert!(vp.zoom > 0.0);
+        assert!(vp.zoom.is_finite());
+    }
+
+    #[test]
+    fn visible_world_rect_extreme_zoom_min() {
+        let vp = Viewport {
+            center_x: 0.0,
+            center_y: 0.0,
+            zoom: 1e-3,
+        };
+        let rect = test_rect();
+        let vis = vp.visible_world_rect(rect);
+        assert!(vis.min_x.is_finite());
+        assert!(vis.max_x.is_finite());
+        assert!(vis.min_y.is_finite());
+        assert!(vis.max_y.is_finite());
+        assert!(vis.max_x > vis.min_x);
+        assert!(vis.max_y > vis.min_y);
+    }
+
+    #[test]
+    fn visible_world_rect_extreme_zoom_max() {
+        let vp = Viewport {
+            center_x: 0.0,
+            center_y: 0.0,
+            zoom: 1e15,
+        };
+        let rect = test_rect();
+        let vis = vp.visible_world_rect(rect);
+        assert!(vis.min_x.is_finite());
+        assert!(vis.max_x.is_finite());
+        assert!(vis.max_x > vis.min_x);
+    }
+
+    #[test]
+    fn pan_extreme_values() {
+        let mut vp = Viewport::default();
+        vp.pan(1e15, -1e15);
+        assert!(vp.center_x.is_finite());
+        assert!(vp.center_y.is_finite());
+    }
+
+    #[test]
+    fn repeated_zoom_stays_finite() {
+        let mut vp = Viewport {
+            zoom: 100.0,
+            ..Default::default()
+        };
+        for _ in 0..1000 {
+            vp.zoom_at_center(1.2);
+        }
+        assert!(vp.zoom.is_finite());
+        assert!(vp.zoom <= 1e15);
+
+        for _ in 0..2000 {
+            vp.zoom_at_center(1.0 / 1.2);
+        }
+        assert!(vp.zoom.is_finite());
+        assert!(vp.zoom >= 1e-3);
+    }
+
+    #[test]
     fn zoom_in_then_out_returns_to_original() {
         let rect = test_rect();
         let cursor = Pos2::new(600.0, 400.0);


### PR DESCRIPTION
## Summary

- Fix `isize` overflow panic in `SpatialGrid::query_point` and `query_visible` when world coordinates are far outside the grid bounds (e.g., hovering at extreme positions with large GDS files). Uses `saturating_add`/`saturating_sub` to prevent the overflow.
- Add 92 new stress tests (138 → 230) covering edge cases across all viewer modules: spatial grid, viewport, drawable, grid spacing, render cache, ruler, and bounds.
- Add 7 new property tests that fuzz `hit_test`, `query_point`, `query_visible`, `visible_world_rect`, and `zoom_to_fit` with random inputs to catch panics.

## Test plan

- All 230 viewer tests pass (`cargo nextest run --package gdsr-viewer`)
- Full suite of 835 tests pass (`cargo nextest run`)
- Pre-commit checks pass (`uvx prek run -a`)
- Property test `spatial_grid_query_point_never_panics` previously caught the overflow bug with input `(0.0, 3602915731.0)` and now passes