### PR TITLE
Add version to workspace gdsr dependency for publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["Matthew McKee <matthewmckee4@yahoo.co.uk>"]
 license = "MIT"
 
 [workspace.dependencies]
-gdsr = { path = "crates/gdsr" }
+gdsr = { path = "crates/gdsr", version = "0.0.1-alpha.2" }
 
 approx = "0.5"
 bytemuck = "1.25.0"

--- a/seal.toml
+++ b/seal.toml
@@ -2,6 +2,7 @@
 current-version = "0.0.1-alpha.2"
 
 version-files = [
+    "Cargo.toml",
     "crates/gdsr/Cargo.toml",
     "crates/gdsr-viewer/Cargo.toml",
 ]


### PR DESCRIPTION
## Summary

Add the workspace dependency version required to publish `gdsr-viewer` to crates.io. Fixes #216.

## Test Plan

Verified with a `cargo publish -p gdsr-viewer --dry-run --allow-dirty` run.