### PR TITLE
Make QuickPick generic and improve recent projects display

### DIFF
--- a/crates/gdsr-viewer/src/app.rs
+++ b/crates/gdsr-viewer/src/app.rs
@@ -5,7 +5,7 @@ use std::thread;
 use crate::drawable::Drawable;
 use crate::panels;
 use crate::quick_pick::{QuickPick, QuickPickResult};
-use crate::recent::RecentProjects;
+use crate::recent::{RecentProjectItem, RecentProjects};
 use crate::ruler::RulerState;
 use crate::spatial::SpatialGrid;
 use crate::state::{
@@ -40,8 +40,8 @@ pub struct ViewerApp {
     scroll_to_selected: bool,
     recent_projects: RecentProjects,
     display_unit: DisplayUnit,
-    cell_picker: QuickPick,
-    recent_picker: QuickPick,
+    cell_picker: QuickPick<String>,
+    recent_picker: QuickPick<RecentProjectItem>,
 }
 
 impl Default for ViewerApp {
@@ -62,8 +62,8 @@ impl Default for ViewerApp {
             scroll_to_selected: false,
             display_unit: DisplayUnit::default(),
             recent_projects: RecentProjects::load(),
-            cell_picker: QuickPick::new("Search cells…"),
-            recent_picker: QuickPick::new("Recent projects…"),
+            cell_picker: QuickPick::new("Search cells…", true),
+            recent_picker: QuickPick::new("Recent projects…", false),
         }
     }
 }
@@ -409,25 +409,27 @@ impl eframe::App for ViewerApp {
         });
 
         // Cell picker (⌘P)
-        let cell_names: Vec<String> = self
-            .cell
-            .as_ref()
-            .map(|c| c.cell_names.clone())
-            .unwrap_or_default();
-        if let QuickPickResult::Selected(idx) = self.cell_picker.show(ctx, &cell_names, true) {
-            self.select_cell(&cell_names[idx]);
+        self.cell_picker.set_items(
+            self.cell
+                .as_ref()
+                .map(|c| c.cell_names.clone())
+                .unwrap_or_default(),
+        );
+        if let QuickPickResult::Selected(idx) = self.cell_picker.show(ctx) {
+            let name = self.cell_picker.items()[idx].clone();
+            self.select_cell(&name);
         }
 
         // Recent projects picker (⌘⌥O)
-        let recent_labels: Vec<String> = self
-            .recent_projects
-            .paths()
-            .iter()
-            .map(|p| p.display().to_string())
-            .collect();
-        if let QuickPickResult::Selected(idx) = self.recent_picker.show(ctx, &recent_labels, false)
-        {
-            let path = self.recent_projects.paths()[idx].clone();
+        self.recent_picker.set_items(
+            self.recent_projects
+                .paths()
+                .iter()
+                .map(|p| RecentProjectItem::from_path(p))
+                .collect(),
+        );
+        if let QuickPickResult::Selected(idx) = self.recent_picker.show(ctx) {
+            let path = self.recent_picker.items()[idx].path.clone();
             self.load_path(&path);
         }
 

--- a/crates/gdsr-viewer/src/quick_pick.rs
+++ b/crates/gdsr-viewer/src/quick_pick.rs
@@ -1,11 +1,32 @@
+/// An item that can be displayed in a [`QuickPick`].
+pub trait QuickPickItem {
+    /// Text used for case-insensitive substring filtering.
+    fn filter_text(&self) -> &str;
+
+    /// Render the item content. The picker handles selection highlighting.
+    fn ui(&self, ui: &mut egui::Ui);
+}
+
+impl QuickPickItem for String {
+    fn filter_text(&self) -> &str {
+        self
+    }
+
+    fn ui(&self, ui: &mut egui::Ui) {
+        ui.label(self.as_str());
+    }
+}
+
 /// A filterable floating picker dialog, similar to VS Code's Quick Pick or Zed's command palette.
-pub struct QuickPick {
+pub struct QuickPick<T> {
     open: bool,
     query: String,
     hint: String,
     /// Index into the filtered list (not the original items).
     cursor: usize,
     scroll_to_cursor: bool,
+    items: Vec<T>,
+    filterable: bool,
 }
 
 /// The result of showing a `QuickPick` for a single frame.
@@ -19,19 +40,29 @@ pub enum QuickPickResult {
     Dismissed,
 }
 
-impl QuickPick {
-    pub fn new(hint: impl Into<String>) -> Self {
+impl<T: QuickPickItem> QuickPick<T> {
+    pub fn new(hint: impl Into<String>, filterable: bool) -> Self {
         Self {
             open: false,
             query: String::new(),
             hint: hint.into(),
             cursor: 0,
             scroll_to_cursor: false,
+            items: Vec::new(),
+            filterable,
         }
     }
 
     pub fn is_open(&self) -> bool {
         self.open
+    }
+
+    pub fn items(&self) -> &[T] {
+        &self.items
+    }
+
+    pub fn set_items(&mut self, items: Vec<T>) {
+        self.items = items;
     }
 
     pub fn open(&mut self) {
@@ -58,16 +89,9 @@ impl QuickPick {
 
     /// Shows the picker and returns the outcome for this frame.
     ///
-    /// `items` is the full list of display labels. The picker filters them by the query
-    /// (case-insensitive substring match). When `filterable` is false, all items are
-    /// shown regardless of the query (useful for recent projects where the search box
-    /// still provides focus but items aren't filtered).
-    pub fn show(
-        &mut self,
-        ctx: &egui::Context,
-        items: &[String],
-        filterable: bool,
-    ) -> QuickPickResult {
+    /// When `filterable` is true, items are filtered by case-insensitive substring match
+    /// on their `filter_text`. When false, all items are always shown.
+    pub fn show(&mut self, ctx: &egui::Context) -> QuickPickResult {
         if !self.open {
             return QuickPickResult::None;
         }
@@ -75,11 +99,14 @@ impl QuickPick {
         let mut result = QuickPickResult::None;
         let query_lower = self.query.to_lowercase();
 
-        let filtered_indices: Vec<usize> = items
+        let filtered_indices: Vec<usize> = self
+            .items
             .iter()
             .enumerate()
-            .filter(|(_, label)| {
-                !filterable || query_lower.is_empty() || label.to_lowercase().contains(&query_lower)
+            .filter(|(_, item)| {
+                !self.filterable
+                    || query_lower.is_empty()
+                    || item.filter_text().to_lowercase().contains(&query_lower)
             })
             .map(|(i, _)| i)
             .collect();
@@ -134,7 +161,32 @@ impl QuickPick {
                 egui::ScrollArea::vertical().show(ui, |ui| {
                     for (pos, &idx) in filtered_indices.iter().enumerate() {
                         let highlighted = pos == self.cursor;
-                        let response = ui.selectable_label(highlighted, &items[idx]);
+                        let item = &self.items[idx];
+
+                        let bg_idx = ui.painter().add(egui::Shape::Noop);
+
+                        let inner = ui.horizontal(|ui| {
+                            ui.set_min_width(ui.available_width());
+                            item.ui(ui);
+                        });
+                        let response = inner.response.interact(egui::Sense::click());
+
+                        let visuals = ui.style().interact_selectable(&response, highlighted);
+                        if highlighted
+                            || response.hovered()
+                            || response.highlighted()
+                            || response.has_focus()
+                        {
+                            ui.painter().set(
+                                bg_idx,
+                                egui::Shape::from(egui::epaint::RectShape::filled(
+                                    response.rect.expand(visuals.expansion),
+                                    visuals.corner_radius,
+                                    visuals.bg_fill,
+                                )),
+                            );
+                        }
+
                         if highlighted && self.scroll_to_cursor {
                             response.scroll_to_me(Some(egui::Align::Center));
                             self.scroll_to_cursor = false;

--- a/crates/gdsr-viewer/src/recent.rs
+++ b/crates/gdsr-viewer/src/recent.rs
@@ -1,5 +1,7 @@
 use std::path::{Path, PathBuf};
 
+use crate::quick_pick::QuickPickItem;
+
 const MAX_ENTRIES: usize = 10;
 
 /// Persists a list of recently opened file paths.
@@ -49,6 +51,56 @@ impl RecentProjects {
     pub fn paths(&self) -> &[PathBuf] {
         &self.paths
     }
+}
+
+/// An item in the recent-projects picker, showing the file name prominently
+/// and the abbreviated path below it.
+pub struct RecentProjectItem {
+    pub name: String,
+    pub display_path: String,
+    pub path: PathBuf,
+}
+
+impl RecentProjectItem {
+    pub fn from_path(path: &Path) -> Self {
+        let name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("unknown")
+            .to_string();
+
+        let display_path = abbreviate_home(path);
+
+        Self {
+            name,
+            display_path,
+            path: path.to_path_buf(),
+        }
+    }
+}
+
+impl QuickPickItem for RecentProjectItem {
+    fn filter_text(&self) -> &str {
+        &self.name
+    }
+
+    fn ui(&self, ui: &mut egui::Ui) {
+        ui.vertical(|ui| {
+            ui.spacing_mut().item_spacing.y = 1.0;
+            ui.label(&self.name);
+            ui.label(egui::RichText::new(&self.display_path).small().weak());
+        });
+    }
+}
+
+/// Replaces the home directory prefix with `~` for shorter display.
+fn abbreviate_home(path: &Path) -> String {
+    if let Ok(home) = std::env::var("HOME") {
+        if let Some(rest) = path.to_str().and_then(|p| p.strip_prefix(&home)) {
+            return format!("~{rest}");
+        }
+    }
+    path.display().to_string()
 }
 
 fn config_path() -> Option<PathBuf> {
@@ -109,5 +161,33 @@ mod tests {
     #[test]
     fn config_path_returns_some() {
         assert!(config_path().is_some());
+    }
+
+    #[test]
+    fn abbreviate_home_replaces_prefix() {
+        let home = std::env::var("HOME").unwrap();
+        let path = PathBuf::from(&home).join("Documents/test.gds");
+        insta::assert_snapshot!(abbreviate_home(&path), @"~/Documents/test.gds");
+    }
+
+    #[test]
+    fn abbreviate_home_leaves_non_home_paths() {
+        insta::assert_snapshot!(abbreviate_home(Path::new("/tmp/test.gds")), @"/tmp/test.gds");
+    }
+
+    #[test]
+    fn recent_project_item_from_path() {
+        let item = RecentProjectItem::from_path(Path::new("/some/dir/chip.gds"));
+        insta::assert_snapshot!(item.name, @"chip.gds");
+        insta::assert_snapshot!(item.display_path, @"/some/dir/chip.gds");
+    }
+
+    #[test]
+    fn recent_project_item_from_home_path() {
+        let home = std::env::var("HOME").unwrap();
+        let path = PathBuf::from(&home).join("projects/chip.gds");
+        let item = RecentProjectItem::from_path(&path);
+        insta::assert_snapshot!(item.name, @"chip.gds");
+        insta::assert_snapshot!(item.display_path, @"~/projects/chip.gds");
     }
 }

--- a/crates/gdsr-viewer/src/recent.rs
+++ b/crates/gdsr-viewer/src/recent.rs
@@ -175,8 +175,9 @@ mod tests {
     #[test]
     fn abbreviate_home_replaces_prefix() {
         let home = home_dir();
-        let path = PathBuf::from(&home).join("Documents/test.gds");
-        assert_eq!(abbreviate_home(&path), "~/Documents/test.gds");
+        let path_str = format!("{home}/Documents/test.gds");
+        let path = Path::new(&path_str);
+        assert_eq!(abbreviate_home(path), "~/Documents/test.gds");
     }
 
     #[test]
@@ -194,8 +195,8 @@ mod tests {
     #[test]
     fn recent_project_item_from_home_path() {
         let home = home_dir();
-        let path = PathBuf::from(&home).join("projects/chip.gds");
-        let item = RecentProjectItem::from_path(&path);
+        let path_str = format!("{home}/projects/chip.gds");
+        let item = RecentProjectItem::from_path(Path::new(&path_str));
         insta::assert_snapshot!(item.name, @"chip.gds");
         assert_eq!(item.display_path, "~/projects/chip.gds");
     }

--- a/crates/gdsr-viewer/src/recent.rs
+++ b/crates/gdsr-viewer/src/recent.rs
@@ -95,7 +95,10 @@ impl QuickPickItem for RecentProjectItem {
 
 /// Replaces the home directory prefix with `~` for shorter display.
 fn abbreviate_home(path: &Path) -> String {
-    if let Ok(home) = std::env::var("HOME") {
+    let home = std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .ok();
+    if let Some(home) = home {
         if let Some(rest) = path.to_str().and_then(|p| p.strip_prefix(&home)) {
             return format!("~{rest}");
         }
@@ -163,11 +166,17 @@ mod tests {
         assert!(config_path().is_some());
     }
 
+    fn home_dir() -> String {
+        std::env::var("HOME")
+            .or_else(|_| std::env::var("USERPROFILE"))
+            .unwrap()
+    }
+
     #[test]
     fn abbreviate_home_replaces_prefix() {
-        let home = std::env::var("HOME").unwrap();
+        let home = home_dir();
         let path = PathBuf::from(&home).join("Documents/test.gds");
-        insta::assert_snapshot!(abbreviate_home(&path), @"~/Documents/test.gds");
+        assert_eq!(abbreviate_home(&path), "~/Documents/test.gds");
     }
 
     #[test]
@@ -184,10 +193,10 @@ mod tests {
 
     #[test]
     fn recent_project_item_from_home_path() {
-        let home = std::env::var("HOME").unwrap();
+        let home = home_dir();
         let path = PathBuf::from(&home).join("projects/chip.gds");
         let item = RecentProjectItem::from_path(&path);
         insta::assert_snapshot!(item.name, @"chip.gds");
-        insta::assert_snapshot!(item.display_path, @"~/projects/chip.gds");
+        assert_eq!(item.display_path, "~/projects/chip.gds");
     }
 }


### PR DESCRIPTION
## Summary

Make `QuickPick` generic and improve recent-project entries with prominent names and abbreviated paths. Closes #204.

## Test Plan

Ran focused recent-project tests and the viewer test suite.