### PR TITLE
Simplify artifact upload glob and include checksums

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,10 +105,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: artifacts-${{ matrix.target }}
-          path: |
-            target/distrib/*.tar.xz
-            target/distrib/*.tar.gz
-            target/distrib/*.zip
+          path: target/distrib/*.*
 
   build-viewer-global:
     name: Build viewer installers


### PR DESCRIPTION
## Summary

Broaden the release artifact glob to include checksum files while excluding raw directories.

## Test Plan

Verified through the release workflow.