### PR TITLE
Add fluent builder API for Polygon, Path, and GdsBox

### DIFF
--- a/crates/gdsr/src/elements/gds_box.rs
+++ b/crates/gdsr/src/elements/gds_box.rs
@@ -13,6 +13,11 @@ pub struct GdsBox {
 }
 
 impl GdsBox {
+    /// Returns a builder for constructing a box with method chaining.
+    pub fn builder() -> GdsBoxBuilder {
+        GdsBoxBuilder::default()
+    }
+
     /// Creates a new box from two diagonal corner points, layer, and box type.
     /// The corners are normalised so that `bottom_left` holds the minimum
     /// coordinates and `top_right` holds the maximum.
@@ -104,6 +109,64 @@ impl GdsBox {
             top_right: self.top_right.to_float_unit(),
             ..self
         }
+    }
+}
+
+/// A builder for constructing [`GdsBox`] instances with method chaining.
+///
+/// All fields have sensible defaults (origin point, layer 0, box type 0).
+/// Corners are automatically normalised when `build()` is called.
+///
+/// # Example
+/// ```
+/// # use gdsr::{GdsBox, Layer, DataType, Point};
+/// let gds_box = GdsBox::builder()
+///     .corner1(Point::integer(0, 0, 1e-9))
+///     .corner2(Point::integer(10, 20, 1e-9))
+///     .layer(Layer::new(1))
+///     .box_type(DataType::new(2))
+///     .build();
+/// ```
+#[derive(Clone, Debug, Default)]
+pub struct GdsBoxBuilder {
+    corner1: Point,
+    corner2: Point,
+    layer: Layer,
+    box_type: DataType,
+}
+
+impl GdsBoxBuilder {
+    /// Sets the first corner point.
+    #[must_use]
+    pub fn corner1(mut self, corner: Point) -> Self {
+        self.corner1 = corner;
+        self
+    }
+
+    /// Sets the second corner point.
+    #[must_use]
+    pub fn corner2(mut self, corner: Point) -> Self {
+        self.corner2 = corner;
+        self
+    }
+
+    /// Sets the box's layer.
+    #[must_use]
+    pub fn layer(mut self, layer: Layer) -> Self {
+        self.layer = layer;
+        self
+    }
+
+    /// Sets the box's type.
+    #[must_use]
+    pub fn box_type(mut self, box_type: DataType) -> Self {
+        self.box_type = box_type;
+        self
+    }
+
+    /// Builds the box, automatically normalising corners.
+    pub fn build(self) -> GdsBox {
+        GdsBox::new(self.corner1, self.corner2, self.layer, self.box_type)
     }
 }
 
@@ -245,6 +308,55 @@ mod tests {
             converted.top_right(),
             converted.top_right().to_integer_unit()
         );
+    }
+
+    #[test]
+    fn builder_with_all_fields() {
+        let gds_box = GdsBox::builder()
+            .corner1(p(0, 0))
+            .corner2(p(10, 20))
+            .layer(Layer::new(3))
+            .box_type(DataType::new(1))
+            .build();
+
+        assert_eq!(gds_box.bottom_left(), p(0, 0));
+        assert_eq!(gds_box.top_right(), p(10, 20));
+        assert_eq!(gds_box.layer(), Layer::new(3));
+        assert_eq!(gds_box.box_type(), DataType::new(1));
+    }
+
+    #[test]
+    fn builder_defaults() {
+        let gds_box = GdsBox::builder().build();
+
+        assert_eq!(gds_box.bottom_left(), Point::default());
+        assert_eq!(gds_box.top_right(), Point::default());
+        assert_eq!(gds_box.layer(), Layer::default());
+        assert_eq!(gds_box.box_type(), DataType::default());
+    }
+
+    #[test]
+    fn builder_normalises_corners() {
+        let gds_box = GdsBox::builder()
+            .corner1(p(10, 20))
+            .corner2(p(0, 0))
+            .build();
+
+        assert_eq!(gds_box.bottom_left(), p(0, 0));
+        assert_eq!(gds_box.top_right(), p(10, 20));
+    }
+
+    #[test]
+    fn builder_matches_new() {
+        let from_new = GdsBox::new(p(5, 5), p(15, 25), Layer::new(2), DataType::new(3));
+        let from_builder = GdsBox::builder()
+            .corner1(p(5, 5))
+            .corner2(p(15, 25))
+            .layer(Layer::new(2))
+            .box_type(DataType::new(3))
+            .build();
+
+        assert_eq!(from_new, from_builder);
     }
 
     #[test]

--- a/crates/gdsr/src/elements/mod.rs
+++ b/crates/gdsr/src/elements/mod.rs
@@ -7,9 +7,9 @@ pub mod reference;
 pub mod text;
 
 pub use element::Element;
-pub use gds_box::GdsBox;
+pub use gds_box::{GdsBox, GdsBoxBuilder};
 pub use node::Node;
-pub use path::{Path, PathType};
-pub use polygon::Polygon;
+pub use path::{Path, PathBuilder, PathType};
+pub use polygon::{Polygon, PolygonBuilder};
 pub use reference::{Instance, Reference};
 pub use text::Text;

--- a/crates/gdsr/src/elements/path.rs
+++ b/crates/gdsr/src/elements/path.rs
@@ -41,6 +41,11 @@ pub struct Path {
 }
 
 impl Path {
+    /// Returns a builder for constructing a path with method chaining.
+    pub fn builder() -> PathBuilder {
+        PathBuilder::default()
+    }
+
     /// Creates a new path from the given points, layer, data type, optional end cap type, optional width, and optional extensions.
     pub fn new(
         points: impl IntoIterator<Item = Point>,
@@ -217,6 +222,99 @@ impl Path {
             end_extension: self.end_extension.map(Unit::to_float_unit),
             ..self
         }
+    }
+}
+
+/// A builder for constructing [`Path`] instances with method chaining.
+///
+/// All fields have sensible defaults (empty points, layer 0, data type 0,
+/// all optional fields `None`).
+///
+/// # Example
+/// ```
+/// # use gdsr::{Path, PathType, Layer, DataType, Point, Unit};
+/// let path = Path::builder()
+///     .points(vec![
+///         Point::integer(0, 0, 1e-9),
+///         Point::integer(10, 0, 1e-9),
+///     ])
+///     .layer(Layer::new(5))
+///     .width(Unit::default_integer(100))
+///     .path_type(PathType::Round)
+///     .build();
+/// ```
+#[derive(Clone, Debug, Default)]
+pub struct PathBuilder {
+    points: Vec<Point>,
+    layer: Layer,
+    data_type: DataType,
+    path_type: Option<PathType>,
+    width: Option<Unit>,
+    begin_extension: Option<Unit>,
+    end_extension: Option<Unit>,
+}
+
+impl PathBuilder {
+    /// Sets the path's points.
+    #[must_use]
+    pub fn points(mut self, points: impl IntoIterator<Item = Point>) -> Self {
+        self.points = points.into_iter().collect();
+        self
+    }
+
+    /// Sets the path's layer.
+    #[must_use]
+    pub fn layer(mut self, layer: Layer) -> Self {
+        self.layer = layer;
+        self
+    }
+
+    /// Sets the path's data type.
+    #[must_use]
+    pub fn data_type(mut self, data_type: DataType) -> Self {
+        self.data_type = data_type;
+        self
+    }
+
+    /// Sets the path's end cap type.
+    #[must_use]
+    pub fn path_type(mut self, path_type: PathType) -> Self {
+        self.path_type = Some(path_type);
+        self
+    }
+
+    /// Sets the path's width.
+    #[must_use]
+    pub fn width(mut self, width: Unit) -> Self {
+        self.width = Some(width);
+        self
+    }
+
+    /// Sets the path's begin extension distance.
+    #[must_use]
+    pub fn begin_extension(mut self, ext: Unit) -> Self {
+        self.begin_extension = Some(ext);
+        self
+    }
+
+    /// Sets the path's end extension distance.
+    #[must_use]
+    pub fn end_extension(mut self, ext: Unit) -> Self {
+        self.end_extension = Some(ext);
+        self
+    }
+
+    /// Builds the path.
+    pub fn build(self) -> Path {
+        Path::new(
+            self.points,
+            self.layer,
+            self.data_type,
+            self.path_type,
+            self.width,
+            self.begin_extension,
+            self.end_extension,
+        )
     }
 }
 
@@ -594,6 +692,82 @@ mod tests {
         let last = arc.points().last().expect("arc should have points");
         assert!(last.x().float_value().abs() < tolerance);
         assert!((last.y().float_value() - radius).abs() < tolerance);
+    }
+
+    #[test]
+    fn test_builder_minimal() {
+        let path = Path::builder()
+            .points(vec![
+                Point::integer(0, 0, 1e-9),
+                Point::integer(10, 0, 1e-9),
+            ])
+            .build();
+
+        assert_eq!(path.points().len(), 2);
+        assert_eq!(path.layer(), Layer::new(0));
+        assert_eq!(path.data_type(), DataType::new(0));
+        assert_eq!(path.width(), None);
+        assert_eq!(path.path_type(), &None);
+        assert_eq!(path.begin_extension(), None);
+        assert_eq!(path.end_extension(), None);
+    }
+
+    #[test]
+    fn test_builder_with_all_fields() {
+        let path = Path::builder()
+            .points(vec![
+                Point::integer(0, 0, 1e-9),
+                Point::integer(10, 0, 1e-9),
+            ])
+            .layer(Layer::new(5))
+            .data_type(DataType::new(3))
+            .width(Unit::default_integer(100))
+            .path_type(PathType::Round)
+            .begin_extension(Unit::default_integer(5))
+            .end_extension(Unit::default_integer(15))
+            .build();
+
+        assert_eq!(path.layer(), Layer::new(5));
+        assert_eq!(path.data_type(), DataType::new(3));
+        assert_eq!(path.width(), Some(Unit::default_integer(100)));
+        assert_eq!(path.path_type(), &Some(PathType::Round));
+        assert_eq!(path.begin_extension(), Some(Unit::default_integer(5)));
+        assert_eq!(path.end_extension(), Some(Unit::default_integer(15)));
+    }
+
+    #[test]
+    fn test_builder_defaults() {
+        let path = Path::builder().build();
+
+        assert!(path.points().is_empty());
+        assert_eq!(path.layer(), Layer::new(0));
+        assert_eq!(path.data_type(), DataType::new(0));
+        assert_eq!(path.width(), None);
+    }
+
+    #[test]
+    fn test_builder_matches_new() {
+        let points = vec![Point::integer(0, 0, 1e-9), Point::integer(10, 0, 1e-9)];
+        let from_new = Path::new(
+            points.clone(),
+            Layer::new(2),
+            DataType::new(1),
+            Some(PathType::Overlap),
+            Some(Unit::default_integer(50)),
+            Some(Unit::default_integer(10)),
+            Some(Unit::default_integer(20)),
+        );
+        let from_builder = Path::builder()
+            .points(points)
+            .layer(Layer::new(2))
+            .data_type(DataType::new(1))
+            .path_type(PathType::Overlap)
+            .width(Unit::default_integer(50))
+            .begin_extension(Unit::default_integer(10))
+            .end_extension(Unit::default_integer(20))
+            .build();
+
+        assert_eq!(from_new, from_builder);
     }
 
     #[test]

--- a/crates/gdsr/src/elements/polygon.rs
+++ b/crates/gdsr/src/elements/polygon.rs
@@ -33,6 +33,11 @@ pub struct Polygon {
 }
 
 impl Polygon {
+    /// Returns a builder for constructing a polygon with method chaining.
+    pub fn builder() -> PolygonBuilder {
+        PolygonBuilder::default()
+    }
+
     /// Creates a new polygon from the given points, layer, and data type.
     /// The polygon is automatically closed if needed.
     pub fn new(points: impl IntoIterator<Item = Point>, layer: Layer, data_type: DataType) -> Self {
@@ -245,6 +250,59 @@ impl Polygon {
     /// Check if a point lies on the edge of the polygon
     pub fn is_point_on_edge(&self, point: &Point) -> bool {
         crate::geometry::is_point_on_edge(point, &self.points)
+    }
+}
+
+/// A builder for constructing [`Polygon`] instances with method chaining.
+///
+/// All fields have sensible defaults (empty points, layer 0, data type 0).
+/// Points are automatically closed when `build()` is called.
+///
+/// # Example
+/// ```
+/// # use gdsr::{Polygon, Layer, DataType, Point};
+/// let polygon = Polygon::builder()
+///     .points(vec![
+///         Point::integer(0, 0, 1e-9),
+///         Point::integer(10, 0, 1e-9),
+///         Point::integer(5, 10, 1e-9),
+///     ])
+///     .layer(Layer::new(1))
+///     .data_type(DataType::new(2))
+///     .build();
+/// ```
+#[derive(Clone, Debug, Default)]
+pub struct PolygonBuilder {
+    points: Vec<Point>,
+    layer: Layer,
+    data_type: DataType,
+}
+
+impl PolygonBuilder {
+    /// Sets the polygon's points.
+    #[must_use]
+    pub fn points(mut self, points: impl IntoIterator<Item = Point>) -> Self {
+        self.points = points.into_iter().collect();
+        self
+    }
+
+    /// Sets the polygon's layer.
+    #[must_use]
+    pub fn layer(mut self, layer: Layer) -> Self {
+        self.layer = layer;
+        self
+    }
+
+    /// Sets the polygon's data type.
+    #[must_use]
+    pub fn data_type(mut self, data_type: DataType) -> Self {
+        self.data_type = data_type;
+        self
+    }
+
+    /// Builds the polygon, automatically closing the point sequence if needed.
+    pub fn build(self) -> Polygon {
+        Polygon::new(self.points, self.layer, self.data_type)
     }
 }
 
@@ -680,6 +738,49 @@ mod tests {
         let origin = Point::float(0.0, 0.0, 1e-6);
         let ring = Polygon::ring(origin, 3.0, 5.0, 360, Layer::new(0), DataType::new(0));
         assert!(!ring.is_point_inside(&origin));
+    }
+
+    #[test]
+    fn test_builder_with_all_fields() {
+        let polygon = Polygon::builder()
+            .points(vec![
+                Point::integer(0, 0, 1e-9),
+                Point::integer(10, 0, 1e-9),
+                Point::integer(5, 10, 1e-9),
+            ])
+            .layer(Layer::new(1))
+            .data_type(DataType::new(2))
+            .build();
+
+        assert_eq!(polygon.layer(), Layer::new(1));
+        assert_eq!(polygon.data_type(), DataType::new(2));
+        assert_eq!(polygon.points().len(), 4);
+    }
+
+    #[test]
+    fn test_builder_defaults() {
+        let polygon = Polygon::builder().build();
+
+        assert_eq!(polygon.layer(), Layer::new(0));
+        assert_eq!(polygon.data_type(), DataType::new(0));
+        assert!(polygon.points().is_empty());
+    }
+
+    #[test]
+    fn test_builder_matches_new() {
+        let points = vec![
+            Point::integer(0, 0, 1e-9),
+            Point::integer(10, 0, 1e-9),
+            Point::integer(10, 10, 1e-9),
+        ];
+        let from_new = Polygon::new(points.clone(), Layer::new(3), DataType::new(4));
+        let from_builder = Polygon::builder()
+            .points(points)
+            .layer(Layer::new(3))
+            .data_type(DataType::new(4))
+            .build();
+
+        assert_eq!(from_new, from_builder);
     }
 
     #[test]

--- a/crates/gdsr/src/lib.rs
+++ b/crates/gdsr/src/lib.rs
@@ -17,7 +17,10 @@ mod units;
 
 pub use cell::Cell;
 pub use elements::text::{HorizontalPresentation, VerticalPresentation};
-pub use elements::{Element, GdsBox, Instance, Node, Path, PathType, Polygon, Reference, Text};
+pub use elements::{
+    Element, GdsBox, GdsBoxBuilder, Instance, Node, Path, PathBuilder, PathType, Polygon,
+    PolygonBuilder, Reference, Text,
+};
 pub use error::GdsError;
 pub use grid::Grid;
 pub use io::write::svg::cell_to_svg;


### PR DESCRIPTION
## Summary

Add fluent builders for `Polygon`, `Path`, and `GdsBox` while preserving existing constructors and validation. Closes #127.

## Test Plan

Ran builder unit tests, the full test suite, and rustdoc examples.