### PR TITLE
Introduce Radians and Degrees newtype wrappers for type-safe angles

### DIFF
--- a/crates/gdsr-viewer/src/testutil.rs
+++ b/crates/gdsr-viewer/src/testutil.rs
@@ -40,7 +40,7 @@ pub mod helpers {
             Layer::new(layer),
             DataType::new(0),
             1.0,
-            0.0,
+            gdsr::Radians::new(0.0),
             false,
             VerticalPresentation::default(),
             HorizontalPresentation::default(),

--- a/crates/gdsr/benches/io.rs
+++ b/crates/gdsr/benches/io.rs
@@ -1,7 +1,7 @@
 use criterion::{Criterion, criterion_group, criterion_main};
 use gdsr::{
     Cell, DataType, Grid, HorizontalPresentation, Layer, Library, Path, PathType, Point, Polygon,
-    Reference, Text, Unit, VerticalPresentation,
+    Radians, Reference, Text, Unit, VerticalPresentation,
 };
 
 const DB_UNITS: f64 = 1e-9;
@@ -69,7 +69,7 @@ fn medium_library() -> Library {
             Layer::new((i % 16) as u16),
             DataType::new(0),
             1.0 + f64::from(i % 5) * 0.5,
-            f64::from(i % 4) * 0.785,
+            Radians::new(f64::from(i % 4) * 0.785),
             i % 2 == 0,
             VERT_PRES[i as usize % 3],
             HORIZ_PRES[i as usize % 3],
@@ -132,7 +132,7 @@ fn complex_library() -> Library {
                 Layer::new(((c + i) % 64) as u16),
                 DataType::new((i % 4) as u16),
                 1.0 + f64::from(i % 3) * 0.5,
-                f64::from(i % 8) * std::f64::consts::FRAC_PI_4,
+                Radians::new(f64::from(i % 8) * std::f64::consts::FRAC_PI_4),
                 i % 3 == 0,
                 VERT_PRES[i as usize % 3],
                 HORIZ_PRES[i as usize % 3],
@@ -155,7 +155,7 @@ fn complex_library() -> Library {
                         .with_spacing_x(Some(point(12_000, 0)))
                         .with_spacing_y(Some(point(0, 10_000)))
                         .with_magnification(1.0 + f64::from(c) * 0.1)
-                        .with_angle(f64::from(c) * 0.1)
+                        .with_angle(Radians::new(f64::from(c) * 0.1))
                         .with_x_reflection(c % 2 == 0),
                 ),
             );
@@ -190,7 +190,7 @@ fn complex_library() -> Library {
                         .with_spacing_x(Some(point(100_000, 0)))
                         .with_spacing_y(Some(point(0, 80_000)))
                         .with_magnification(0.9 + f64::from(r) * 0.1)
-                        .with_angle(f64::from(r) * 0.05)
+                        .with_angle(Radians::new(f64::from(r) * 0.05))
                         .with_x_reflection(r % 2 == 1),
                 ),
             );

--- a/crates/gdsr/examples/sample.rs
+++ b/crates/gdsr/examples/sample.rs
@@ -1,6 +1,6 @@
 use gdsr::{
     Cell, DataType, Grid, HorizontalPresentation, Layer, Library, Path, PathType, Point, Polygon,
-    Reference, Text, Unit, VerticalPresentation, cell_to_svg,
+    Radians, Reference, Text, Unit, VerticalPresentation, cell_to_svg,
 };
 
 fn main() -> Result<(), gdsr::GdsError> {
@@ -87,7 +87,7 @@ fn main() -> Result<(), gdsr::GdsError> {
         Layer::new(6),
         DataType::new(0),
         1.0,
-        0.0,
+        Radians::new(0.0),
         false,
         VerticalPresentation::Bottom,
         HorizontalPresentation::Left,
@@ -98,7 +98,7 @@ fn main() -> Result<(), gdsr::GdsError> {
         Layer::new(7),
         DataType::new(0),
         2.0,
-        0.0,
+        Radians::new(0.0),
         false,
         VerticalPresentation::Middle,
         HorizontalPresentation::Centre,
@@ -113,7 +113,7 @@ fn main() -> Result<(), gdsr::GdsError> {
         None,
         None,
         1.0,
-        0.0,
+        Radians::new(0.0),
         false,
     )));
     top.add(Reference::new("paths").with_grid(Grid::new(
@@ -123,7 +123,7 @@ fn main() -> Result<(), gdsr::GdsError> {
         None,
         None,
         1.0,
-        0.0,
+        Radians::new(0.0),
         false,
     )));
     top.add(Reference::new("text").with_grid(Grid::new(
@@ -133,7 +133,7 @@ fn main() -> Result<(), gdsr::GdsError> {
         None,
         None,
         1.0,
-        0.0,
+        Radians::new(0.0),
         false,
     )));
     // Array reference: 3x2 grid of the polygons cell
@@ -144,7 +144,7 @@ fn main() -> Result<(), gdsr::GdsError> {
         Some(Point::default_integer(5000, 0)),
         Some(Point::default_integer(0, 2000)),
         1.0,
-        0.0,
+        Radians::new(0.0),
         false,
     )));
 

--- a/crates/gdsr/src/cell.rs
+++ b/crates/gdsr/src/cell.rs
@@ -223,7 +223,7 @@ impl Movable for Cell {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{DataType, Layer};
+    use crate::{DataType, Layer, Radians};
 
     #[test]
     fn test_cell_new() {
@@ -366,7 +366,7 @@ mod tests {
 
         insta::assert_debug_snapshot!(moved_elements);
 
-        let rotated_cell = moved_cell.rotate(90.0, Point::integer(5, 5, 1e-9));
+        let rotated_cell = moved_cell.rotate(Radians::new(90.0), Point::integer(5, 5, 1e-9));
 
         let rotated_elements = rotated_cell.get_elements(None, &library);
 

--- a/crates/gdsr/src/elements/element.rs
+++ b/crates/gdsr/src/elements/element.rs
@@ -257,7 +257,7 @@ impl Dimensions for Element {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{DataType, GdsBox, Grid, Layer, Node, Point};
+    use crate::{DataType, GdsBox, Grid, Layer, Node, Point, Radians};
 
     const UNITS: f64 = 1e-9;
 
@@ -452,7 +452,7 @@ mod tests {
     fn test_element_transform_preserves_variant() {
         let centre = origin();
         for element in all_elements() {
-            let rotated = element.clone().rotate(std::f64::consts::PI / 2.0, centre);
+            let rotated = element.clone().rotate(Radians::FRAC_PI_2, centre);
             assert_eq!(
                 std::mem::discriminant(&element),
                 std::mem::discriminant(&rotated)

--- a/crates/gdsr/src/elements/polygon.rs
+++ b/crates/gdsr/src/elements/polygon.rs
@@ -1,4 +1,6 @@
-use crate::{DataType, Dimensions, Layer, LayerMapping, Movable, Point, Transformable, Unit};
+use crate::{
+    DataType, Dimensions, Layer, LayerMapping, Movable, Point, Radians, Transformable, Unit,
+};
 
 fn are_points_closed(points: &[Point]) -> bool {
     let points_vec: Vec<Point> = points.to_vec();
@@ -51,7 +53,7 @@ impl Polygon {
         center: Point,
         radius: f64,
         num_sides: usize,
-        rotation: f64,
+        rotation: Radians,
         layer: Layer,
         data_type: DataType,
     ) -> Self {
@@ -61,7 +63,7 @@ impl Polygon {
         let y_units = center.y().units();
 
         let points = (0..num_sides).map(|i| {
-            let angle = rotation + (i as f64) * std::f64::consts::TAU / (num_sides as f64);
+            let angle = rotation.value() + (i as f64) * std::f64::consts::TAU / (num_sides as f64);
             center
                 + Point::new(
                     Unit::float(radius * angle.cos(), x_units),
@@ -428,8 +430,14 @@ mod tests {
     #[test]
     fn test_regular_polygon_num_sides_clamped_to_3() {
         let origin = Point::float(0.0, 0.0, 1e-6);
-        let polygon =
-            Polygon::regular_polygon(origin, 5.0, 1, 0.0, Layer::new(0), DataType::new(0));
+        let polygon = Polygon::regular_polygon(
+            origin,
+            5.0,
+            1,
+            Radians::new(0.0),
+            Layer::new(0),
+            DataType::new(0),
+        );
         assert_eq!(polygon.points().len(), 4);
     }
 }

--- a/crates/gdsr/src/elements/reference.rs
+++ b/crates/gdsr/src/elements/reference.rs
@@ -3,7 +3,7 @@ use std::sync::mpsc;
 
 use crate::elements::Element;
 use crate::traits::{Movable, Transformable};
-use crate::{Cell, Grid, Library, Point, Transformation};
+use crate::{Cell, Grid, Library, Point, Radians, Transformation};
 
 /// The target of a [`Reference`](crate::Reference): either a cell name or an inline element.
 #[derive(Clone, Debug, PartialEq)]
@@ -168,7 +168,7 @@ impl Reference {
 
                 // Apply transformations around cell-local origin (0,0)
                 if grid.x_reflection() {
-                    new_element = new_element.reflect(0.0, Point::default());
+                    new_element = new_element.reflect(Radians::new(0.0), Point::default());
                 }
 
                 new_element = new_element.rotate(grid.angle(), Point::default());
@@ -396,7 +396,7 @@ mod tests {
                 Layer::new(1),
                 DataType::new(0),
                 1.0,
-                0.0,
+                Radians::new(0.0),
                 false,
                 VerticalPresentation::Middle,
                 HorizontalPresentation::Centre,
@@ -712,7 +712,7 @@ mod tests {
             .with_spacing_x(Some(Point::integer(10, 0, 1e-9)))
             .with_spacing_y(Some(Point::integer(0, 10, 1e-9)))
             .with_magnification(2.0)
-            .with_angle(std::f64::consts::PI / 2.0)
+            .with_angle(Radians::FRAC_PI_2)
             .with_x_reflection(false);
 
         let reference = Reference::new(polygon.clone()).with_grid(grid);
@@ -743,9 +743,9 @@ mod tests {
         let reference = Reference::new(polygon).with_grid(grid);
 
         let centre = Point::integer(5, 5, 1e-9);
-        let transformed = reference.rotate(std::f64::consts::PI / 2.0, centre);
+        let transformed = reference.rotate(Radians::FRAC_PI_2, centre);
 
-        assert!(transformed.grid().angle() != 0.0);
+        assert!(transformed.grid().angle() != Radians::new(0.0));
     }
 
     #[test]
@@ -1350,7 +1350,7 @@ mod tests {
             .with_columns(2)
             .with_rows(1)
             .with_spacing_x(Some(Point::integer(20, 0, 1e-9)))
-            .with_angle(std::f64::consts::FRAC_PI_2);
+            .with_angle(Radians::FRAC_PI_2);
 
         let reference = Reference::new(polygon.clone()).with_grid(grid);
         let elements = reference.get_elements_in_grid(&Element::Polygon(polygon));
@@ -1441,7 +1441,7 @@ mod tests {
             .with_origin(Point::integer(100, 200, 1e-9))
             .with_columns(1)
             .with_rows(1)
-            .with_angle(std::f64::consts::FRAC_PI_2);
+            .with_angle(Radians::FRAC_PI_2);
 
         let reference = Reference::new("base").with_grid(grid);
         let flattened = reference.flatten(None, &library);

--- a/crates/gdsr/src/elements/text.rs
+++ b/crates/gdsr/src/elements/text.rs
@@ -1,4 +1,4 @@
-use crate::{DataType, Dimensions, Layer, Movable, Point, Transformable};
+use crate::{DataType, Dimensions, Layer, Movable, Point, Radians, Transformable};
 
 // --- Presentation types ---
 
@@ -158,7 +158,7 @@ pub struct Text {
     pub(crate) layer: Layer,
     pub(crate) datatype: DataType,
     pub(crate) magnification: f64,
-    pub(crate) angle: f64,
+    pub(crate) angle: Radians,
     pub(crate) x_reflection: bool,
     pub(crate) vertical_presentation: VerticalPresentation,
     pub(crate) horizontal_presentation: HorizontalPresentation,
@@ -172,7 +172,7 @@ impl Default for Text {
             layer: Layer::new(0),
             datatype: DataType::new(0),
             magnification: 1.0,
-            angle: 0.0,
+            angle: Radians::new(0.0),
             x_reflection: false,
             vertical_presentation: VerticalPresentation::default(),
             horizontal_presentation: HorizontalPresentation::default(),
@@ -188,7 +188,7 @@ impl Text {
         layer: Layer,
         datatype: DataType,
         magnification: f64,
-        angle: f64,
+        angle: Radians,
         x_reflection: bool,
         vertical_presentation: VerticalPresentation,
         horizontal_presentation: HorizontalPresentation,
@@ -269,13 +269,13 @@ impl Text {
     }
 
     /// Returns the rotation angle in radians.
-    pub const fn angle(&self) -> f64 {
+    pub const fn angle(&self) -> Radians {
         self.angle
     }
 
     /// Sets the rotation angle and returns the modified value.
     #[must_use]
-    pub fn set_angle(mut self, angle: f64) -> Self {
+    pub fn set_angle(mut self, angle: Radians) -> Self {
         self.angle = angle;
         self
     }
@@ -664,7 +664,7 @@ mod tests {
             Layer::new(5),
             DataType::new(0),
             2.0,
-            45.0,
+            Radians::new(45.0),
             true,
             VerticalPresentation::Top,
             HorizontalPresentation::Right,
@@ -674,7 +674,7 @@ mod tests {
         assert_eq!(text.origin(), &Point::integer(100, 200, 1e-9));
         assert_eq!(text.layer(), Layer::new(5));
         assert_eq!(text.magnification(), 2.0);
-        assert_eq!(text.angle(), 45.0);
+        assert_eq!(text.angle(), Radians::new(45.0));
         assert!(text.x_reflection());
     }
 
@@ -686,7 +686,7 @@ mod tests {
         assert_eq!(text.origin(), &Point::integer(0, 0, 1e-9));
         assert_eq!(text.layer(), Layer::new(0));
         assert_eq!(text.magnification(), 1.0);
-        assert_eq!(text.angle(), 0.0);
+        assert_eq!(text.angle(), Radians::new(0.0));
         assert!(!text.x_reflection());
     }
 
@@ -698,7 +698,7 @@ mod tests {
             Layer::new(1),
             DataType::new(0),
             1.5,
-            30.0,
+            Radians::new(30.0),
             false,
             VerticalPresentation::Bottom,
             HorizontalPresentation::Left,
@@ -734,8 +734,8 @@ mod tests {
 
     #[test]
     fn test_set_angle() {
-        let text = Text::default().set_angle(90.0);
-        assert_eq!(text.angle(), 90.0);
+        let text = Text::default().set_angle(Radians::new(90.0));
+        assert_eq!(text.angle(), Radians::new(90.0));
     }
 
     #[test]
@@ -766,7 +766,7 @@ mod tests {
             .set_origin(Point::integer(100, 200, 1e-9))
             .set_layer(Layer::new(5))
             .set_magnification(2.0)
-            .set_angle(45.0)
+            .set_angle(Radians::new(45.0))
             .set_x_reflection(true)
             .set_vertical_presentation(VerticalPresentation::Bottom)
             .set_horizontal_presentation(HorizontalPresentation::Left);
@@ -775,7 +775,7 @@ mod tests {
         assert_eq!(text.origin(), &Point::integer(100, 200, 1e-9));
         assert_eq!(text.layer(), Layer::new(5));
         assert_eq!(text.magnification(), 2.0);
-        assert_eq!(text.angle(), 45.0);
+        assert_eq!(text.angle(), Radians::new(45.0));
         assert!(text.x_reflection());
         assert_eq!(text.vertical_presentation(), &VerticalPresentation::Bottom);
         assert_eq!(
@@ -810,7 +810,7 @@ mod tests {
     fn test_text_rotate() {
         let text = Text::default();
 
-        let rotated_text = text.rotate(PI / 2.0, Point::origin());
+        let rotated_text = text.rotate(Radians::new(PI / 2.0), Point::origin());
 
         assert_debug_snapshot!(rotated_text, @r#"
         Text {
@@ -836,7 +836,9 @@ mod tests {
                 0,
             ),
             magnification: 1.0,
-            angle: 1.5707963267948966,
+            angle: Radians(
+                1.5707963267948966,
+            ),
             x_reflection: false,
             vertical_presentation: Middle,
             horizontal_presentation: Centre,
@@ -850,12 +852,12 @@ mod tests {
             .set_origin(Point::integer(10, 20, 1e-9))
             .set_x_reflection(false);
 
-        let reflected = text.reflect(0.0, Point::origin());
+        let reflected = text.reflect(Radians::new(0.0), Point::origin());
 
         assert!(reflected.x_reflection());
         assert_eq!(reflected.origin(), &Point::integer(10, -20, 1e-9));
 
-        let reflected_again = reflected.reflect(0.0, Point::origin());
+        let reflected_again = reflected.reflect(Radians::new(0.0), Point::origin());
 
         assert!(!reflected_again.x_reflection());
         assert_eq!(reflected_again.origin(), &Point::integer(10, 20, 1e-9));
@@ -899,13 +901,13 @@ mod tests {
             .set_x_reflection(false);
 
         let transformed = text
-            .reflect(0.0, Point::origin())
+            .reflect(Radians::new(0.0), Point::origin())
             .scale(2.0, Point::origin())
-            .rotate(PI / 2.0, Point::origin());
+            .rotate(Radians::new(PI / 2.0), Point::origin());
 
         assert!(transformed.x_reflection());
         assert_eq!(transformed.magnification(), 2.0);
-        assert_eq!(transformed.angle(), PI / 2.0);
+        assert_eq!(transformed.angle(), Radians::new(PI / 2.0));
 
         assert_debug_snapshot!(transformed, @r#"
         Text {
@@ -931,7 +933,9 @@ mod tests {
                 0,
             ),
             magnification: 2.0,
-            angle: 1.5707963267948966,
+            angle: Radians(
+                1.5707963267948966,
+            ),
             x_reflection: true,
             vertical_presentation: Middle,
             horizontal_presentation: Centre,

--- a/crates/gdsr/src/grid.rs
+++ b/crates/gdsr/src/grid.rs
@@ -1,8 +1,6 @@
 use std::f64::consts::PI;
 
-use crate::{
-    AngleInRadians, Movable, Point, Reflection, Rotation, Scale, Transformable, Transformation,
-};
+use crate::{Movable, Point, Radians, Reflection, Rotation, Scale, Transformable, Transformation};
 
 /// A grid layout that repeats elements in rows and columns with optional transformations.
 #[derive(Clone, Debug, PartialEq)]
@@ -13,7 +11,7 @@ pub struct Grid {
     spacing_x: Option<Point>,
     spacing_y: Option<Point>,
     magnification: f64,
-    angle: AngleInRadians,
+    angle: Radians,
     x_reflection: bool,
 }
 
@@ -27,7 +25,7 @@ impl Grid {
         spacing_x: Option<Point>,
         spacing_y: Option<Point>,
         magnification: f64,
-        angle: AngleInRadians,
+        angle: Radians,
         x_reflection: bool,
     ) -> Self {
         Self {
@@ -73,7 +71,7 @@ impl Grid {
     }
 
     /// Returns the rotation angle in radians.
-    pub const fn angle(&self) -> f64 {
+    pub const fn angle(&self) -> Radians {
         self.angle
     }
 
@@ -155,13 +153,13 @@ impl Grid {
     }
 
     /// Sets the rotation angle in radians.
-    pub const fn set_angle(&mut self, angle: AngleInRadians) {
+    pub const fn set_angle(&mut self, angle: Radians) {
         self.angle = angle;
     }
 
     /// Returns a new grid with the given rotation angle.
     #[must_use]
-    pub const fn with_angle(mut self, angle: AngleInRadians) -> Self {
+    pub const fn with_angle(mut self, angle: Radians) -> Self {
         self.angle = angle;
         self
     }
@@ -210,7 +208,7 @@ impl Default for Grid {
             None,
             None,
             1.0,
-            0.0,
+            Radians::new(0.0),
             false,
         )
     }
@@ -226,7 +224,7 @@ impl std::fmt::Display for Grid {
             .map_or_else(|| "None".to_string(), |p| p.to_string());
         write!(
             f,
-            "Grid at {} with {} columns and {} rows, spacing ({}, {}), magnification {:?}, angle {:?}, x_reflection {}",
+            "Grid at {} with {} columns and {} rows, spacing ({}, {}), magnification {:?}, angle {}, x_reflection {}",
             self.origin,
             self.columns,
             self.rows,
@@ -272,12 +270,12 @@ impl Transformable for Grid {
 
         if let Some(rotation) = &transformation.rotation {
             self.angle += rotation.angle();
-            let result = self.angle % (PI * 2.0);
-            self.angle = if result < 0.0 {
+            let result = self.angle.value() % (PI * 2.0);
+            self.angle = Radians::new(if result < 0.0 {
                 result + PI * 2.0
             } else {
                 result
-            };
+            });
         }
 
         // Handle reflection
@@ -326,7 +324,7 @@ mod tests {
             Some(p(5, 0)),
             Some(p(0, 5)),
             1.0,
-            0.0,
+            Radians::new(0.0),
             false,
         )
     }
@@ -340,7 +338,7 @@ mod tests {
             Some(p(5, 0)),
             Some(p(0, 5)),
             1.5,
-            45.0,
+            Radians::new(45.0),
             true,
         );
 
@@ -350,7 +348,7 @@ mod tests {
         assert_eq!(grid.spacing_x(), Some(p(5, 0)));
         assert_eq!(grid.spacing_y(), Some(p(0, 5)));
         assert_eq!(grid.magnification(), 1.5);
-        assert_eq!(grid.angle(), 45.0);
+        assert_eq!(grid.angle(), Radians::new(45.0));
         assert!(grid.x_reflection());
     }
 
@@ -363,7 +361,7 @@ mod tests {
         assert_eq!(grid.spacing_x(), None);
         assert_eq!(grid.spacing_y(), None);
         assert_eq!(grid.magnification(), 1.0);
-        assert_eq!(grid.angle(), 0.0);
+        assert_eq!(grid.angle(), Radians::new(0.0));
         assert!(!grid.x_reflection());
     }
 
@@ -376,15 +374,33 @@ mod tests {
             Some(p(5, 0)),
             Some(p(0, 5)),
             1.0,
-            0.0,
+            Radians::new(0.0),
             false,
         );
         assert_snapshot!(format!("{grid}"), @"Grid at Point(10 (1.000e-9), 20 (1.000e-9)) with 2 columns and 3 rows, spacing (Point(5 (1.000e-9), 0 (1.000e-9)), Point(0 (1.000e-9), 5 (1.000e-9))), magnification 1.0, angle 0.0, x_reflection false");
 
-        let grid = Grid::new(p(10, 20), 2, 3, Some(p(5, 0)), None, 1.0, 0.0, false);
+        let grid = Grid::new(
+            p(10, 20),
+            2,
+            3,
+            Some(p(5, 0)),
+            None,
+            1.0,
+            Radians::new(0.0),
+            false,
+        );
         assert_snapshot!(format!("{grid}"), @"Grid at Point(10 (1.000e-9), 20 (1.000e-9)) with 2 columns and 3 rows, spacing (Point(5 (1.000e-9), 0 (1.000e-9)), None), magnification 1.0, angle 0.0, x_reflection false");
 
-        let grid = Grid::new(p(10, 20), 2, 3, None, Some(p(0, 5)), 1.0, 0.0, false);
+        let grid = Grid::new(
+            p(10, 20),
+            2,
+            3,
+            None,
+            Some(p(0, 5)),
+            1.0,
+            Radians::new(0.0),
+            false,
+        );
         assert_snapshot!(format!("{grid}"), @"Grid at Point(10 (1.000e-9), 20 (1.000e-9)) with 2 columns and 3 rows, spacing (None, Point(0 (1.000e-9), 5 (1.000e-9))), magnification 1.0, angle 0.0, x_reflection false");
     }
 
@@ -397,7 +413,7 @@ mod tests {
         grid.set_spacing_x(Some(p(10, 0)));
         grid.set_spacing_y(Some(p(0, 10)));
         grid.set_magnification(2.0);
-        grid.set_angle(90.0);
+        grid.set_angle(Radians::new(90.0));
         grid.set_x_reflection(true);
 
         let grid_with = test_grid()
@@ -407,7 +423,7 @@ mod tests {
             .with_spacing_x(Some(p(10, 0)))
             .with_spacing_y(Some(p(0, 10)))
             .with_magnification(2.0)
-            .with_angle(90.0)
+            .with_angle(Radians::new(90.0))
             .with_x_reflection(true);
 
         assert_eq!(grid, grid_with);
@@ -417,7 +433,7 @@ mod tests {
         assert_eq!(grid.spacing_x(), Some(p(10, 0)));
         assert_eq!(grid.spacing_y(), Some(p(0, 10)));
         assert_eq!(grid.magnification(), 2.0);
-        assert_eq!(grid.angle(), 90.0);
+        assert_eq!(grid.angle(), Radians::new(90.0));
         assert!(grid.x_reflection());
     }
 
@@ -431,13 +447,13 @@ mod tests {
 
     #[test]
     fn test_grid_transform_with_rotation() {
-        let transformed = test_grid().rotate(FRAC_PI_2, origin());
-        assert_eq!(transformed.angle, FRAC_PI_2);
+        let transformed = test_grid().rotate(Radians::new(FRAC_PI_2), origin());
+        assert_eq!(transformed.angle, Radians::new(FRAC_PI_2));
     }
 
     #[test]
     fn test_grid_transform_with_reflection() {
-        let transformed = test_grid().reflect(0.0, origin());
+        let transformed = test_grid().reflect(Radians::new(0.0), origin());
         assert!(transformed.x_reflection);
     }
 
@@ -459,7 +475,7 @@ mod tests {
             Some(p(10, 0)),
             Some(p(0, 10)),
             1.0,
-            0.0,
+            Radians::new(0.0),
             false,
         );
         let scaled = grid.scale(3.0, origin());
@@ -476,7 +492,7 @@ mod tests {
             Some(p(10, 0)),
             Some(p(0, 10)),
             1.0,
-            0.0,
+            Radians::new(0.0),
             false,
         );
         let scaled = grid.scale(2.0, p(50, 50));
@@ -515,11 +531,11 @@ mod tests {
             Some(p(5, 0)),
             Some(p(0, 5)),
             1.0,
-            FRAC_PI_2,
+            Radians::new(FRAC_PI_2),
             false,
         );
-        let transformed = grid.rotate(PI * 2.0, origin());
-        assert!((transformed.angle - FRAC_PI_2).abs() < 0.001);
+        let transformed = grid.rotate(Radians::new(PI * 2.0), origin());
+        assert!((transformed.angle.value() - FRAC_PI_2).abs() < 0.001);
     }
 
     #[test]
@@ -531,7 +547,7 @@ mod tests {
             Some(p(10, 0)),
             Some(p(0, 10)),
             1.0,
-            0.0,
+            Radians::new(0.0),
             false,
         );
         assert_eq!(grid.columns(), 1);
@@ -560,9 +576,9 @@ mod tests {
     #[test]
     fn test_grid_transform_rotation_then_reflection() {
         let transformed = test_grid()
-            .rotate(FRAC_PI_2, origin())
-            .reflect(0.0, origin());
-        assert!((transformed.angle() - FRAC_PI_2).abs() < 0.001);
+            .rotate(Radians::new(FRAC_PI_2), origin())
+            .reflect(Radians::new(0.0), origin());
+        assert!((transformed.angle().value() - FRAC_PI_2).abs() < 0.001);
         assert!(transformed.x_reflection());
     }
 
@@ -575,7 +591,7 @@ mod tests {
             Some(pf(10.0, 0.0)),
             Some(pf(0.0, 10.0)),
             1.0,
-            0.0,
+            Radians::new(0.0),
             false,
         );
         let converted = grid.to_integer_unit();
@@ -596,7 +612,7 @@ mod tests {
             Some(p(5, 0)),
             Some(p(0, 5)),
             1.0,
-            0.0,
+            Radians::new(0.0),
             false,
         );
         let converted = grid.to_float_unit();
@@ -608,7 +624,16 @@ mod tests {
 
     #[test]
     fn test_grid_to_integer_unit_none_spacing() {
-        let grid = Grid::new(pf(1.0, 2.0), 2, 2, None, None, 1.0, 0.0, false);
+        let grid = Grid::new(
+            pf(1.0, 2.0),
+            2,
+            2,
+            None,
+            None,
+            1.0,
+            Radians::new(0.0),
+            false,
+        );
         let converted = grid.to_integer_unit();
         assert_eq!(converted.spacing_x(), None);
         assert_eq!(converted.spacing_y(), None);

--- a/crates/gdsr/src/io/read/mod.rs
+++ b/crates/gdsr/src/io/read/mod.rs
@@ -8,7 +8,7 @@ use crate::elements::{GdsBox, Node, Path, PathType, Polygon, Reference, Text};
 use crate::error::GdsError;
 use crate::geometry::round_to_decimals;
 use crate::library::Library;
-use crate::{DEFAULT_INTEGER_UNITS, DataType, Instance, Layer, Point, Unit};
+use crate::{DEFAULT_INTEGER_UNITS, DataType, Degrees, Instance, Layer, Point, Unit};
 
 #[allow(clippy::too_many_lines)]
 pub fn from_gds<P: AsRef<std::path::Path>>(
@@ -278,10 +278,11 @@ pub fn from_gds<P: AsRef<std::path::Path>>(
                 }
                 GDSRecord::Angle => {
                     if let GDSRecordData::F64(angle) = data {
+                        let radians = Degrees::new(angle[0]).to_radians();
                         if let Some(text) = &mut text {
-                            text.angle = angle[0];
+                            text.angle = radians;
                         } else if let Some(reference) = &mut reference {
-                            reference.grid.set_angle(angle[0].to_radians());
+                            reference.grid.set_angle(radians);
                         }
                     }
                 }

--- a/crates/gdsr/src/io/write/mod.rs
+++ b/crates/gdsr/src/io/write/mod.rs
@@ -446,7 +446,7 @@ pub fn write_text(text: &Text, db_units: f64) -> Result<Vec<u8>, GdsError> {
     )?;
     write_transformation_to_file(
         &mut buffer,
-        text.angle(),
+        text.angle().to_degrees().value(),
         text.magnification(),
         text.x_reflection(),
     )?;
@@ -485,7 +485,7 @@ fn write_reference_element(
 
             let mut new_element = element.clone();
             if grid.x_reflection() {
-                new_element = new_element.reflect(0.0, Point::default());
+                new_element = new_element.reflect(crate::Radians::new(0.0), Point::default());
             }
             new_element = new_element.rotate(grid.angle(), Point::default());
             new_element = new_element.scale(grid.magnification(), Point::default());
@@ -519,7 +519,7 @@ fn write_reference_cell(
     write_string_with_record_to_file(&mut buffer, GDSRecord::SName, cell_name)?;
     write_transformation_to_file(
         &mut buffer,
-        grid.angle().to_degrees(),
+        grid.angle().to_degrees().value(),
         grid.magnification(),
         grid.x_reflection(),
     )?;

--- a/crates/gdsr/src/lib.rs
+++ b/crates/gdsr/src/lib.rs
@@ -27,5 +27,5 @@ pub use point::Point;
 pub use stats::{CellStats, LibraryStats};
 pub use traits::{Dimensions, Movable, Transformable};
 pub use transformation::{Reflection, Rotation, Scale, Transformation, Translation};
-pub use types::{AngleInRadians, DataType, Layer, LayerMapping};
+pub use types::{DataType, Degrees, Layer, LayerMapping, Radians};
 pub use units::{DEFAULT_FLOAT_UNITS, DEFAULT_INTEGER_UNITS, FloatUnit, IntegerUnit, Unit};

--- a/crates/gdsr/src/point.rs
+++ b/crates/gdsr/src/point.rs
@@ -1,7 +1,7 @@
 use std::ops::{Add, Div, Mul, Sub};
 
 use crate::units::Unit;
-use crate::{AngleInRadians, Movable, Transformable, Transformation};
+use crate::{Movable, Radians, Transformable, Transformation};
 
 /// A 2D point with x and y coordinates, each carrying their own unit of measurement.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
@@ -135,8 +135,8 @@ impl Point {
     /// # Returns
     /// A new `Point` representing the rotated position
     #[must_use]
-    pub fn rotate_around_point(&self, angle: AngleInRadians, center: &Self) -> Self {
-        if angle == 0.0 {
+    pub fn rotate_around_point(&self, angle: Radians, center: &Self) -> Self {
+        if angle.value() == 0.0 {
             return *self;
         }
 
@@ -386,7 +386,7 @@ mod tests {
         #[test]
         fn chaining_from_and_methods() {
             let point = Point::integer(100, 200, 1e-9);
-            let rotated = point.rotate(std::f64::consts::PI, Point::integer(0, 0, 1e-9));
+            let rotated = point.rotate(Radians(std::f64::consts::PI), Point::integer(0, 0, 1e-9));
 
             assert_eq!(point.x(), Unit::integer(100, 1e-9));
             assert_eq!(point.y(), Unit::integer(200, 1e-9));
@@ -478,11 +478,12 @@ mod tests {
         use std::f64::consts::PI;
 
         use super::*;
+        use crate::Radians;
 
         #[test]
         fn rotate_90_degrees() {
             let point = Point::float(1.0, 0.0, 1e-6);
-            let rotated = point.rotate(PI / 2.0, Point::float(0.0, 0.0, 1e-6));
+            let rotated = point.rotate(Radians(PI / 2.0), Point::float(0.0, 0.0, 1e-6));
 
             assert!((rotated.x().absolute_value() - 0.0) < 1e-15);
             assert!((rotated.y().absolute_value() - 1e-6) < 1e-15);
@@ -491,7 +492,7 @@ mod tests {
         #[test]
         fn rotate_180_degrees() {
             let point = Point::float(1.0, 0.0, 1e-6);
-            let rotated = point.rotate(PI, Point::float(0.0, 0.0, 1e-6));
+            let rotated = point.rotate(Radians(PI), Point::float(0.0, 0.0, 1e-6));
 
             assert!((rotated.x().absolute_value() - (-1e-6)) < 1e-15);
             assert!((rotated.y().absolute_value() - 0.0) < 1e-15);
@@ -500,7 +501,7 @@ mod tests {
         #[test]
         fn rotate_270_degrees() {
             let point = Point::float(1.0, 0.0, 1e-6);
-            let rotated = point.rotate(3.0 * PI / 2.0, Point::float(0.0, 0.0, 1e-6));
+            let rotated = point.rotate(Radians(3.0 * PI / 2.0), Point::float(0.0, 0.0, 1e-6));
 
             assert!((rotated.x().absolute_value() - 0.0) < 1e-15);
             assert!((rotated.y().absolute_value() - (-1e-6)) < 1e-15);
@@ -509,7 +510,7 @@ mod tests {
         #[test]
         fn rotate_360_degrees() {
             let point = Point::float(1.0, 0.0, 1e-6);
-            let rotated = point.rotate(2.0 * PI, Point::float(0.0, 0.0, 1e-6));
+            let rotated = point.rotate(Radians(2.0 * PI), Point::float(0.0, 0.0, 1e-6));
 
             assert!((rotated.x().absolute_value() - 1e-6) < 1e-15);
             assert!((rotated.y().absolute_value() - 0.0) < 1e-15);
@@ -518,7 +519,7 @@ mod tests {
         #[test]
         fn rotate_arbitrary_point() {
             let point = Point::float(3.0, 4.0, 1e-6);
-            let rotated = point.rotate(PI / 4.0, Point::float(0.0, 0.0, 1e-6)); // 45 degrees
+            let rotated = point.rotate(Radians(PI / 4.0), Point::float(0.0, 0.0, 1e-6));
 
             let expected_x = 3e-6f64.mul_add((PI / 4.0).cos(), -(4e-6 * (PI / 4.0).sin()));
             let expected_y = 3e-6f64.mul_add((PI / 4.0).sin(), 4e-6 * (PI / 4.0).cos());

--- a/crates/gdsr/src/property_tests/arbitrary.rs
+++ b/crates/gdsr/src/property_tests/arbitrary.rs
@@ -84,7 +84,7 @@ impl Arbitrary for Reflection {
             (i32::arbitrary(g) % MAX_COORD).clamp(-MAX_COORD, MAX_COORD),
             1e-9,
         );
-        Self::new(angle, centre)
+        Self::new(Radians::new(angle), centre)
     }
 }
 
@@ -101,7 +101,7 @@ impl Arbitrary for Rotation {
             (i32::arbitrary(g) % MAX_COORD).clamp(-MAX_COORD, MAX_COORD),
             1e-9,
         );
-        Self::new(angle, centre)
+        Self::new(Radians::new(angle), centre)
     }
 }
 
@@ -304,7 +304,7 @@ impl Arbitrary for Text {
             layer,
             datatype,
             1.0,
-            0.0,
+            Radians::new(0.0),
             false,
             hp_options[usize::arbitrary(g) % hp_options.len()],
             vp_options[usize::arbitrary(g) % vp_options.len()],
@@ -327,7 +327,7 @@ impl Arbitrary for Grid {
             Some(Point::integer(sx, 0, 1e-9)),
             Some(Point::integer(0, sy, 1e-9)),
             1.0,
-            0.0,
+            Radians::new(0.0),
             false,
         )
     }
@@ -441,7 +441,7 @@ pub(super) fn arb_gds_text(g: &mut Gen) -> Text {
         arb_layer(g),
         DataType::new(0),
         1.0,
-        0.0,
+        Radians::new(0.0),
         false,
         hp_options[usize::arbitrary(g) % hp_options.len()],
         vp_options[usize::arbitrary(g) % vp_options.len()],

--- a/crates/gdsr/src/property_tests/grid.rs
+++ b/crates/gdsr/src/property_tests/grid.rs
@@ -5,7 +5,9 @@ use crate::*;
 #[quickcheck]
 fn double_reflection_cancels(grid: Grid) -> bool {
     let centre = Point::integer(0, 0, 1e-9);
-    let transformed = grid.reflect(0.0, centre).reflect(0.0, centre);
+    let transformed = grid
+        .reflect(Radians::new(0.0), centre)
+        .reflect(Radians::new(0.0), centre);
     !transformed.x_reflection()
 }
 

--- a/crates/gdsr/src/property_tests/point.rs
+++ b/crates/gdsr/src/property_tests/point.rs
@@ -1,5 +1,3 @@
-use std::f64::consts::TAU;
-
 use quickcheck_macros::quickcheck;
 
 use crate::*;
@@ -72,7 +70,7 @@ fn scalar_multiplication_distributivity(a: Point, b: Point, s: i32) -> bool {
 fn rotation_by_2pi_is_identity(a: Point) -> bool {
     let a = a.to_float_unit();
     let origin = Point::float(0.0, 0.0, a.units().0);
-    let rotated = a.rotate(TAU, origin);
+    let rotated = a.rotate(Radians::TAU, origin);
 
     let dx = (rotated.x().absolute_value() - a.x().absolute_value()).abs();
     let dy = (rotated.y().absolute_value() - a.y().absolute_value()).abs();

--- a/crates/gdsr/src/property_tests/polygon.rs
+++ b/crates/gdsr/src/property_tests/polygon.rs
@@ -38,7 +38,7 @@ fn translation_preserves_perimeter(polygon: Polygon, dx: i32, dy: i32) -> bool {
 fn rotation_preserves_area(polygon: Polygon) -> bool {
     let units = polygon.points()[0].units().0;
     let centre = Point::integer(0, 0, units);
-    let rotated = polygon.clone().rotate(std::f64::consts::FRAC_PI_2, centre);
+    let rotated = polygon.clone().rotate(Radians::FRAC_PI_2, centre);
     let original_area = polygon.area().float_value();
     let rotated_area = rotated.area().float_value();
     if original_area == 0.0 {
@@ -74,7 +74,7 @@ fn regular_polygon_vertices_equidistant_from_center(num_sides: usize) -> bool {
         center,
         radius,
         num_sides,
-        0.0,
+        Radians::new(0.0),
         Layer::new(0),
         DataType::new(0),
     );

--- a/crates/gdsr/src/property_tests/roundtrip.rs
+++ b/crates/gdsr/src/property_tests/roundtrip.rs
@@ -1,5 +1,3 @@
-use std::f64::consts::FRAC_PI_2;
-
 use quickcheck::{Arbitrary, Gen};
 use quickcheck_macros::quickcheck;
 use tempfile::tempdir;
@@ -183,7 +181,7 @@ fn rotated_aref_roundtrip(_seed: u8) -> bool {
                 .with_rows(rows)
                 .with_spacing_x(Some(Point::integer(20, 0, 1e-9)))
                 .with_spacing_y(Some(Point::integer(0, 20, 1e-9)))
-                .with_angle(FRAC_PI_2),
+                .with_angle(Radians::FRAC_PI_2),
         ),
     );
     library.add_cell(cell);

--- a/crates/gdsr/src/property_tests/text.rs
+++ b/crates/gdsr/src/property_tests/text.rs
@@ -5,7 +5,10 @@ use crate::*;
 #[quickcheck]
 fn double_reflection_cancels(text: Text) -> bool {
     let centre = Point::integer(0, 0, text.origin().units().0);
-    let reflected_twice = text.clone().reflect(0.0, centre).reflect(0.0, centre);
+    let reflected_twice = text
+        .clone()
+        .reflect(Radians::new(0.0), centre)
+        .reflect(Radians::new(0.0), centre);
     reflected_twice.x_reflection() == text.x_reflection()
 }
 

--- a/crates/gdsr/src/property_tests/transformation.rs
+++ b/crates/gdsr/src/property_tests/transformation.rs
@@ -39,7 +39,7 @@ fn rotation_by_zero_is_identity(x: i32, y: i32, cx: i32, cy: i32) -> bool {
     let cy = (cy % MAX_COORD).clamp(-MAX_COORD, MAX_COORD);
     let point = Point::integer(x, y, 1e-9);
     let centre = Point::integer(cx, cy, 1e-9);
-    let rotation = Rotation::new(0.0, centre);
+    let rotation = Rotation::new(Radians::new(0.0), centre);
     let result = rotation.apply_to_point(&point);
     point_approx_eq(&result, &point, 1e-6)
 }
@@ -53,7 +53,7 @@ fn rotation_by_two_pi_is_identity(x: i32, y: i32, cx: i32, cy: i32) -> bool {
     let cy = (cy % MAX_COORD).clamp(-MAX_COORD, MAX_COORD);
     let point = Point::integer(x, y, 1e-9);
     let centre = Point::integer(cx, cy, 1e-9);
-    let rotation = Rotation::new(std::f64::consts::TAU, centre);
+    let rotation = Rotation::new(Radians::TAU, centre);
     let result = rotation.apply_to_point(&point);
     point_approx_eq(&result, &point, 1e-6)
 }

--- a/crates/gdsr/src/property_tests/validation.rs
+++ b/crates/gdsr/src/property_tests/validation.rs
@@ -1,5 +1,3 @@
-use std::f64::consts::{FRAC_PI_2, FRAC_PI_4};
-
 use quickcheck::Gen;
 use quickcheck_macros::quickcheck;
 use tempfile::tempdir;
@@ -44,7 +42,7 @@ fn get_elements(units: f64) -> Vec<Element> {
             Layer::new(3),
             DataType::new(0),
             2.0,
-            0.0,
+            Radians::new(0.0),
             false,
             VerticalPresentation::Middle,
             HorizontalPresentation::Centre,
@@ -94,7 +92,7 @@ fn get_elements(units: f64) -> Vec<Element> {
             Some(Point::integer(0, 10, units)),
             Some(Point::integer(10, 0, units)),
             1.0,
-            FRAC_PI_4,
+            Radians::FRAC_PI_4,
             false,
         ))
         .into(),
@@ -114,7 +112,7 @@ fn get_elements(units: f64) -> Vec<Element> {
             None,
             None,
             2.0,
-            FRAC_PI_4,
+            Radians::FRAC_PI_4,
             false,
         ))
         .into(),
@@ -134,7 +132,7 @@ fn get_elements(units: f64) -> Vec<Element> {
             None,
             None,
             2.0,
-            -FRAC_PI_4,
+            Radians::new(-std::f64::consts::FRAC_PI_4),
             false,
         ))
         .into(),
@@ -155,49 +153,7 @@ fn get_elements(units: f64) -> Vec<Element> {
             None,
             None,
             1.0,
-            0.0,
-            false,
-        ))
-        .into(),
-        Reference::new(Polygon::new(
-            [
-                Point::integer(0, 0, units),
-                Point::integer(20, 0, units),
-                Point::integer(20, 20, units),
-                Point::integer(0, 20, units),
-            ],
-            Layer::new(4),
-            DataType::new(0),
-        ))
-        .with_grid(Grid::new(
-            Point::integer(300, 50, units),
-            1,
-            2,
-            None,
-            Some(Point::integer(10, 10, units)),
-            1.0,
-            0.0,
-            false,
-        ))
-        .into(),
-        Reference::new(Polygon::new(
-            [
-                Point::integer(0, 0, units),
-                Point::integer(20, 0, units),
-                Point::integer(20, 20, units),
-                Point::integer(0, 20, units),
-            ],
-            Layer::new(4),
-            DataType::new(0),
-        ))
-        .with_grid(Grid::new(
-            Point::integer(300, 50, units),
-            2,
-            1,
-            Some(Point::integer(10, 10, units)),
-            None,
-            1.0,
-            0.0,
+            Radians::new(0.0),
             false,
         ))
         .into(),
@@ -218,7 +174,7 @@ fn get_elements(units: f64) -> Vec<Element> {
             None,
             Some(Point::integer(10, 10, units)),
             1.0,
-            0.0,
+            Radians::new(0.0),
             false,
         ))
         .into(),
@@ -239,7 +195,49 @@ fn get_elements(units: f64) -> Vec<Element> {
             Some(Point::integer(10, 10, units)),
             None,
             1.0,
-            0.0,
+            Radians::new(0.0),
+            false,
+        ))
+        .into(),
+        Reference::new(Polygon::new(
+            [
+                Point::integer(0, 0, units),
+                Point::integer(20, 0, units),
+                Point::integer(20, 20, units),
+                Point::integer(0, 20, units),
+            ],
+            Layer::new(4),
+            DataType::new(0),
+        ))
+        .with_grid(Grid::new(
+            Point::integer(300, 50, units),
+            1,
+            2,
+            None,
+            Some(Point::integer(10, 10, units)),
+            1.0,
+            Radians::new(0.0),
+            false,
+        ))
+        .into(),
+        Reference::new(Polygon::new(
+            [
+                Point::integer(0, 0, units),
+                Point::integer(20, 0, units),
+                Point::integer(20, 20, units),
+                Point::integer(0, 20, units),
+            ],
+            Layer::new(4),
+            DataType::new(0),
+        ))
+        .with_grid(Grid::new(
+            Point::integer(300, 50, units),
+            2,
+            1,
+            Some(Point::integer(10, 10, units)),
+            None,
+            1.0,
+            Radians::new(0.0),
             false,
         ))
         .into(),
@@ -272,7 +270,7 @@ fn test_library_roundtrip_mixed_elements() {
         Layer::new(1),
         DataType::new(0),
         1.0,
-        0.0,
+        Radians::new(0.0),
         false,
         VerticalPresentation::default(),
         HorizontalPresentation::default(),
@@ -360,7 +358,7 @@ fn test_library_roundtrip_different_units() {
             Some(Point::integer(150, 0, units)),
             Some(Point::integer(0, 150, units)),
             1.5,
-            45.0,
+            Radians::new(45.0),
             true,
         ));
 
@@ -484,7 +482,7 @@ fn test_text_with_various_presentations() {
         Layer::new(1),
         DataType::new(0),
         1.0,
-        0.0,
+        Radians::new(0.0),
         false,
         VerticalPresentation::Top,
         HorizontalPresentation::Left,
@@ -496,7 +494,7 @@ fn test_text_with_various_presentations() {
         Layer::new(1),
         DataType::new(0),
         1.5,
-        45.0,
+        Radians::new(45.0),
         false,
         VerticalPresentation::Middle,
         HorizontalPresentation::Centre,
@@ -508,7 +506,7 @@ fn test_text_with_various_presentations() {
         Layer::new(2),
         DataType::new(0),
         2.0,
-        90.0,
+        Radians::new(90.0),
         true,
         VerticalPresentation::Bottom,
         HorizontalPresentation::Right,
@@ -699,7 +697,7 @@ fn test_single_cell_with_all_element_types() {
         Layer::new(3),
         DataType::new(0),
         2.0,
-        0.0,
+        Radians::new(0.0),
         false,
         VerticalPresentation::Middle,
         HorizontalPresentation::Centre,
@@ -749,7 +747,7 @@ fn test_element_reference() {
             Some(Point::integer(10, 10, units)),
             Some(Point::integer(10, 10, units)),
             1.0,
-            0.0,
+            Radians::new(0.0),
             false,
         ));
 
@@ -799,7 +797,7 @@ fn test_cell_reference() {
             Some(Point::integer(10, 10, units)),
             Some(Point::integer(10, 10, units)),
             2.0,
-            FRAC_PI_2,
+            Radians::FRAC_PI_2,
             true,
         ));
 
@@ -812,7 +810,7 @@ fn test_cell_reference() {
             Some(Point::integer(10, 10, units)),
             None,
             2.0,
-            FRAC_PI_2,
+            Radians::FRAC_PI_2,
             true,
         ));
 
@@ -825,7 +823,7 @@ fn test_cell_reference() {
             None,
             Some(Point::integer(10, 10, units)),
             2.0,
-            FRAC_PI_2,
+            Radians::FRAC_PI_2,
             true,
         ));
 
@@ -1013,7 +1011,7 @@ fn test_all_presentation_combinations_roundtrip() {
                 Layer::new(1),
                 DataType::new(0),
                 1.0,
-                0.0,
+                Radians::new(0.0),
                 false,
                 *vp,
                 *hp,
@@ -1159,7 +1157,7 @@ fn test_text_invalid_layer() {
         Layer::new(256),
         DataType::new(0),
         1.0,
-        0.0,
+        Radians::new(0.0),
         false,
         VerticalPresentation::default(),
         HorizontalPresentation::default(),
@@ -1180,7 +1178,7 @@ fn test_text_string_too_long() {
         Layer::new(0),
         DataType::new(0),
         1.0,
-        0.0,
+        Radians::new(0.0),
         false,
         VerticalPresentation::default(),
         HorizontalPresentation::default(),
@@ -1201,7 +1199,7 @@ fn test_text_string_at_max_length() {
         Layer::new(0),
         DataType::new(0),
         1.0,
-        0.0,
+        Radians::new(0.0),
         false,
         VerticalPresentation::default(),
         HorizontalPresentation::default(),

--- a/crates/gdsr/src/snapshots/gdsr__cell__tests__cell_get_elements-2.snap
+++ b/crates/gdsr/src/snapshots/gdsr__cell__tests__cell_get_elements-2.snap
@@ -64,7 +64,9 @@ expression: moved_elements
                 0,
             ),
             magnification: 1.0,
-            angle: 0.0,
+            angle: Radians(
+                0.0,
+            ),
             x_reflection: false,
             vertical_presentation: Middle,
             horizontal_presentation: Centre,

--- a/crates/gdsr/src/snapshots/gdsr__cell__tests__cell_get_elements-3.snap
+++ b/crates/gdsr/src/snapshots/gdsr__cell__tests__cell_get_elements-3.snap
@@ -64,7 +64,9 @@ expression: rotated_elements
                 0,
             ),
             magnification: 1.0,
-            angle: 90.0,
+            angle: Radians(
+                90.0,
+            ),
             x_reflection: false,
             vertical_presentation: Middle,
             horizontal_presentation: Centre,

--- a/crates/gdsr/src/snapshots/gdsr__cell__tests__cell_get_elements.snap
+++ b/crates/gdsr/src/snapshots/gdsr__cell__tests__cell_get_elements.snap
@@ -64,7 +64,9 @@ expression: elements
                 0,
             ),
             magnification: 1.0,
-            angle: 0.0,
+            angle: Radians(
+                0.0,
+            ),
             x_reflection: false,
             vertical_presentation: Middle,
             horizontal_presentation: Centre,

--- a/crates/gdsr/src/traits.rs
+++ b/crates/gdsr/src/traits.rs
@@ -1,5 +1,5 @@
 use crate::transformation::{Reflection, Rotation, Scale, Transformation, Translation};
-use crate::{AngleInRadians, Point};
+use crate::{Point, Radians};
 
 /// Trait for types that can be geometrically transformed (rotated, scaled, reflected, translated).
 pub trait Transformable: Sized {
@@ -15,7 +15,7 @@ pub trait Transformable: Sized {
 
     /// Rotates by the given angle (in radians) around the centre point.
     #[must_use]
-    fn rotate(self, angle: AngleInRadians, centre: Point) -> Self {
+    fn rotate(self, angle: Radians, centre: Point) -> Self {
         self.transform_impl(
             Transformation::default().with_rotation(Some(Rotation::new(angle, centre))),
         )
@@ -29,7 +29,7 @@ pub trait Transformable: Sized {
 
     /// Reflects across the axis defined by the given angle (in radians) through the centre point.
     #[must_use]
-    fn reflect(self, angle: f64, centre: Point) -> Self {
+    fn reflect(self, angle: Radians, centre: Point) -> Self {
         self.transform_impl(
             Transformation::default().with_reflection(Some(Reflection::new(angle, centre))),
         )

--- a/crates/gdsr/src/transformation/mod.rs
+++ b/crates/gdsr/src/transformation/mod.rs
@@ -110,6 +110,7 @@ impl From<&Self> for Transformation {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Radians;
 
     #[test]
     fn test_transformation_default() {
@@ -122,7 +123,7 @@ mod tests {
 
     #[test]
     fn test_transformation_with_reflection() {
-        let reflection = Reflection::new(0.0, Point::integer(0, 0, 1e-9));
+        let reflection = Reflection::new(Radians::new(0.0), Point::integer(0, 0, 1e-9));
         let mut transformation = Transformation::default();
         transformation.with_reflection(Some(reflection.clone()));
 
@@ -132,7 +133,7 @@ mod tests {
 
     #[test]
     fn test_transformation_with_rotation() {
-        let rotation = Rotation::new(45.0, Point::integer(0, 0, 1e-9));
+        let rotation = Rotation::new(Radians::new(45.0), Point::integer(0, 0, 1e-9));
         let mut transformation = Transformation::default();
         transformation.with_rotation(Some(rotation.clone()));
 
@@ -192,7 +193,7 @@ mod tests {
 
     #[test]
     fn test_from_reflection() {
-        let reflection = Reflection::new(0.0, Point::integer(0, 0, 1e-9));
+        let reflection = Reflection::new(Radians::new(0.0), Point::integer(0, 0, 1e-9));
         let transformation: Transformation = reflection.clone().into();
 
         assert!(transformation.reflection.is_some());
@@ -204,7 +205,7 @@ mod tests {
 
     #[test]
     fn test_from_rotation() {
-        let rotation = Rotation::new(45.0, Point::integer(0, 0, 1e-9));
+        let rotation = Rotation::new(Radians::new(45.0), Point::integer(0, 0, 1e-9));
         let transformation: Transformation = rotation.clone().into();
 
         assert!(transformation.rotation.is_some());
@@ -252,7 +253,7 @@ mod tests {
     #[test]
     fn test_rotation_and_scale_combined() {
         let origin = Point::integer(0, 0, 1e-9);
-        let rotation = Rotation::new(std::f64::consts::FRAC_PI_2, origin);
+        let rotation = Rotation::new(Radians::FRAC_PI_2, origin);
         let scale = Scale::new(2.0, origin);
 
         let mut transformation = Transformation::default();
@@ -262,7 +263,7 @@ mod tests {
         let point = Point::integer(3, 0, 1e-9);
         let result = transformation.apply_to_point(&point);
 
-        let rotated = Rotation::new(std::f64::consts::FRAC_PI_2, origin).apply_to_point(&point);
+        let rotated = Rotation::new(Radians::FRAC_PI_2, origin).apply_to_point(&point);
         let expected = Scale::new(2.0, origin).apply_to_point(&rotated);
         assert_point_approx_eq(&result, &expected);
         assert_point_approx_eq(&result, &Point::integer(0, 6, 1e-9));
@@ -271,7 +272,7 @@ mod tests {
     #[test]
     fn test_rotation_and_translation_combined() {
         let origin = Point::integer(0, 0, 1e-9);
-        let rotation = Rotation::new(std::f64::consts::FRAC_PI_2, origin);
+        let rotation = Rotation::new(Radians::FRAC_PI_2, origin);
         let translation = Translation::new(Point::integer(10, 5, 1e-9));
 
         let mut transformation = Transformation::default();
@@ -281,7 +282,7 @@ mod tests {
         let point = Point::integer(4, 0, 1e-9);
         let result = transformation.apply_to_point(&point);
 
-        let rotated = Rotation::new(std::f64::consts::FRAC_PI_2, origin).apply_to_point(&point);
+        let rotated = Rotation::new(Radians::FRAC_PI_2, origin).apply_to_point(&point);
         let expected = Translation::new(Point::integer(10, 5, 1e-9)).apply_to_point(&rotated);
         assert_point_approx_eq(&result, &expected);
         assert_point_approx_eq(&result, &Point::integer(10, 9, 1e-9));
@@ -309,8 +310,8 @@ mod tests {
     #[test]
     fn test_reflection_and_rotation_combined() {
         let origin = Point::integer(0, 0, 1e-9);
-        let reflection = Reflection::new(0.0, origin);
-        let rotation = Rotation::new(std::f64::consts::FRAC_PI_2, origin);
+        let reflection = Reflection::new(Radians::new(0.0), origin);
+        let rotation = Rotation::new(Radians::FRAC_PI_2, origin);
 
         let mut transformation = Transformation::default();
         transformation.with_reflection(Some(reflection.clone()));
@@ -329,8 +330,8 @@ mod tests {
     #[test]
     fn test_all_four_transformations_combined() {
         let origin = Point::integer(0, 0, 1e-9);
-        let reflection = Reflection::new(0.0, origin);
-        let rotation = Rotation::new(std::f64::consts::FRAC_PI_2, origin);
+        let reflection = Reflection::new(Radians::new(0.0), origin);
+        let rotation = Rotation::new(Radians::FRAC_PI_2, origin);
         let scale = Scale::new(2.0, origin);
         let translation = Translation::new(Point::integer(10, 10, 1e-9));
 
@@ -358,8 +359,8 @@ mod tests {
     #[test]
     fn test_order_of_operations_reflection_before_rotation() {
         let origin = Point::integer(0, 0, 1e-9);
-        let reflection = Reflection::new(0.0, origin);
-        let rotation = Rotation::new(std::f64::consts::FRAC_PI_2, origin);
+        let reflection = Reflection::new(Radians::new(0.0), origin);
+        let rotation = Rotation::new(Radians::FRAC_PI_2, origin);
         let scale = Scale::new(2.0, origin);
         let translation = Translation::new(Point::integer(5, 5, 1e-9));
 
@@ -447,7 +448,7 @@ mod tests {
     #[test]
     fn test_rotation_greater_than_2pi() {
         let origin = Point::integer(0, 0, 1e-9);
-        let angle = std::f64::consts::TAU + std::f64::consts::FRAC_PI_2;
+        let angle = Radians::TAU + Radians::FRAC_PI_2;
         let rotation = Rotation::new(angle, origin);
         let mut transformation = Transformation::default();
         transformation.with_rotation(Some(rotation));
@@ -455,7 +456,7 @@ mod tests {
         let point = Point::integer(10, 0, 1e-9);
         let result = transformation.apply_to_point(&point);
 
-        let just_90 = Rotation::new(std::f64::consts::FRAC_PI_2, origin);
+        let just_90 = Rotation::new(Radians::FRAC_PI_2, origin);
         let expected = just_90.apply_to_point(&point);
         assert_point_approx_eq(&result, &expected);
     }
@@ -463,7 +464,7 @@ mod tests {
     #[test]
     fn test_rotation_negative_angle() {
         let origin = Point::integer(0, 0, 1e-9);
-        let rotation = Rotation::new(-std::f64::consts::FRAC_PI_2, origin);
+        let rotation = Rotation::new(-Radians::FRAC_PI_2, origin);
         let mut transformation = Transformation::default();
         transformation.with_rotation(Some(rotation));
 
@@ -476,8 +477,8 @@ mod tests {
     #[test]
     fn test_all_transformations_simultaneously() {
         let origin = Point::integer(0, 0, 1e-9);
-        let reflection = Reflection::new(0.0, origin);
-        let rotation = Rotation::new(std::f64::consts::FRAC_PI_4, origin);
+        let reflection = Reflection::new(Radians::new(0.0), origin);
+        let rotation = Rotation::new(Radians::FRAC_PI_4, origin);
         let scale = Scale::new(3.0, origin);
         let translation = Translation::new(Point::integer(100, 200, 1e-9));
 

--- a/crates/gdsr/src/transformation/reflection.rs
+++ b/crates/gdsr/src/transformation/reflection.rs
@@ -1,9 +1,9 @@
-use crate::{AngleInRadians, Point};
+use crate::{Point, Radians};
 
 /// A reflection transformation defined by an axis angle and centre point.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Reflection {
-    angle: AngleInRadians,
+    angle: Radians,
     centre: Point,
 }
 
@@ -19,25 +19,25 @@ impl std::fmt::Display for Reflection {
 
 impl Reflection {
     /// Creates a new reflection with the given axis angle (in radians) and centre point.
-    pub const fn new(angle: AngleInRadians, centre: Point) -> Self {
+    pub const fn new(angle: Radians, centre: Point) -> Self {
         Self { angle, centre }
     }
 
     /// Returns the axis angle in radians.
-    pub const fn angle(&self) -> AngleInRadians {
+    pub const fn angle(&self) -> Radians {
         self.angle
     }
 
     /// Creates a horizontal reflection (angle = 0) about the x-axis.
     pub const fn new_horizontal() -> Self {
-        Self::new(0.0, Point::integer(0, 1, 1e-9))
+        Self::new(Radians(0.0), Point::integer(0, 1, 1e-9))
     }
 
     /// Creates a reflection from a line defined by two points.
     pub fn from_line(point1: &Point, point2: &Point) -> Self {
         let dx = (point2.x() - point1.x()).absolute_value();
         let dy = (point2.y() - point1.y()).absolute_value();
-        let angle = dy.atan2(dx);
+        let angle = Radians(dy.atan2(dx));
         let centre = Point::new(
             (point1.x() + point2.x()) / 2.0,
             (point1.y() + point2.y()) / 2.0,
@@ -47,8 +47,8 @@ impl Reflection {
 
     /// Reflects a point across this reflection's axis and returns the new point.
     pub fn apply_to_point(&self, point: &Point) -> Point {
-        let cos_2angle = (2.0 * self.angle).cos();
-        let sin_2angle = (2.0 * self.angle).sin();
+        let cos_2angle = (2.0 * self.angle.value()).cos();
+        let sin_2angle = (2.0 * self.angle.value()).sin();
 
         let self_center_x = self.centre.x();
         let self_center_y = self.centre.y();
@@ -69,21 +69,21 @@ mod tests {
 
     #[test]
     fn test_reflection_new() {
-        let reflection = Reflection::new(45.0, Point::integer(10, 20, 1e-9));
-        assert_eq!(reflection.angle, 45.0);
+        let reflection = Reflection::new(Radians(45.0), Point::integer(10, 20, 1e-9));
+        assert_eq!(reflection.angle, Radians(45.0));
         assert_eq!(reflection.centre, Point::integer(10, 20, 1e-9));
     }
 
     #[test]
     fn test_reflection_new_horizontal() {
         let reflection = Reflection::new_horizontal();
-        assert_eq!(reflection.angle, 0.0);
+        assert_eq!(reflection.angle, Radians(0.0));
         assert_eq!(reflection.centre, Point::integer(0, 1, 1e-9));
     }
 
     #[test]
     fn test_reflection_horizontal_axis() {
-        let reflection = Reflection::new(0.0, Point::integer(0, 0, 1e-9));
+        let reflection = Reflection::new(Radians(0.0), Point::integer(0, 0, 1e-9));
         let point = Point::integer(10, 5, 1e-9);
         let reflected = reflection.apply_to_point(&point);
 
@@ -97,7 +97,7 @@ mod tests {
     #[test]
     fn test_reflection_apply_at_centre() {
         let centre = Point::integer(10, 10, 1e-9);
-        let reflection = Reflection::new(45.0, centre);
+        let reflection = Reflection::new(Radians(45.0), centre);
         let reflected = reflection.apply_to_point(&centre);
 
         // Point at centre should remain unchanged
@@ -111,7 +111,7 @@ mod tests {
         let reflection = Reflection::from_line(&point1, &point2);
 
         // Horizontal line should have angle 0
-        assert_eq!(reflection.angle, 0.0);
+        assert_eq!(reflection.angle, Radians(0.0));
         // Centre should be midpoint
         assert_eq!(reflection.centre, Point::integer(5, 5, 1e-9));
     }
@@ -124,7 +124,7 @@ mod tests {
 
         // Vertical line should have angle π/2
         let expected_angle = std::f64::consts::FRAC_PI_2;
-        assert!((reflection.angle - expected_angle).abs() < 1e-10);
+        assert!((reflection.angle.value() - expected_angle).abs() < 1e-10);
         // Centre should be midpoint
         assert_eq!(reflection.centre, Point::integer(5, 5, 1e-9));
     }
@@ -137,14 +137,14 @@ mod tests {
 
         // Diagonal line (45 degrees) should have angle π/4
         let expected_angle = std::f64::consts::FRAC_PI_4;
-        assert!((reflection.angle - expected_angle).abs() < 1e-10);
+        assert!((reflection.angle.value() - expected_angle).abs() < 1e-10);
         // Centre should be midpoint
         assert_eq!(reflection.centre, Point::integer(5, 5, 1e-9));
     }
 
     #[test]
     fn test_reflection_display() {
-        let reflection = Reflection::new(0.5, Point::integer(10, 20, 1e-9));
+        let reflection = Reflection::new(Radians(0.5), Point::integer(10, 20, 1e-9));
         insta::assert_snapshot!(reflection.to_string(), @"Reflection with angle 0.5 rad about Point(10 (1.000e-9), 20 (1.000e-9))");
     }
 
@@ -170,7 +170,7 @@ mod tests {
         let reflection = Reflection::from_line(&point1, &point2);
 
         let expected_angle = (10.0_f64).atan2(5.0);
-        assert!((reflection.angle - expected_angle).abs() < 1e-10);
+        assert!((reflection.angle.value() - expected_angle).abs() < 1e-10);
 
         assert_eq!(reflection.centre, Point::integer(-3, -5, 1e-9));
 
@@ -199,7 +199,7 @@ mod tests {
         let reflection = Reflection::from_line(&point1, &point2);
 
         let expected_angle = (-6.0_f64).atan2(10.0);
-        assert!((reflection.angle - expected_angle).abs() < 1e-10);
+        assert!((reflection.angle.value() - expected_angle).abs() < 1e-10);
 
         assert_eq!(reflection.centre, Point::integer(0, 0, 1e-9));
 

--- a/crates/gdsr/src/transformation/rotation.rs
+++ b/crates/gdsr/src/transformation/rotation.rs
@@ -1,9 +1,9 @@
-use crate::{AngleInRadians, Point};
+use crate::{Point, Radians};
 
 /// A rotation transformation defined by an angle (in radians) and a centre point.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Rotation {
-    angle: AngleInRadians,
+    angle: Radians,
     centre: Point,
 }
 
@@ -15,12 +15,12 @@ impl std::fmt::Display for Rotation {
 
 impl Rotation {
     /// Creates a new rotation with the given angle (in radians) and centre point.
-    pub const fn new(angle: AngleInRadians, centre: Point) -> Self {
+    pub const fn new(angle: Radians, centre: Point) -> Self {
         Self { angle, centre }
     }
 
     /// Returns the rotation angle in radians.
-    pub const fn angle(&self) -> AngleInRadians {
+    pub const fn angle(&self) -> Radians {
         self.angle
     }
 
@@ -55,23 +55,23 @@ mod tests {
 
     #[test]
     fn test_rotation_new() {
-        let rotation = Rotation::new(FRAC_PI_2, Point::integer(10, 20, 1e-9));
-        assert_eq!(rotation.angle(), FRAC_PI_2);
+        let rotation = Rotation::new(Radians(FRAC_PI_2), Point::integer(10, 20, 1e-9));
+        assert_eq!(rotation.angle(), Radians(FRAC_PI_2));
         assert_eq!(rotation.centre(), &Point::integer(10, 20, 1e-9));
     }
 
     #[test]
     fn test_rotation_getters() {
         let centre = Point::integer(5, 10, 1e-9);
-        let rotation = Rotation::new(FRAC_PI_4, centre);
-        assert_eq!(rotation.angle(), FRAC_PI_4);
+        let rotation = Rotation::new(Radians(FRAC_PI_4), centre);
+        assert_eq!(rotation.angle(), Radians(FRAC_PI_4));
         assert_eq!(rotation.centre(), &centre);
     }
 
     #[test]
     fn test_rotation_apply_at_centre() {
         let centre = Point::integer(10, 10, 1e-9);
-        let rotation = Rotation::new(90.0, centre);
+        let rotation = Rotation::new(Radians(90.0), centre);
         let rotated = rotation.apply_to_point(&centre);
 
         // Point at centre should remain unchanged
@@ -80,13 +80,13 @@ mod tests {
 
     #[test]
     fn test_rotation_display() {
-        let rotation = Rotation::new(FRAC_PI_2, Point::integer(10, 20, 1e-9));
+        let rotation = Rotation::new(Radians(FRAC_PI_2), Point::integer(10, 20, 1e-9));
         insta::assert_snapshot!(rotation.to_string(), @"Rotation of 1.5707963267948966 rad about Point(10 (1.000e-9), 20 (1.000e-9))");
     }
 
     #[test]
     fn test_rotation_90_degrees() {
-        let rotation = Rotation::new(90.0, Point::integer(0, 0, 1e-9));
+        let rotation = Rotation::new(Radians(90.0), Point::integer(0, 0, 1e-9));
         let point = Point::integer(10, 0, 1e-9);
         let rotated = rotation.apply_to_point(&point);
 
@@ -103,8 +103,8 @@ mod tests {
         let origin = Point::integer(0, 0, 1e-9);
         let point = Point::integer(10, 0, 1e-9);
 
-        let rotation_large = Rotation::new(std::f64::consts::TAU + FRAC_PI_2, origin);
-        let rotation_normal = Rotation::new(FRAC_PI_2, origin);
+        let rotation_large = Rotation::new(Radians(std::f64::consts::TAU + FRAC_PI_2), origin);
+        let rotation_normal = Rotation::new(Radians(FRAC_PI_2), origin);
 
         let result_large = rotation_large.apply_to_point(&point);
         let result_normal = rotation_normal.apply_to_point(&point);
@@ -126,7 +126,7 @@ mod tests {
     #[test]
     fn test_rotation_negative_angle() {
         let origin = Point::integer(0, 0, 1e-9);
-        let rotation = Rotation::new(-FRAC_PI_2, origin);
+        let rotation = Rotation::new(Radians(-FRAC_PI_2), origin);
         let point = Point::integer(10, 0, 1e-9);
         let rotated = rotation.apply_to_point(&point);
 

--- a/crates/gdsr/src/types.rs
+++ b/crates/gdsr/src/types.rs
@@ -38,7 +38,97 @@ impl std::fmt::Display for DataType {
     }
 }
 
-pub type AngleInRadians = f64;
+/// An angle measured in radians.
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Default)]
+pub struct Radians(pub f64);
+
+impl Radians {
+    pub const PI: Self = Self(std::f64::consts::PI);
+    pub const TAU: Self = Self(std::f64::consts::TAU);
+    pub const FRAC_PI_2: Self = Self(std::f64::consts::FRAC_PI_2);
+    pub const FRAC_PI_4: Self = Self(std::f64::consts::FRAC_PI_4);
+
+    pub const fn new(value: f64) -> Self {
+        Self(value)
+    }
+
+    pub const fn value(self) -> f64 {
+        self.0
+    }
+
+    /// Returns the sine of the angle.
+    pub fn sin(self) -> f64 {
+        self.0.sin()
+    }
+
+    /// Returns the cosine of the angle.
+    pub fn cos(self) -> f64 {
+        self.0.cos()
+    }
+
+    /// Converts to degrees.
+    pub fn to_degrees(self) -> Degrees {
+        Degrees(self.0.to_degrees())
+    }
+}
+
+impl std::fmt::Display for Radians {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.0)
+    }
+}
+
+impl std::ops::Add for Radians {
+    type Output = Self;
+    fn add(self, rhs: Self) -> Self {
+        Self(self.0 + rhs.0)
+    }
+}
+
+impl std::ops::AddAssign for Radians {
+    fn add_assign(&mut self, rhs: Self) {
+        self.0 += rhs.0;
+    }
+}
+
+impl std::ops::Sub for Radians {
+    type Output = Self;
+    fn sub(self, rhs: Self) -> Self {
+        Self(self.0 - rhs.0)
+    }
+}
+
+impl std::ops::Neg for Radians {
+    type Output = Self;
+    fn neg(self) -> Self {
+        Self(-self.0)
+    }
+}
+
+/// An angle measured in degrees.
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Default)]
+pub struct Degrees(pub f64);
+
+impl Degrees {
+    pub const fn new(value: f64) -> Self {
+        Self(value)
+    }
+
+    pub const fn value(self) -> f64 {
+        self.0
+    }
+
+    /// Converts to radians.
+    pub fn to_radians(self) -> Radians {
+        Radians(self.0.to_radians())
+    }
+}
+
+impl std::fmt::Display for Degrees {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.0)
+    }
+}
 
 /// A mapping from one (`Layer`, `DataType`) pair to another, used for bulk layer remapping.
 pub type LayerMapping = std::collections::HashMap<(Layer, DataType), (Layer, DataType)>;

--- a/scripts/benchmark/benchmark_gdsr.rs
+++ b/scripts/benchmark/benchmark_gdsr.rs
@@ -1,6 +1,6 @@
 use gdsr::{
-    Cell, DataType, Grid, HorizontalPresentation, Layer, Library, Path, PathType, Point, Polygon, Reference, Text,
-    Unit, VerticalPresentation,
+    Cell, DataType, Grid, HorizontalPresentation, Layer, Library, Path, PathType, Point, Polygon,
+    Radians, Reference, Text, Unit, VerticalPresentation,
 };
 
 const DB_UNITS: f64 = 1e-9;
@@ -71,7 +71,7 @@ fn build_library() -> Library {
 
                 DataType::new((i % 4) as u16),
                 1.0 + f64::from(i % 3) * 0.5,
-                f64::from(i % 8) * std::f64::consts::FRAC_PI_4,
+                Radians::new(f64::from(i % 8) * std::f64::consts::FRAC_PI_4),
                 i % 3 == 0,
                 VERT_PRES[i as usize % 3],
                 HORIZ_PRES[i as usize % 3],
@@ -94,7 +94,7 @@ fn build_library() -> Library {
                         .with_spacing_x(Some(point(15_000, 0)))
                         .with_spacing_y(Some(point(0, 12_000)))
                         .with_magnification(1.0 + f64::from(c % 5) * 0.1)
-                        .with_angle(f64::from(c % 8) * 0.05)
+                        .with_angle(Radians::new(f64::from(c % 8) * 0.05))
                         .with_x_reflection(c % 3 == 0),
                 ),
             );
@@ -143,7 +143,7 @@ fn build_library() -> Library {
                         .with_spacing_x(Some(point(150_000, 0)))
                         .with_spacing_y(Some(point(0, 120_000)))
                         .with_magnification(0.9 + f64::from(r) * 0.1)
-                        .with_angle(f64::from(r) * 0.03)
+                        .with_angle(Radians::new(f64::from(r) * 0.03))
                         .with_x_reflection(r % 2 == 1),
                 ),
             );


### PR DESCRIPTION
## Summary

Replace the raw angle alias with `Radians` and `Degrees` newtypes, fix inconsistent internal angle units, and convert explicitly at GDS boundaries. Closes #233.

## Test Plan

Ran the full test suite, round-trip property tests, and updated snapshot coverage.