### PR TITLE
Add Polygon::rectangle() shape constructor

### DIFF
--- a/crates/gdsr/src/elements/polygon.rs
+++ b/crates/gdsr/src/elements/polygon.rs
@@ -105,6 +105,34 @@ impl Polygon {
         Self::new(points, layer, data_type)
     }
 
+    /// Creates an axis-aligned rectangle from two opposing corners.
+    ///
+    /// The corners are normalized using min/max so the rectangle is well-defined regardless of
+    /// which opposing corners are passed. Points are generated in counter-clockwise winding order.
+    pub fn rectangle(corner1: Point, corner2: Point, layer: Layer, data_type: DataType) -> Self {
+        let x_units = corner1.x().units();
+        let y_units = corner1.y().units();
+
+        let x1 = corner1.x().float_value();
+        let y1 = corner1.y().float_value();
+        let x2 = corner2.x().float_value();
+        let y2 = corner2.y().float_value();
+
+        let min_x = x1.min(x2);
+        let max_x = x1.max(x2);
+        let min_y = y1.min(y2);
+        let max_y = y1.max(y2);
+
+        let points = [
+            Point::new(Unit::float(min_x, x_units), Unit::float(min_y, y_units)),
+            Point::new(Unit::float(max_x, x_units), Unit::float(min_y, y_units)),
+            Point::new(Unit::float(max_x, x_units), Unit::float(max_y, y_units)),
+            Point::new(Unit::float(min_x, x_units), Unit::float(max_y, y_units)),
+        ];
+
+        Self::new(points, layer, data_type)
+    }
+
     /// Returns the polygon's points (including the closing point).
     pub fn points(&self) -> &[Point] {
         &self.points
@@ -498,6 +526,110 @@ mod tests {
         assert!((min.y().float_value() - (-5.0)).abs() < 1e-6);
         assert!((max.x().float_value() - 10.0).abs() < 1e-6);
         assert!((max.y().float_value() - 5.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_rectangle_creation() {
+        let rect = Polygon::rectangle(
+            Point::integer(0, 0, 1e-9),
+            Point::integer(10, 5, 1e-9),
+            Layer::new(1),
+            DataType::new(0),
+        );
+
+        insta::assert_debug_snapshot!(rect.points(), @r#"
+        [
+            Point {
+                x: Float(
+                    FloatUnit {
+                        value: 0.0,
+                        units: 1e-9,
+                    },
+                ),
+                y: Float(
+                    FloatUnit {
+                        value: 0.0,
+                        units: 1e-9,
+                    },
+                ),
+            },
+            Point {
+                x: Float(
+                    FloatUnit {
+                        value: 10.0,
+                        units: 1e-9,
+                    },
+                ),
+                y: Float(
+                    FloatUnit {
+                        value: 0.0,
+                        units: 1e-9,
+                    },
+                ),
+            },
+            Point {
+                x: Float(
+                    FloatUnit {
+                        value: 10.0,
+                        units: 1e-9,
+                    },
+                ),
+                y: Float(
+                    FloatUnit {
+                        value: 5.0,
+                        units: 1e-9,
+                    },
+                ),
+            },
+            Point {
+                x: Float(
+                    FloatUnit {
+                        value: 0.0,
+                        units: 1e-9,
+                    },
+                ),
+                y: Float(
+                    FloatUnit {
+                        value: 5.0,
+                        units: 1e-9,
+                    },
+                ),
+            },
+            Point {
+                x: Float(
+                    FloatUnit {
+                        value: 0.0,
+                        units: 1e-9,
+                    },
+                ),
+                y: Float(
+                    FloatUnit {
+                        value: 0.0,
+                        units: 1e-9,
+                    },
+                ),
+            },
+        ]
+        "#);
+        assert_eq!(rect.layer(), Layer::new(1));
+        assert_eq!(rect.data_type(), DataType::new(0));
+    }
+
+    #[test]
+    fn test_rectangle_swapped_corners() {
+        let rect1 = Polygon::rectangle(
+            Point::integer(0, 0, 1e-9),
+            Point::integer(10, 5, 1e-9),
+            Layer::new(0),
+            DataType::new(0),
+        );
+        let rect2 = Polygon::rectangle(
+            Point::integer(10, 5, 1e-9),
+            Point::integer(0, 0, 1e-9),
+            Layer::new(0),
+            DataType::new(0),
+        );
+        assert_eq!(rect1.points(), rect2.points());
     }
 
     #[test]

--- a/crates/gdsr/src/elements/polygon.rs
+++ b/crates/gdsr/src/elements/polygon.rs
@@ -110,13 +110,13 @@ impl Polygon {
     /// The corners are normalized using min/max so the rectangle is well-defined regardless of
     /// which opposing corners are passed. Points are generated in counter-clockwise winding order.
     pub fn rectangle(corner1: Point, corner2: Point, layer: Layer, data_type: DataType) -> Self {
-        let x_units = corner1.x().units();
-        let y_units = corner1.y().units();
+        let x_units = corner1.x().units().min(corner2.x().units());
+        let y_units = corner1.y().units().min(corner2.y().units());
 
-        let x1 = corner1.x().float_value();
-        let y1 = corner1.y().float_value();
-        let x2 = corner2.x().float_value();
-        let y2 = corner2.y().float_value();
+        let x1 = corner1.x().scale_to(x_units).float_value();
+        let y1 = corner1.y().scale_to(y_units).float_value();
+        let x2 = corner2.x().scale_to(x_units).float_value();
+        let y2 = corner2.y().scale_to(y_units).float_value();
 
         let min_x = x1.min(x2);
         let max_x = x1.max(x2);
@@ -562,6 +562,19 @@ mod tests {
             DataType::new(0),
         );
         assert_eq!(rect1.points(), rect2.points());
+    }
+
+    #[test]
+    fn test_rectangle_mixed_units() {
+        let rect = Polygon::rectangle(
+            Point::integer(2, 3, 1e-6),
+            Point::integer(5000, 8000, 1e-9),
+            Layer::new(0),
+            DataType::new(0),
+        );
+        assert_eq!(rect.points().len(), 5);
+        assert_eq!(rect.points()[0], Point::float(2000.0, 3000.0, 1e-9));
+        assert_eq!(rect.points()[2], Point::float(5000.0, 8000.0, 1e-9));
     }
 
     #[test]

--- a/crates/gdsr/src/elements/polygon.rs
+++ b/crates/gdsr/src/elements/polygon.rs
@@ -537,82 +537,14 @@ mod tests {
             DataType::new(0),
         );
 
-        insta::assert_debug_snapshot!(rect.points(), @r#"
-        [
-            Point {
-                x: Float(
-                    FloatUnit {
-                        value: 0.0,
-                        units: 1e-9,
-                    },
-                ),
-                y: Float(
-                    FloatUnit {
-                        value: 0.0,
-                        units: 1e-9,
-                    },
-                ),
-            },
-            Point {
-                x: Float(
-                    FloatUnit {
-                        value: 10.0,
-                        units: 1e-9,
-                    },
-                ),
-                y: Float(
-                    FloatUnit {
-                        value: 0.0,
-                        units: 1e-9,
-                    },
-                ),
-            },
-            Point {
-                x: Float(
-                    FloatUnit {
-                        value: 10.0,
-                        units: 1e-9,
-                    },
-                ),
-                y: Float(
-                    FloatUnit {
-                        value: 5.0,
-                        units: 1e-9,
-                    },
-                ),
-            },
-            Point {
-                x: Float(
-                    FloatUnit {
-                        value: 0.0,
-                        units: 1e-9,
-                    },
-                ),
-                y: Float(
-                    FloatUnit {
-                        value: 5.0,
-                        units: 1e-9,
-                    },
-                ),
-            },
-            Point {
-                x: Float(
-                    FloatUnit {
-                        value: 0.0,
-                        units: 1e-9,
-                    },
-                ),
-                y: Float(
-                    FloatUnit {
-                        value: 0.0,
-                        units: 1e-9,
-                    },
-                ),
-            },
-        ]
-        "#);
+        assert_eq!(rect.points().len(), 5);
         assert_eq!(rect.layer(), Layer::new(1));
         assert_eq!(rect.data_type(), DataType::new(0));
+        assert_eq!(rect.points()[0], Point::float(0.0, 0.0, 1e-9));
+        assert_eq!(rect.points()[1], Point::float(10.0, 0.0, 1e-9));
+        assert_eq!(rect.points()[2], Point::float(10.0, 5.0, 1e-9));
+        assert_eq!(rect.points()[3], Point::float(0.0, 5.0, 1e-9));
+        assert_eq!(rect.points()[4], rect.points()[0]);
     }
 
     #[test]

--- a/crates/gdsr/src/property_tests/polygon.rs
+++ b/crates/gdsr/src/property_tests/polygon.rs
@@ -82,18 +82,6 @@ fn close_points_is_idempotent(polygon: Polygon) -> bool {
     once == twice
 }
 
-/// Non-degenerate rectangles (distinct corners) always have exactly 5 points.
-#[quickcheck]
-fn rectangle_has_five_points(x1: i16, y1: i16, x2: i16, y2: i16) -> quickcheck::TestResult {
-    if x1 == x2 || y1 == y2 {
-        return quickcheck::TestResult::discard();
-    }
-    let corner1 = Point::integer(i32::from(x1), i32::from(y1), 1e-9);
-    let corner2 = Point::integer(i32::from(x2), i32::from(y2), 1e-9);
-    let rect = Polygon::rectangle(corner1, corner2, Layer::new(0), DataType::new(0));
-    quickcheck::TestResult::from_bool(rect.points().len() == 5)
-}
-
 #[quickcheck]
 fn rectangle_area_equals_width_times_height(x1: i16, y1: i16, x2: i16, y2: i16) -> bool {
     let corner1 = Point::integer(i32::from(x1), i32::from(y1), 1e-9);
@@ -105,32 +93,6 @@ fn rectangle_area_equals_width_times_height(x1: i16, y1: i16, x2: i16, y2: i16) 
     let expected = width * height;
 
     (rect.area().float_value() - expected).abs() < 1e-6
-}
-
-#[quickcheck]
-fn rectangle_all_points_within_bounding_box(x1: i16, y1: i16, x2: i16, y2: i16) -> bool {
-    let corner1 = Point::integer(i32::from(x1), i32::from(y1), 1e-9);
-    let corner2 = Point::integer(i32::from(x2), i32::from(y2), 1e-9);
-    let rect = Polygon::rectangle(corner1, corner2, Layer::new(0), DataType::new(0));
-
-    let (min, max) = rect.bounding_box();
-    rect.points().iter().all(|p| {
-        p.x().float_value() >= min.x().float_value()
-            && p.x().float_value() <= max.x().float_value()
-            && p.y().float_value() >= min.y().float_value()
-            && p.y().float_value() <= max.y().float_value()
-    })
-}
-
-#[quickcheck]
-fn rectangle_corner_order_does_not_matter(x1: i16, y1: i16, x2: i16, y2: i16) -> bool {
-    let c1 = Point::integer(i32::from(x1), i32::from(y1), 1e-9);
-    let c2 = Point::integer(i32::from(x2), i32::from(y2), 1e-9);
-
-    let rect_forward = Polygon::rectangle(c1, c2, Layer::new(0), DataType::new(0));
-    let rect_reverse = Polygon::rectangle(c2, c1, Layer::new(0), DataType::new(0));
-
-    rect_forward.points() == rect_reverse.points()
 }
 
 #[quickcheck]

--- a/crates/gdsr/src/property_tests/polygon.rs
+++ b/crates/gdsr/src/property_tests/polygon.rs
@@ -82,6 +82,57 @@ fn close_points_is_idempotent(polygon: Polygon) -> bool {
     once == twice
 }
 
+/// Non-degenerate rectangles (distinct corners) always have exactly 5 points.
+#[quickcheck]
+fn rectangle_has_five_points(x1: i16, y1: i16, x2: i16, y2: i16) -> quickcheck::TestResult {
+    if x1 == x2 || y1 == y2 {
+        return quickcheck::TestResult::discard();
+    }
+    let corner1 = Point::integer(i32::from(x1), i32::from(y1), 1e-9);
+    let corner2 = Point::integer(i32::from(x2), i32::from(y2), 1e-9);
+    let rect = Polygon::rectangle(corner1, corner2, Layer::new(0), DataType::new(0));
+    quickcheck::TestResult::from_bool(rect.points().len() == 5)
+}
+
+#[quickcheck]
+fn rectangle_area_equals_width_times_height(x1: i16, y1: i16, x2: i16, y2: i16) -> bool {
+    let corner1 = Point::integer(i32::from(x1), i32::from(y1), 1e-9);
+    let corner2 = Point::integer(i32::from(x2), i32::from(y2), 1e-9);
+    let rect = Polygon::rectangle(corner1, corner2, Layer::new(0), DataType::new(0));
+
+    let width = (f64::from(x2) - f64::from(x1)).abs();
+    let height = (f64::from(y2) - f64::from(y1)).abs();
+    let expected = width * height;
+
+    (rect.area().float_value() - expected).abs() < 1e-6
+}
+
+#[quickcheck]
+fn rectangle_all_points_within_bounding_box(x1: i16, y1: i16, x2: i16, y2: i16) -> bool {
+    let corner1 = Point::integer(i32::from(x1), i32::from(y1), 1e-9);
+    let corner2 = Point::integer(i32::from(x2), i32::from(y2), 1e-9);
+    let rect = Polygon::rectangle(corner1, corner2, Layer::new(0), DataType::new(0));
+
+    let (min, max) = rect.bounding_box();
+    rect.points().iter().all(|p| {
+        p.x().float_value() >= min.x().float_value()
+            && p.x().float_value() <= max.x().float_value()
+            && p.y().float_value() >= min.y().float_value()
+            && p.y().float_value() <= max.y().float_value()
+    })
+}
+
+#[quickcheck]
+fn rectangle_corner_order_does_not_matter(x1: i16, y1: i16, x2: i16, y2: i16) -> bool {
+    let c1 = Point::integer(i32::from(x1), i32::from(y1), 1e-9);
+    let c2 = Point::integer(i32::from(x2), i32::from(y2), 1e-9);
+
+    let rect_forward = Polygon::rectangle(c1, c2, Layer::new(0), DataType::new(0));
+    let rect_reverse = Polygon::rectangle(c2, c1, Layer::new(0), DataType::new(0));
+
+    rect_forward.points() == rect_reverse.points()
+}
+
 #[quickcheck]
 fn regular_polygon_vertices_equidistant_from_center(num_sides: usize) -> bool {
     let num_sides = (num_sides % 100) + 3;


### PR DESCRIPTION
## Summary

Add `Polygon::rectangle()` for constructing normalized axis-aligned rectangles from opposing corners. Closes #224.

## Test Plan

Ran unit and property coverage for point order, area, bounds, and swapped corners.