### PR TITLE
Fix typo in README installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ GDSII manipulation, written in Rust.
 
 ## Installation
 
-Install uv with our standalone installers:
+Install gdsr viewer with our standalone installers:
 
 ```shell
 # On macOS and Linux.


### PR DESCRIPTION
## Summary

Correct the README installation heading so it refers to the GDSR viewer installer. Closes #231.

## Test Plan

Not recorded.