### PR TITLE
Fix release artifact upload failing on directories

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,10 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: artifacts-${{ matrix.target }}
-          path: target/distrib/*
+          path: |
+            target/distrib/*.tar.xz
+            target/distrib/*.tar.gz
+            target/distrib/*.zip
 
   build-viewer-global:
     name: Build viewer installers


### PR DESCRIPTION
## Summary

Restrict release uploads to archive files so cargo-dist output directories no longer cause `gh release upload` failures.

## Test Plan

Verified through the release workflow and checked that platform archives were uploaded.