### PR TITLE
Fix path extension rendering in viewer

### DIFF
--- a/crates/gdsr-viewer/src/drawable.rs
+++ b/crates/gdsr-viewer/src/drawable.rs
@@ -398,11 +398,18 @@ impl Drawable for gdsr::Path {
 
     fn world_bbox(&self) -> Option<WorldBBox> {
         let (min_pt, max_pt) = self.bounding_box();
+        let half_width = self
+            .width()
+            .map(|w| w.absolute_value() / 2.0)
+            .unwrap_or(0.0);
+        let begin_ext = self.begin_extension().map_or(0.0, |u| u.absolute_value());
+        let end_ext = self.end_extension().map_or(0.0, |u| u.absolute_value());
+        let pad = half_width + begin_ext.max(end_ext);
         Some(WorldBBox::new(
-            min_pt.x().absolute_value(),
-            min_pt.y().absolute_value(),
-            max_pt.x().absolute_value(),
-            max_pt.y().absolute_value(),
+            min_pt.x().absolute_value() - pad,
+            min_pt.y().absolute_value() - pad,
+            max_pt.x().absolute_value() + pad,
+            max_pt.y().absolute_value() + pad,
         ))
     }
 
@@ -418,14 +425,47 @@ impl Drawable for gdsr::Path {
         let min_tolerance = 3.0 / zoom;
         let tolerance = half_width.max(min_tolerance);
         let tol_sq = tolerance * tolerance;
-        for pair in pts.windows(2) {
-            let (ax, ay) = (pair[0].x().absolute_value(), pair[0].y().absolute_value());
-            let (bx, by) = (pair[1].x().absolute_value(), pair[1].y().absolute_value());
-            if point_to_segment_dist_sq(wx, wy, ax, ay, bx, by) <= tol_sq {
-                return true;
+
+        let path_type = self.path_type().unwrap_or_default();
+        let begin_ext = self.begin_extension().map_or(0.0, |u| u.absolute_value());
+        let end_ext = self.end_extension().map_or(0.0, |u| u.absolute_value());
+
+        let mut segments: Vec<(f64, f64, f64, f64)> = pts
+            .windows(2)
+            .map(|pair| {
+                (
+                    pair[0].x().absolute_value(),
+                    pair[0].y().absolute_value(),
+                    pair[1].x().absolute_value(),
+                    pair[1].y().absolute_value(),
+                )
+            })
+            .collect();
+
+        if path_type == gdsr::PathType::Overlap && !segments.is_empty() {
+            if let Some(first) = segments.first_mut() {
+                let dx = first.2 - first.0;
+                let dy = first.3 - first.1;
+                let len = (dx * dx + dy * dy).sqrt();
+                if len > f64::EPSILON {
+                    first.0 -= dx / len * begin_ext;
+                    first.1 -= dy / len * begin_ext;
+                }
+            }
+            if let Some(last) = segments.last_mut() {
+                let dx = last.2 - last.0;
+                let dy = last.3 - last.1;
+                let len = (dx * dx + dy * dy).sqrt();
+                if len > f64::EPSILON {
+                    last.2 += dx / len * end_ext;
+                    last.3 += dy / len * end_ext;
+                }
             }
         }
-        false
+
+        segments
+            .iter()
+            .any(|&(ax, ay, bx, by)| point_to_segment_dist_sq(wx, wy, ax, ay, bx, by) <= tol_sq)
     }
 
     fn draw(&self, ctx: &mut DrawContext) {

--- a/crates/gdsr-viewer/src/spatial.rs
+++ b/crates/gdsr-viewer/src/spatial.rs
@@ -412,10 +412,11 @@ mod tests {
             .world_bbox()
             .expect("should have bbox");
         let scale = 1e-9;
-        assert!((bbox.min_x - 10.0 * scale).abs() < 1e-15);
-        assert!((bbox.min_y - 20.0 * scale).abs() < 1e-15);
-        assert!((bbox.max_x - 30.0 * scale).abs() < 1e-15);
-        assert!((bbox.max_y - 40.0 * scale).abs() < 1e-15);
+        let half_width = 2.5 * scale;
+        assert!((bbox.min_x - (10.0 * scale - half_width)).abs() < 1e-15);
+        assert!((bbox.min_y - (20.0 * scale - half_width)).abs() < 1e-15);
+        assert!((bbox.max_x - (30.0 * scale + half_width)).abs() < 1e-15);
+        assert!((bbox.max_y - (40.0 * scale + half_width)).abs() < 1e-15);
     }
 
     #[test]

--- a/crates/gdsr/src/geometry/path_expansion.rs
+++ b/crates/gdsr/src/geometry/path_expansion.rs
@@ -158,6 +158,12 @@ fn miter_or_bevel(
     right.push((p.0 - miter.0 / 2.0 * s, p.1 - miter.1 / 2.0 * s));
 }
 
+/// Generates a semicircular end cap.
+///
+/// The polygon is built as: left, end cap, right reversed, begin cap.
+/// The end cap must start at the left offset and sweep clockwise to the right offset.
+/// The begin cap must start at the right offset (where the reversed right side ends)
+/// and sweep clockwise to the left offset (where the polygon closes).
 fn semicircle_cap(
     center: (f64, f64),
     normal: (f64, f64),
@@ -168,17 +174,17 @@ fn semicircle_cap(
     let segments = segments.max(4);
     let mut pts = Vec::with_capacity(segments + 1);
 
-    // The cap goes from one side of the normal to the other, sweeping π radians
-    let start_angle = normal.1.atan2(normal.0);
-    let sweep = if is_begin {
-        std::f64::consts::PI
+    // End cap starts from +normal (left offset), begin cap from −normal (right offset).
+    // Both sweep −π (clockwise) to reach the opposite side.
+    let start_angle = if is_begin {
+        (-normal.1).atan2(-normal.0)
     } else {
-        -std::f64::consts::PI
+        normal.1.atan2(normal.0)
     };
 
     for i in 0..=segments {
         let t = i as f64 / segments as f64;
-        let angle = start_angle + sweep * t;
+        let angle = start_angle - std::f64::consts::PI * t;
         pts.push((
             center.0 + half_width * angle.cos(),
             center.1 + half_width * angle.sin(),
@@ -266,13 +272,56 @@ mod tests {
             0.0,
             4,
         );
-        // Left side + end semicircle + right side reversed + begin semicircle
-        assert!(pts.len() > 4, "Round cap should produce more points");
-        // First and last left-side points
+        // left(2) + end_cap(5) + right_rev(2) + begin_cap(5) = 14
+        assert_eq!(pts.len(), 14);
+        // First point: left[0] = (0, 1)
         assert!((pts[0].0 - 0.0).abs() < 1e-10);
         assert!((pts[0].1 - 1.0).abs() < 1e-10);
+        // Second: left[1] = (10, 1)
         assert!((pts[1].0 - 10.0).abs() < 1e-10);
         assert!((pts[1].1 - 1.0).abs() < 1e-10);
+        // Last point of polygon should equal first (closed, contiguous)
+        let last = pts.last().unwrap();
+        assert!((last.0 - pts[0].0).abs() < 1e-10);
+        assert!((last.1 - pts[0].1).abs() < 1e-10);
+    }
+
+    #[test]
+    fn round_cap_polygon_is_contiguous() {
+        // Use a short path (length 1) so the straight edges are shorter
+        // than the diameter (2 * half_width = 2). A broken cap that jumps
+        // across the diameter would produce a gap > 1.5, which exceeds
+        // the path length and is clearly wrong.
+        let pts = expand_path_to_polygon(
+            &[(0.0, 0.0), (1.0, 0.0)],
+            1.0,
+            PathType::Round,
+            0.0,
+            0.0,
+            16,
+        );
+        let max_gap_sq = pts
+            .windows(2)
+            .map(|w| {
+                let dx = w[1].0 - w[0].0;
+                let dy = w[1].1 - w[0].1;
+                dx * dx + dy * dy
+            })
+            .fold(0.0_f64, f64::max);
+        // The longest straight edge is 1.0 (gap² = 1.0). Arc steps with
+        // 16 segments are much smaller. A cap-connection gap would be ≈2.0
+        // (gap² ≈ 4.0), easily caught by this threshold.
+        assert!(
+            max_gap_sq < 1.5,
+            "gap² = {max_gap_sq}, polygon has a discontinuity"
+        );
+        // Polygon should close: last point ≈ first point
+        let first = pts.first().unwrap();
+        let last = pts.last().unwrap();
+        assert!(
+            (first.0 - last.0).abs() < 1e-10 && (first.1 - last.1).abs() < 1e-10,
+            "polygon not closed: first={first:?}, last={last:?}"
+        );
     }
 
     #[test]

--- a/crates/gdsr/src/geometry/path_expansion.rs
+++ b/crates/gdsr/src/geometry/path_expansion.rs
@@ -351,4 +351,153 @@ mod tests {
             .is_empty()
         );
     }
+
+    #[test]
+    fn overlap_zero_extension_matches_no_extension() {
+        let with_zero = expand_path_to_polygon(
+            &[(0.0, 0.0), (10.0, 0.0)],
+            1.0,
+            PathType::Overlap,
+            0.0,
+            0.0,
+            8,
+        );
+        let without = expand_path_to_polygon(
+            &[(0.0, 0.0), (10.0, 0.0)],
+            1.0,
+            PathType::Square,
+            0.0,
+            0.0,
+            8,
+        );
+        insta::assert_debug_snapshot!(with_zero, @r"
+        [
+            (
+                0.0,
+                1.0,
+            ),
+            (
+                10.0,
+                1.0,
+            ),
+            (
+                10.0,
+                -1.0,
+            ),
+            (
+                0.0,
+                -1.0,
+            ),
+        ]
+        ");
+        assert_eq!(with_zero, without);
+    }
+
+    #[test]
+    fn overlap_extension_polygon_is_contiguous() {
+        let pts = expand_path_to_polygon(
+            &[(0.0, 0.0), (5.0, 0.0), (10.0, 0.0)],
+            1.0,
+            PathType::Overlap,
+            2.0,
+            3.0,
+            8,
+        );
+        // Extended polygon should span from x=-2 to x=13, with no gaps at segment joins
+        insta::assert_debug_snapshot!(pts, @r"
+        [
+            (
+                -2.0,
+                1.0,
+            ),
+            (
+                5.0,
+                1.0,
+            ),
+            (
+                13.0,
+                1.0,
+            ),
+            (
+                13.0,
+                -1.0,
+            ),
+            (
+                5.0,
+                -1.0,
+            ),
+            (
+                -2.0,
+                -1.0,
+            ),
+        ]
+        ");
+    }
+
+    #[test]
+    fn overlap_diagonal_extensions() {
+        let pts = expand_path_to_polygon(
+            &[(0.0, 0.0), (10.0, 10.0)],
+            1.0,
+            PathType::Overlap,
+            2.0,
+            3.0,
+            8,
+        );
+        assert_eq!(pts.len(), 4);
+        // Begin extends backward along (−1/√2, −1/√2) by 2
+        // End extends forward along (1/√2, 1/√2) by 3
+        // Normal is (−1/√2, 1/√2), so left offset adds normal, right subtracts
+        let s = 1.0 / 2.0_f64.sqrt();
+        let begin = (-2.0 * s, -2.0 * s);
+        let end = (10.0 + 3.0 * s, 10.0 + 3.0 * s);
+        // left[0] = begin + normal * hw
+        assert!((pts[0].0 - (begin.0 - s)).abs() < 1e-10);
+        assert!((pts[0].1 - (begin.1 + s)).abs() < 1e-10);
+        // left[1] = end + normal * hw
+        assert!((pts[1].0 - (end.0 - s)).abs() < 1e-10);
+        assert!((pts[1].1 - (end.1 + s)).abs() < 1e-10);
+    }
+
+    #[test]
+    fn square_ignores_extensions() {
+        let with_ext = expand_path_to_polygon(
+            &[(0.0, 0.0), (10.0, 0.0)],
+            1.0,
+            PathType::Square,
+            5.0,
+            5.0,
+            8,
+        );
+        let without_ext = expand_path_to_polygon(
+            &[(0.0, 0.0), (10.0, 0.0)],
+            1.0,
+            PathType::Square,
+            0.0,
+            0.0,
+            8,
+        );
+        assert_eq!(with_ext, without_ext);
+    }
+
+    #[test]
+    fn round_ignores_extensions() {
+        let with_ext = expand_path_to_polygon(
+            &[(0.0, 0.0), (10.0, 0.0)],
+            1.0,
+            PathType::Round,
+            5.0,
+            5.0,
+            8,
+        );
+        let without_ext = expand_path_to_polygon(
+            &[(0.0, 0.0), (10.0, 0.0)],
+            1.0,
+            PathType::Round,
+            0.0,
+            0.0,
+            8,
+        );
+        assert_eq!(with_ext, without_ext);
+    }
 }

--- a/crates/gdsr/src/property_tests/path.rs
+++ b/crates/gdsr/src/property_tests/path.rs
@@ -100,6 +100,73 @@ fn straight_path_area_matches_length_times_width(x_end: i16, width: u8) -> bool 
     rel_err < 1e-6
 }
 
+/// For a straight Overlap path, area ≈ (length + `begin_ext` + `end_ext`) × width.
+#[quickcheck]
+fn overlap_extension_area_matches_extended_length_times_width(
+    x_end: i16,
+    width: u8,
+    begin_ext: u8,
+    end_ext: u8,
+) -> bool {
+    let x_end = i32::from(x_end).max(1);
+    let width = i32::from(width).max(1);
+    let begin_ext = i32::from(begin_ext);
+    let end_ext = i32::from(end_ext);
+    let units = 1e-6;
+
+    let path = Path::new(
+        vec![Point::integer(0, 0, units), Point::integer(x_end, 0, units)],
+        Layer::new(0),
+        DataType::new(0),
+        Some(PathType::Overlap),
+        Some(Unit::integer(width, units)),
+        Some(Unit::integer(begin_ext, units)),
+        Some(Unit::integer(end_ext, units)),
+    );
+
+    let Some(poly_pts) = path.to_polygon_points(8) else {
+        return false;
+    };
+
+    let computed_area = geometry::area(&poly_pts).float_value();
+    let expected =
+        (f64::from(x_end) + f64::from(begin_ext) + f64::from(end_ext)) * f64::from(width);
+    let rel_err = (computed_area - expected).abs() / expected.max(1e-10);
+    rel_err < 1e-6
+}
+
+/// Overlap with zero extensions produces the same polygon as Square with no extensions.
+#[quickcheck]
+fn overlap_zero_extension_matches_square(x_end: i16, width: u8) -> bool {
+    let x_end = i32::from(x_end).max(1);
+    let width = i32::from(width).max(1);
+    let units = 1e-6;
+
+    let overlap_path = Path::new(
+        vec![Point::integer(0, 0, units), Point::integer(x_end, 0, units)],
+        Layer::new(0),
+        DataType::new(0),
+        Some(PathType::Overlap),
+        Some(Unit::integer(width, units)),
+        Some(Unit::integer(0, units)),
+        Some(Unit::integer(0, units)),
+    );
+
+    let square_path = Path::new(
+        vec![Point::integer(0, 0, units), Point::integer(x_end, 0, units)],
+        Layer::new(0),
+        DataType::new(0),
+        Some(PathType::Square),
+        Some(Unit::integer(width, units)),
+        None,
+        None,
+    );
+
+    let overlap_pts = overlap_path.to_polygon_points(8);
+    let square_pts = square_path.to_polygon_points(8);
+    overlap_pts == square_pts
+}
+
 /// All centerline points of a straight horizontal path should be inside the expanded polygon.
 #[quickcheck]
 fn centerline_points_inside_expanded_straight_path(x_end: i16, width: u8) -> bool {


### PR DESCRIPTION
## Summary

Fix round-cap winding and overlap path bounds or hit testing so extended paths render without gaps and remain interactive. Closes #191.

## Test Plan

Ran focused unit and property coverage, nextest, and `uvx prek run -a`.