### PR TITLE
Add Polygon::ellipse() shape constructor

### DIFF
--- a/crates/gdsr/src/elements/polygon.rs
+++ b/crates/gdsr/src/elements/polygon.rs
@@ -74,6 +74,37 @@ impl Polygon {
         Self::new(points, layer, data_type)
     }
 
+    /// Creates an ellipse approximation as a polygon.
+    ///
+    /// `center` is the center of the ellipse. `radius_x` and `radius_y` are the semi-axes along
+    /// the x and y directions, interpreted in the same units as the center point. `num_points` is
+    /// the number of vertices (clamped to a minimum of 3). Vertices are generated counter-clockwise
+    /// starting from angle 0. When `radius_x == radius_y`, the result is identical to a circle.
+    pub fn ellipse(
+        center: Point,
+        radius_x: f64,
+        radius_y: f64,
+        num_points: usize,
+        layer: Layer,
+        data_type: DataType,
+    ) -> Self {
+        let num_points = num_points.max(3);
+
+        let x_units = center.x().units();
+        let y_units = center.y().units();
+
+        let points = (0..num_points).map(|i| {
+            let angle = (i as f64) * std::f64::consts::TAU / (num_points as f64);
+            center
+                + Point::new(
+                    Unit::float(radius_x * angle.cos(), x_units),
+                    Unit::float(radius_y * angle.sin(), y_units),
+                )
+        });
+
+        Self::new(points, layer, data_type)
+    }
+
     /// Returns the polygon's points (including the closing point).
     pub fn points(&self) -> &[Point] {
         &self.points
@@ -425,6 +456,48 @@ mod tests {
         let polygon = Polygon::new(vec![], Layer::new(1), DataType::new(0));
         let moved = polygon.move_to(Point::integer(5, 5, 1e-9));
         assert_eq!(moved.points().len(), 0);
+    }
+
+    #[test]
+    fn test_ellipse_num_points_clamped_to_3() {
+        let origin = Point::float(0.0, 0.0, 1e-6);
+        let polygon = Polygon::ellipse(origin, 5.0, 3.0, 1, Layer::new(0), DataType::new(0));
+        assert_eq!(polygon.points().len(), 4);
+    }
+
+    #[test]
+    fn test_ellipse_equal_radii_matches_circle() {
+        let origin = Point::float(0.0, 0.0, 1e-6);
+        let radius = 5.0;
+        let num_points = 36;
+        let ellipse = Polygon::ellipse(
+            origin,
+            radius,
+            radius,
+            num_points,
+            Layer::new(0),
+            DataType::new(0),
+        );
+        let circle = Polygon::regular_polygon(
+            origin,
+            radius,
+            num_points,
+            Radians::new(0.0),
+            Layer::new(0),
+            DataType::new(0),
+        );
+        assert_eq!(ellipse.points(), circle.points());
+    }
+
+    #[test]
+    fn test_ellipse_bounding_box() {
+        let origin = Point::float(0.0, 0.0, 1e-6);
+        let ellipse = Polygon::ellipse(origin, 10.0, 5.0, 360, Layer::new(0), DataType::new(0));
+        let (min, max) = ellipse.bounding_box();
+        assert!((min.x().float_value() - (-10.0)).abs() < 1e-6);
+        assert!((min.y().float_value() - (-5.0)).abs() < 1e-6);
+        assert!((max.x().float_value() - 10.0).abs() < 1e-6);
+        assert!((max.y().float_value() - 5.0).abs() < 1e-6);
     }
 
     #[test]

--- a/crates/gdsr/src/property_tests/polygon.rs
+++ b/crates/gdsr/src/property_tests/polygon.rs
@@ -4,6 +4,60 @@ use crate::elements::polygon::close_points;
 use crate::*;
 
 #[quickcheck]
+fn ellipse_has_correct_point_count(num_points: usize) -> bool {
+    let num_points = (num_points % 100) + 3;
+    let center = Point::float(0.0, 0.0, 1e-6);
+    let polygon = Polygon::ellipse(
+        center,
+        10.0,
+        5.0,
+        num_points,
+        Layer::new(0),
+        DataType::new(0),
+    );
+    polygon.points().len() == num_points + 1
+}
+
+#[quickcheck]
+fn ellipse_equal_radii_points_equidistant(num_points: usize) -> bool {
+    let num_points = (num_points % 100) + 3;
+    let center = Point::float(0.0, 0.0, 1e-6);
+    let radius = 10.0;
+    let polygon = Polygon::ellipse(
+        center,
+        radius,
+        radius,
+        num_points,
+        Layer::new(0),
+        DataType::new(0),
+    );
+
+    polygon.points().iter().take(num_points).all(|p| {
+        let dx = p.x().float_value();
+        let dy = p.y().float_value();
+        let dist = (dx * dx + dy * dy).sqrt();
+        (dist - radius).abs() < 1e-9
+    })
+}
+
+/// All vertices satisfy the ellipse equation (x-cx)^2/rx^2 + (y-cy)^2/ry^2 ~= 1.
+#[quickcheck]
+fn ellipse_points_satisfy_ellipse_equation(num_points: usize) -> bool {
+    let num_points = (num_points % 100) + 3;
+    let center = Point::float(3.0, -2.0, 1e-6);
+    let rx = 7.0;
+    let ry = 4.0;
+    let polygon = Polygon::ellipse(center, rx, ry, num_points, Layer::new(0), DataType::new(0));
+
+    polygon.points().iter().take(num_points).all(|p| {
+        let dx = p.x().float_value() - 3.0;
+        let dy = p.y().float_value() - (-2.0);
+        let val = (dx * dx) / (rx * rx) + (dy * dy) / (ry * ry);
+        (val - 1.0).abs() < 1e-9
+    })
+}
+
+#[quickcheck]
 fn area_is_non_negative(polygon: Polygon) -> bool {
     polygon.area().float_value() >= 0.0
 }

--- a/crates/gdsr/src/property_tests/polygon.rs
+++ b/crates/gdsr/src/property_tests/polygon.rs
@@ -3,43 +3,6 @@ use quickcheck_macros::quickcheck;
 use crate::elements::polygon::close_points;
 use crate::*;
 
-#[quickcheck]
-fn ellipse_has_correct_point_count(num_points: usize) -> bool {
-    let num_points = (num_points % 100) + 3;
-    let center = Point::float(0.0, 0.0, 1e-6);
-    let polygon = Polygon::ellipse(
-        center,
-        10.0,
-        5.0,
-        num_points,
-        Layer::new(0),
-        DataType::new(0),
-    );
-    polygon.points().len() == num_points + 1
-}
-
-#[quickcheck]
-fn ellipse_equal_radii_points_equidistant(num_points: usize) -> bool {
-    let num_points = (num_points % 100) + 3;
-    let center = Point::float(0.0, 0.0, 1e-6);
-    let radius = 10.0;
-    let polygon = Polygon::ellipse(
-        center,
-        radius,
-        radius,
-        num_points,
-        Layer::new(0),
-        DataType::new(0),
-    );
-
-    polygon.points().iter().take(num_points).all(|p| {
-        let dx = p.x().float_value();
-        let dy = p.y().float_value();
-        let dist = (dx * dx + dy * dy).sqrt();
-        (dist - radius).abs() < 1e-9
-    })
-}
-
 /// All vertices satisfy the ellipse equation (x-cx)^2/rx^2 + (y-cy)^2/ry^2 ~= 1.
 #[quickcheck]
 fn ellipse_points_satisfy_ellipse_equation(num_points: usize) -> bool {


### PR DESCRIPTION
## Summary

Add `Polygon::ellipse()` for constructing counter-clockwise ellipse approximations with validated minimum point counts. Closes #226.

## Test Plan

Ran unit and property coverage for clamping, bounds, point counts, equal radii, and the ellipse equation.