### PR TITLE
Add selectable display units with coordinate display in viewer

### DIFF
--- a/crates/gdsr-viewer/src/app.rs
+++ b/crates/gdsr-viewer/src/app.rs
@@ -8,7 +8,9 @@ use crate::quick_pick::{QuickPick, QuickPickResult};
 use crate::recent::RecentProjects;
 use crate::ruler::RulerState;
 use crate::spatial::SpatialGrid;
-use crate::state::{CellState, CellViewMode, FileLoadState, LayerState, RenderCache, SidePanelTab};
+use crate::state::{
+    CellState, CellViewMode, DisplayUnit, FileLoadState, LayerState, RenderCache, SidePanelTab,
+};
 use crate::viewport::{self, Viewport};
 
 /// Returns shortcut text with the platform-appropriate modifier (⌘ on macOS, Ctrl on others).
@@ -37,6 +39,7 @@ pub struct ViewerApp {
     cell_view_mode: CellViewMode,
     scroll_to_selected: bool,
     recent_projects: RecentProjects,
+    display_unit: DisplayUnit,
     cell_picker: QuickPick,
     recent_picker: QuickPick,
 }
@@ -57,6 +60,7 @@ impl Default for ViewerApp {
             side_panel_tab: SidePanelTab::default(),
             cell_view_mode: CellViewMode::default(),
             scroll_to_selected: false,
+            display_unit: DisplayUnit::default(),
             recent_projects: RecentProjects::load(),
             cell_picker: QuickPick::new("Search cells…"),
             recent_picker: QuickPick::new("Recent projects…"),
@@ -362,6 +366,12 @@ impl eframe::App for ViewerApp {
 
                 ui.separator();
 
+                if let Some((wx, wy)) = self.mouse_world_pos {
+                    ui.label(self.display_unit.format_pair(wx, wy));
+                }
+
+                ui.separator();
+
                 if self.file_load.loading {
                     ui.label("Loading...");
                 } else if self.cell.as_ref().is_some_and(|c| c.elements_loading) {
@@ -380,9 +390,14 @@ impl eframe::App for ViewerApp {
                 }
 
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                    if let Some((wx, wy)) = self.mouse_world_pos {
-                        ui.label(format!("({wx:.6}, {wy:.6})"));
-                    }
+                    egui::ComboBox::from_id_salt("display_unit")
+                        .selected_text(self.display_unit.label())
+                        .width(60.0)
+                        .show_ui(ui, |ui| {
+                            for unit in DisplayUnit::ALL {
+                                ui.selectable_value(&mut self.display_unit, unit, unit.label());
+                            }
+                        });
                     if self.ruler.active {
                         ui.label("Ruler: click to place point (Esc to cancel)");
                     }

--- a/crates/gdsr-viewer/src/state.rs
+++ b/crates/gdsr-viewer/src/state.rs
@@ -366,6 +366,133 @@ mod tests {
         assert_eq!(first, second);
         assert!(!first.is_empty());
     }
+
+    #[test]
+    fn display_unit_auto_nanometers() {
+        insta::assert_snapshot!(
+            DisplayUnit::Auto.format_pair(5e-8, -3e-8),
+            @"(50.00, -30.00) nm"
+        );
+    }
+
+    #[test]
+    fn display_unit_auto_micrometers() {
+        insta::assert_snapshot!(
+            DisplayUnit::Auto.format_pair(1.5e-6, 2.0e-5),
+            @"(1.500, 20.000) µm"
+        );
+    }
+
+    #[test]
+    fn display_unit_auto_millimeters() {
+        insta::assert_snapshot!(
+            DisplayUnit::Auto.format_pair(2.5e-3, 1.0e-3),
+            @"(2.5000, 1.0000) mm"
+        );
+    }
+
+    #[test]
+    fn display_unit_fixed_nanometers() {
+        insta::assert_snapshot!(
+            DisplayUnit::Nanometers.format_pair(1.5e-6, 2.0e-6),
+            @"(1500.00, 2000.00) nm"
+        );
+    }
+
+    #[test]
+    fn display_unit_fixed_micrometers() {
+        insta::assert_snapshot!(
+            DisplayUnit::Micrometers.format_pair(5e-8, 1e-7),
+            @"(0.050, 0.100) µm"
+        );
+    }
+
+    #[test]
+    fn display_unit_fixed_millimeters() {
+        insta::assert_snapshot!(
+            DisplayUnit::Millimeters.format_pair(5e-8, 1e-7),
+            @"(0.0000, 0.0001) mm"
+        );
+    }
+
+    #[test]
+    fn display_unit_auto_zero() {
+        insta::assert_snapshot!(
+            DisplayUnit::Auto.format_pair(0.0, 0.0),
+            @"(0.00, 0.00) nm"
+        );
+    }
+
+    #[test]
+    fn display_unit_auto_uses_larger_axis_for_scale() {
+        // x is in nm range but y is in µm range, so both should display as µm
+        insta::assert_snapshot!(
+            DisplayUnit::Auto.format_pair(5e-8, 2.0e-6),
+            @"(0.050, 2.000) µm"
+        );
+    }
+
+    #[test]
+    fn display_unit_label() {
+        insta::assert_snapshot!(DisplayUnit::Auto.label(), @"Auto");
+        insta::assert_snapshot!(DisplayUnit::Nanometers.label(), @"nm");
+        insta::assert_snapshot!(DisplayUnit::Micrometers.label(), @"µm");
+        insta::assert_snapshot!(DisplayUnit::Millimeters.label(), @"mm");
+    }
+
+    #[test]
+    fn display_unit_default_is_auto() {
+        assert_eq!(DisplayUnit::default(), DisplayUnit::Auto);
+    }
+}
+
+/// Controls how world coordinates (meters) are displayed to the user.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum DisplayUnit {
+    /// Automatically choose nm/µm/mm based on magnitude.
+    #[default]
+    Auto,
+    Nanometers,
+    Micrometers,
+    Millimeters,
+}
+
+impl DisplayUnit {
+    pub const ALL: [Self; 4] = [
+        Self::Auto,
+        Self::Nanometers,
+        Self::Micrometers,
+        Self::Millimeters,
+    ];
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Auto => "Auto",
+            Self::Nanometers => "nm",
+            Self::Micrometers => "µm",
+            Self::Millimeters => "mm",
+        }
+    }
+
+    /// Formats an (x, y) coordinate pair in the selected unit, using a
+    /// consistent unit suffix for both axes.
+    pub fn format_pair(self, x: f64, y: f64) -> String {
+        match self {
+            Self::Auto => {
+                let abs = x.abs().max(y.abs());
+                if abs < 1e-6 {
+                    format!("({:.2}, {:.2}) nm", x * 1e9, y * 1e9)
+                } else if abs < 1e-3 {
+                    format!("({:.3}, {:.3}) µm", x * 1e6, y * 1e6)
+                } else {
+                    format!("({:.4}, {:.4}) mm", x * 1e3, y * 1e3)
+                }
+            }
+            Self::Nanometers => format!("({:.2}, {:.2}) nm", x * 1e9, y * 1e9),
+            Self::Micrometers => format!("({:.3}, {:.3}) µm", x * 1e6, y * 1e6),
+            Self::Millimeters => format!("({:.4}, {:.4}) mm", x * 1e3, y * 1e3),
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]


### PR DESCRIPTION
## Summary

- Display real-time cursor coordinates in the bottom-left of the status bar, formatted with meaningful physical units (nm, µm, mm) instead of raw float values
- Add a unit selector dropdown (Auto/nm/µm/mm) on the right side of the status bar for user-configurable coordinate display
- Auto mode picks the appropriate unit based on the larger coordinate magnitude, keeping both axes in the same unit for consistency

Closes #194

## Test plan

- Verify 10 new inline snapshot tests cover all `DisplayUnit` variants and edge cases (Auto scale selection, fixed units, zero coordinates, mixed-magnitude axes)
- All 148 viewer tests pass
- Manual testing: open a GDS file, hover over the layout, and confirm coordinates update in real-time with proper unit formatting; switch units via dropdown and verify display updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)