### PR TITLE
Add repository standards

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.github/ISSUE_TEMPLATE/1_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.yml
@@ -1,5 +1,6 @@
 name: Bug report
 description: Report an error or unexpected behavior
+labels: ["bug"]
 body:
   - type: markdown
     attributes:
@@ -14,6 +15,16 @@ body:
       description: |
         A clear and concise description of the bug, including a minimal reproducible example.
 
+        Include the command you invoked, the input layout when possible, and the full output, including the complete error message.
+
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: Platform
+      description: What operating system and architecture are you using? (see `uname -orsm`)
+      placeholder: e.g., macOS 15 arm64, Windows 11 x86_64, Ubuntu 24.04 amd64
     validations:
       required: true
 
@@ -23,4 +34,4 @@ body:
       description: What version of GDSR are you using?
       placeholder: e.g., GDSR 0.1.0
     validations:
-      required: false
+      required: true

--- a/.github/ISSUE_TEMPLATE/3_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/3_feature_request.yml
@@ -1,0 +1,19 @@
+name: Feature request
+description: Propose a new feature or change to existing behavior
+labels: ["needs-decision"]
+body:
+  - type: textarea
+    attributes:
+      label: Summary
+      description: |
+        Describe the feature or behavior change you want, including the problem it solves.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Example
+      description: |
+        Show the API call, CLI command, layout operation, or GDSII structure you would expect to use if this existed.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Documentation
+    url: https://matthewmckee4.github.io/gdsr/
+    about: Please consult the documentation before creating an issue.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,10 @@
+<!--
+Before requesting review, make sure the PR has a clear summary, a descriptive
+title, references to relevant issues, and a short test plan. If AI helped
+produce the change, make sure the contribution still follows the project's
+review and authorship expectations.
+-->
+
 ## Summary
 
 <!-- What's the purpose of the change? What does it do, and why? -->

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,7 @@
+# Configuration for the actionlint tool, which we run via prek to verify the
+# syntax of GitHub Actions workflows.
+
+self-hosted-runner:
+  labels:
+    - macos-15-intel
+    - ubuntu-22.04-arm

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,46 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    labels:
+      - "dependencies"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    labels:
+      - "dependencies"
+    schedule:
+      interval: "weekly"
+    groups:
+      pre-commit-hooks:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "rust-toolchain"
+    directory: "/"
+    labels:
+      - "dependencies"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    labels:
+      - "dependencies"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,23 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 env:
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  CARGO_TERM_COLOR: always
   PYTHON_VERSION: "3.14"
+  RUSTUP_MAX_RETRIES: 10
 
 jobs:
   determine_changes:
     name: "determine changes"
 
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     outputs:
       # Flag that is raised when any code is changed
@@ -45,14 +54,28 @@ jobs:
         run: |
           if git diff --quiet "${MERGE_BASE}...HEAD" -- \
             . \
+            ':!.gitattributes' \
+            ':!.github/CODEOWNERS' \
+            ':!.github/FUNDING.yml' \
+            ':!.github/ISSUE_TEMPLATE/**' \
+            ':!.github/PULL_REQUEST_TEMPLATE.md' \
+            ':!.github/actionlint.yaml' \
+            ':!.github/codecov.yml' \
+            ':!.github/dependabot.yml' \
+            ':!.github/zizmor.yml' \
             ':!docs/' \
             ':!.markdownlint.yaml' \
             ':!.pre-commit-config.yaml' \
+            ':!AGENTS.md' \
             ':!CHANGELOG.md' \
             ':!CODE_OF_CONDUCT.md' \
             ':!CONTRIBUTING.md' \
             ':!LICENSE' \
             ':!README.md' \
+            ':!SECURITY.md' \
+            ':!STYLE.md' \
+            ':!rustfmt.toml' \
+            ':!rust-toolchain.toml' \
             ':!seal.toml' \
             ':!zensical.toml' \
           ; then
@@ -65,6 +88,7 @@ jobs:
     name: "pre commit"
 
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -75,12 +99,16 @@ jobs:
 
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
 
+      - name: "Install Rust components"
+        run: rustup component add rustfmt clippy
+
       - uses: j178/prek-action@91fd7d7cf70ae1dee9f4f44e7dfa5d1073fe6623 # v1.0.11
 
   build-docs:
     name: "Build docs"
 
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -102,6 +130,7 @@ jobs:
     name: "cargo test (${{ matrix.os }})"
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
 
     needs: determine_changes
     if: ${{ (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
@@ -135,6 +164,7 @@ jobs:
     name: "coverage"
 
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     needs: determine_changes
 
@@ -166,17 +196,19 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
           slug: MatthewMckee4/gdsr
+          use_pypi: true
           fail_ci_if_error: true
 
   benchmarks:
     name: "benchmarks"
 
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     needs: determine_changes
 
-    # Disabled until benchmarks are stabilized and actively maintained
-    if: false
+    # Disabled until benchmarks are stabilized and actively maintained.
+    if: ${{ vars.ENABLE_BENCHMARKS == 'true' }}
 
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,13 +12,15 @@ on:
 env:
   PYTHON_VERSION: "3.14"
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   generate-release:
     name: Generate release metadata
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
     outputs:
       release-metadata: ${{ steps.seal-generate.outputs.metadata }}
       tag: ${{ github.event.inputs.tag }}
@@ -51,6 +53,9 @@ jobs:
     runs-on: ${{ matrix.runner }}
     needs: generate-release
     if: github.event_name == 'workflow_dispatch'
+    timeout-minutes: 30
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -112,6 +117,9 @@ jobs:
     runs-on: ubuntu-22.04
     needs: generate-release
     if: github.event_name == 'workflow_dispatch'
+    timeout-minutes: 20
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository
@@ -140,6 +148,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [generate-release, build-viewer-local, build-viewer-global]
     if: github.event_name == 'workflow_dispatch'
+    timeout-minutes: 15
+    permissions:
+      contents: write
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -200,6 +211,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: create-release
     if: github.event_name == 'workflow_dispatch'
+    timeout-minutes: 10
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository
@@ -225,6 +239,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: create-release
     if: github.event_name == 'workflow_dispatch'
+    timeout-minutes: 10
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,25 @@
 /target
+/site
 
-node_modules/
+uv.lock
+
+__pycache__/
+*.py[cod]
+.venv*/
+.tox/
+.nox/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+
+*.rs.pending-snap
+**/*.rs.bk
+
+*.profraw
+.coverage
+.coverage.*
+htmlcov/
 
 .DS_Store
+
+node_modules/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+fail_fast: false
+
 exclude:
   glob:
     - "*.svg"
@@ -8,43 +10,77 @@ repos:
     rev: v6.0.0
     hooks:
       - id: check-added-large-files
+        priority: 0
       - id: check-case-conflict
+        priority: 0
       - id: check-merge-conflict
+        priority: 0
       - id: check-symlinks
+        priority: 0
       - id: check-yaml
+        priority: 0
       - id: check-toml
+        priority: 0
       - id: debug-statements
+        priority: 0
       - id: end-of-file-fixer
+        priority: 0
       - id: mixed-line-ending
+        priority: 0
       - id: detect-private-key
+        priority: 0
 
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.24.1
+    rev: v0.25
     hooks:
       - id: validate-pyproject
+        priority: 0
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1.40.0
+    rev: v1.47.2
     hooks:
       - id: typos
+        priority: 0
+
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint
+        priority: 0
+
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.26.1
+    hooks:
+      - id: zizmor
+        priority: 0
+
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.37.3
+    hooks:
+      - id: check-github-workflows
+        priority: 0
 
   - repo: https://github.com/executablebooks/mdformat
     rev: 1.0.0
     hooks:
       - id: mdformat
+        priority: 1
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.46.0
+    rev: v0.49.0
     hooks:
       - id: markdownlint-fix
+        priority: 2
 
   - repo: https://github.com/doublify/pre-commit-rust
     rev: v1.0
     hooks:
       - id: cargo-check
         args: ["--all-targets", "--all-features"]
+        priority: 2
       - id: clippy
         args: ["--all-targets", "--all-features", "--", "-D", "warnings"]
+        priority: 2
 
   - repo: local
     hooks:
@@ -54,27 +90,20 @@ repos:
         language: system
         types: [rust]
         pass_filenames: false
-
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
-    hooks:
-      - id: prettier
-        types_or: [yaml, toml]
+        priority: 1
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.7
+    rev: v0.15.18
     hooks:
       - id: ruff-check
-        args: [--fix]
+        args: [--fix, --exit-non-zero-on-fix]
+        priority: 1
       - id: ruff-format
-
-  - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.18.0
-    hooks:
-      - id: zizmor
+        priority: 1
 
   - repo: https://github.com/DevinR528/cargo-sort
-    rev: v2.0.2
+    rev: v2.1.4
     hooks:
       - id: cargo-sort
         args: ["-g", "-w"]
+        priority: 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,81 @@
+# GDSR Repository
+
+GDSR is a Rust workspace for reading, writing, and viewing GDSII layout files.
+Read `CONTRIBUTING.md` before changing files; it has the current crate map,
+setup commands, docs commands, and release process.
+
+## Running Tests
+
+Run the test suite with nextest:
+
+```sh
+cargo nextest run
+```
+
+Pass package or test filters directly when a narrower run is enough during
+iteration:
+
+```sh
+cargo nextest run -p gdsr
+```
+
+If `cargo-nextest` is not installed, use `cargo test`.
+
+Run Clippy with the same strictness as CI:
+
+```sh
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+```
+
+Run docs locally with:
+
+```sh
+uv run -s scripts/prepare_docs.py
+uv run --isolated --with-requirements docs/requirements.txt zensical serve
+```
+
+Run `uvx prek run -a` at the end of every task. During iteration, use
+`uvx prek run --files <path1> <path2>` with every changed file to keep hook runs
+independent of staged state.
+
+## Snapshots And Generated Files
+
+Prefer property or integration tests when behavior crosses parser, writer,
+geometry, or viewer boundaries. Keep UI changes tested through pure logic such
+as coordinate transforms, selection state, or data preparation instead of
+rendering.
+
+Prefer inline snapshots for small expected values. Use external snapshot files
+only when the output is too large to read inline. After updating snapshots,
+review the diff before accepting them and check for pending snapshot files.
+
+`scripts/prepare_docs.py` generates `docs/index.md` from `README.md`; update the
+source content rather than hand-editing the generated file.
+
+## Development Guidelines
+
+- All behavior changes must be tested. If you did not run the relevant tests,
+  the change is not done.
+- Look for existing utilities and local patterns before writing new code.
+- Keep visibility narrow by default, but make an item public when another
+  workspace crate needs it and that is the cleaner implementation.
+- Keep Rust imports at the top of the file, not locally inside functions.
+- Avoid `panic!`, `unreachable!`, `.unwrap()`, unsafe code, and Clippy ignores.
+  Encode constraints in the type system instead.
+- Prefer `if let` for fallibility, and prefer let chains over nested `if let`
+  when it improves readability.
+- Prefer `#[expect()]` over `#[allow()]` when a Clippy lint must be suppressed.
+- Prefer short imports over fully qualified paths for readability.
+- Use comments to explain invariants or unusual decisions, not to narrate code.
+- Avoid redundant comments and section separators in tests.
+- Prefer function comments over inline comments.
+- Add new dependencies to `[workspace.dependencies]` in the root `Cargo.toml`
+  and reference them with `{ workspace = true }` in crate manifests.
+- Consider whether a change needs docs under `docs/`. New public APIs, CLI
+  changes, changed defaults, and release behavior changes usually need docs.
+
+## Pull Requests
+
+Always use the pull request template and add labels. Write the description in
+concise prose paragraphs, with code examples only when they help the reviewer.
+Do not add AI tooling as an author or co-author.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for
+moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+<matthewmckee04@yahoo.co.uk>. All complaints will be reviewed and investigated
+promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+<https://www.contributor-covenant.org/version/2/0/code_of_conduct.html>.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+For answers to common questions about this code of conduct, see the FAQ at
+<https://www.contributor-covenant.org/faq>. Translations are available at
+<https://www.contributor-covenant.org/translations>.
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,28 +1,133 @@
-# Contributing
+# Contributing to GDSR
 
-## Finding ways to help
+Thanks for your interest in contributing to GDSR. Contributions of all kinds are
+welcome, and we try to keep the development process as smooth as possible.
 
-We label issues that would be good for a first time contributor as
+If you hit a bug, have a feature idea, or want to suggest an improvement to the
+contributing docs themselves, please
+[open an issue](https://github.com/MatthewMckee4/gdsr/issues/new).
+
+For small changes like bug fixes, feel free to jump straight to a pull request.
+For anything larger, it is usually worth opening an issue first to discuss the
+approach.
+
+If you want to tackle an issue that is already open, please leave a comment
+letting me know you would like to work on it. There is only one person working
+on this project right now, so issues may be out of date and I do not want you to
+work on something that does not align with the goals for the project.
+
+## Finding Ways To Help
+
+We label issues that would be good for a first-time contributor as
 [`good first issue`](https://github.com/MatthewMckee4/gdsr/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22).
-These usually do not require significant experience with code base.
+These usually do not require significant experience with the codebase.
 
-We label issues that we think are a good opportunity for subsequent contributions as
+We label issues that we think are a good opportunity for subsequent
+contributions as
 [`help wanted`](https://github.com/MatthewMckee4/gdsr/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22).
 These require varying levels of experience.
 
-## Setup
+## Architecture
 
-[Rust](https://rustup.rs/) is required to build and work on the project.
+GDSR is a Rust workspace with a library crate, a viewer crate, docs, and
+benchmark tooling.
 
-## Testing
+The main crates:
 
-For running tests, we recommend [nextest](https://nexte.st/).
+- `gdsr` - the library crate. Contains the GDSII data model, binary reader and
+  writer, units, element types, and geometry helpers.
+- `gdsr-viewer` - the `egui`/`eframe` viewer binary. Loads GDSII libraries,
+  renders cells, and provides the interactive inspection workflow.
+
+Infrastructure and tooling:
+
+- `docs/` - zensical documentation.
+- `scripts/prepare_docs.py` - prepares generated docs pages before serving or
+  building the docs.
+- `scripts/benchmark/` - benchmark plotting and benchmark result assets.
+
+## Prerequisites
+
+GDSR is written in Rust. Install the
+[Rust toolchain](https://www.rust-lang.org/tools/install) to get started. The
+repository includes `rust-toolchain.toml`, so `rustup` will select the expected
+toolchain automatically.
+
+You can optionally install prek hooks to automatically run validation checks
+when making a commit:
+
+```bash
+uv tool install prek
+prek install
+```
+
+We recommend [nextest](https://nexte.st/) for running the Rust test suite:
+
+```bash
+cargo install cargo-nextest --locked
+```
+
+## Development
+
+To run the tests:
+
+```bash
+cargo nextest run
+```
+
+Pass test arguments directly for focused iteration:
+
+```bash
+cargo nextest run -p gdsr
+```
+
+Before opening a pull request, run the relevant tests plus the full validation
+sweep:
+
+```bash
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+uvx prek run -a
+```
 
 ## Documentation
 
-To prepare and run the documentation locally, run:
+We use zensical to build the documentation.
 
-```shell
+```bash
+uv run -s scripts/prepare_docs.py
+uv run --isolated --with-requirements docs/requirements.txt zensical build
+```
+
+To serve the docs locally:
+
+```bash
 uv run -s scripts/prepare_docs.py
 uv run --isolated --with-requirements docs/requirements.txt zensical serve
+```
+
+## Release Process
+
+Releases are automated through the release workflow and `seal`.
+
+First, install [seal](https://github.com/MatthewMckee4/seal), then bump the
+version with:
+
+```bash
+seal bump alpha
+```
+
+or:
+
+```bash
+seal bump <version>
+```
+
+This creates a branch and commit, so you just need to open a pull request.
+
+## GitHub Actions
+
+If you update GitHub Actions, run `pinact` to pin action versions:
+
+```bash
+pinact run
 ```

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
+# Please update rustfmt.toml when bumping the Rust edition.
 edition = "2024"
 rust-version = "1.85"
 homepage = "https://github.com/MatthewMckee4/gdsr"
@@ -46,7 +47,15 @@ targets = [
 ]
 
 [workspace.lints.clippy]
-pedantic = { level = "warn", priority = -2 }
+all = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+nursery = { level = "warn", priority = -1 }
+correctness = { level = "warn", priority = -1 }
+suspicious = { level = "warn", priority = -1 }
+style = { level = "warn", priority = -1 }
+complexity = { level = "warn", priority = -1 }
+perf = { level = "warn", priority = -1 }
+
 # Allowed pedantic lints
 char_lit_as_u8 = "allow"
 collapsible_else_if = "allow"
@@ -54,15 +63,20 @@ collapsible_if = "allow"
 implicit_hasher = "allow"
 map_unwrap_or = "allow"
 match_same_arms = "allow"
+missing_const_for_fn = "allow"
 missing_errors_doc = "allow"
 missing_panics_doc = "allow"
 module_name_repetitions = "allow"
 must_use_candidate = "allow"
+option_if_let_else = "allow"
+significant_drop_tightening = "allow"
 similar_names = "allow"
 struct_excessive_bools = "allow"
+suboptimal_flops = "allow"
 too_many_arguments = "allow"
 too_many_lines = "allow"
 used_underscore_binding = "allow"
+collapsible_match = "allow"
 # Disallowed restriction lints
 print_stdout = "warn"
 print_stderr = "warn"
@@ -81,6 +95,10 @@ cast_possible_truncation = "allow"
 cast_sign_loss = "allow"
 float_cmp = "allow"
 cast_possible_wrap = "allow"
+
+[workspace.lints.rust]
+unsafe_code = "warn"
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(codspeed)"] }
 
 [profile.dist]
 inherits = "release"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+GDSR parses and writes GDSII files and includes a viewer for inspecting layout
+data. It does not execute code from GDSII files.
+
+Malformed or hostile files should be rejected with an error rather than causing
+panics, memory unsafety, or uncontrolled resource use. A file being too large to
+open comfortably, or a parser returning a normal error for invalid GDSII data, is
+not usually a vulnerability.
+
+Please report vulnerabilities in GDSR privately by emailing
+<matthewmckee04@yahoo.co.uk>. Include the affected version, a minimal
+reproduction, and the impact you expect.
+
+Security fixes target the latest released version and the `main` branch.

--- a/STYLE.md
+++ b/STYLE.md
@@ -1,0 +1,45 @@
+# Style Guide
+
+This guide covers user-facing text in GDSR documentation, CLI output, issue
+templates, and release notes.
+
+## General
+
+- Write `GDSR` for the project, `gdsr` for the crate, and `gdsr-viewer` for the
+  viewer binary.
+- Write `GDSII` for the file format.
+- Use direct, concrete language. Prefer "run `gdsr-viewer path/to/file.gds`"
+  over "it is possible to run the viewer".
+- Use backticks for commands, flags, environment variables, file paths, crate
+  names, and code expressions.
+- Avoid bare URLs in prose. Prefer descriptive links.
+- Wrap Markdown at 100 characters unless the file is generated.
+
+## Documentation
+
+- Start from the user's task, then add details.
+- Put common workflows before edge cases.
+- Keep generated pages generated. Update the source and regenerate the docs
+  instead of hand-editing generated output.
+- Use `console` fences when showing commands and their output. Use `bash` only
+  for shell scripts.
+- Include command output only when the exact output matters.
+- Link to reference pages from guides when the reader needs the complete option
+  list.
+
+## CLI Output
+
+- Error messages should say what failed and include the relevant path, layer,
+  cell, or element when available.
+- Hints should be actionable and formatted as `hint: <message>`.
+- Output must still make sense without color.
+- Write machine-readable data to stdout. Write diagnostics, progress, and
+  warnings to stderr.
+
+## Terminology
+
+- Use "library" for a complete GDSII library.
+- Use "cell" for structures unless quoting GDSII record names.
+- Use "element" for boundaries, paths, text, references, nodes, and boxes.
+- Use "layer" and "datatype" for the GDSII layer selectors.
+- Use "snapshot", not "golden file", for snapshot-testing output.

--- a/crates/gdsr-viewer/src/drawable.rs
+++ b/crates/gdsr-viewer/src/drawable.rs
@@ -151,7 +151,7 @@ impl DrawContext<'_> {
 
 /// Pre-tessellates a polyline stroke into a [`Mesh`] of quads (2 triangles per edge).
 /// For `closed` polylines, the last point connects back to the first.
-pub(crate) fn stroke_polyline_to_mesh(points: &[Pos2], stroke: Stroke, closed: bool) -> Mesh {
+pub fn stroke_polyline_to_mesh(points: &[Pos2], stroke: Stroke, closed: bool) -> Mesh {
     let mut mesh = Mesh::default();
     if points.len() < 2 {
         return mesh;
@@ -449,7 +449,7 @@ impl Drawable for gdsr::Path {
             if let Some(first) = segments.first_mut() {
                 let dx = first.2 - first.0;
                 let dy = first.3 - first.1;
-                let len = (dx * dx + dy * dy).sqrt();
+                let len = dx.hypot(dy);
                 if len > f64::EPSILON {
                     first.0 -= dx / len * begin_ext;
                     first.1 -= dy / len * begin_ext;
@@ -458,7 +458,7 @@ impl Drawable for gdsr::Path {
             if let Some(last) = segments.last_mut() {
                 let dx = last.2 - last.0;
                 let dy = last.3 - last.1;
-                let len = (dx * dx + dy * dy).sqrt();
+                let len = dx.hypot(dy);
                 if len > f64::EPSILON {
                     last.2 += dx / len * end_ext;
                     last.3 += dy / len * end_ext;

--- a/crates/gdsr-viewer/src/grid.rs
+++ b/crates/gdsr-viewer/src/grid.rs
@@ -56,6 +56,10 @@ fn draw_grid_lines(
     stroke: Stroke,
 ) {
     let mut x = first_line(visible.min_x, spacing);
+    #[expect(
+        clippy::while_float,
+        reason = "grid lines advance in visible world coordinates"
+    )]
     while x <= visible.max_x {
         let top = viewport.world_to_screen(x, visible.max_y, rect);
         let bottom = viewport.world_to_screen(x, visible.min_y, rect);
@@ -64,6 +68,10 @@ fn draw_grid_lines(
     }
 
     let mut y = first_line(visible.min_y, spacing);
+    #[expect(
+        clippy::while_float,
+        reason = "grid lines advance in visible world coordinates"
+    )]
     while y <= visible.max_y {
         let left = viewport.world_to_screen(visible.min_x, y, rect);
         let right = viewport.world_to_screen(visible.max_x, y, rect);

--- a/crates/gdsr-viewer/src/hierarchy.rs
+++ b/crates/gdsr-viewer/src/hierarchy.rs
@@ -52,6 +52,10 @@ fn build_node<'a>(
 ) -> CellTreeNode {
     ancestors.insert(name);
     let children = if let Some(kids) = children_of.get(name) {
+        #[expect(
+            clippy::needless_collect,
+            reason = "collect avoids borrowing ancestors across recursive mutation"
+        )]
         let valid_kids: Vec<&str> = kids
             .iter()
             .filter(|kid| !ancestors.contains(**kid))

--- a/crates/gdsr-viewer/src/ruler.rs
+++ b/crates/gdsr-viewer/src/ruler.rs
@@ -29,7 +29,7 @@ impl Measurement {
     pub fn distance(&self) -> f64 {
         let dx = self.end.0 - self.start.0;
         let dy = self.end.1 - self.start.1;
-        (dx * dx + dy * dy).sqrt()
+        dx.hypot(dy)
     }
 }
 
@@ -66,11 +66,10 @@ impl RulerState {
                 end: (wx, wy),
             });
             self.start = None;
-            true
         } else {
             self.start = Some((wx, wy));
-            true
         }
+        true
     }
 
     /// Draws all ruler overlays: completed measurements and in-progress line to cursor.
@@ -99,7 +98,7 @@ impl RulerState {
                 });
                 draw_endpoint(painter, s_end);
 
-                let distance = ((mx - start.0).powi(2) + (my - start.1).powi(2)).sqrt();
+                let distance = (mx - start.0).hypot(my - start.1);
                 let label = format_distance(distance);
                 let midpoint = Pos2::new(
                     f32::midpoint(s_start.x, s_end.x),

--- a/crates/gdsr-viewer/src/viewport/mod.rs
+++ b/crates/gdsr-viewer/src/viewport/mod.rs
@@ -1,4 +1,4 @@
-pub(crate) mod bounds;
+pub mod bounds;
 
 pub use bounds::compute_bounds;
 

--- a/crates/gdsr/src/elements/path.rs
+++ b/crates/gdsr/src/elements/path.rs
@@ -564,7 +564,7 @@ mod tests {
         for point in arc.points() {
             let dx = point.x().float_value() - center.x().float_value();
             let dy = point.y().float_value() - center.y().float_value();
-            let dist = (dx * dx + dy * dy).sqrt();
+            let dist = dx.hypot(dy);
             assert!(
                 (dist - radius).abs() < tolerance,
                 "point distance {dist} differs from radius {radius}"

--- a/crates/gdsr/src/elements/polygon.rs
+++ b/crates/gdsr/src/elements/polygon.rs
@@ -10,7 +10,7 @@ fn are_points_closed(points: &[Point]) -> bool {
     points_vec.first() == points_vec.last()
 }
 
-pub(crate) fn close_points(points: impl IntoIterator<Item = Point>) -> Vec<Point> {
+pub fn close_points(points: impl IntoIterator<Item = Point>) -> Vec<Point> {
     let mut points_vec = points.into_iter().collect::<Vec<_>>();
     if !are_points_closed(&points_vec) {
         if let Some(first) = points_vec.first().copied() {

--- a/crates/gdsr/src/elements/reference.rs
+++ b/crates/gdsr/src/elements/reference.rs
@@ -284,7 +284,7 @@ impl Reference {
                         reference.clone().flatten(Some(depth - 1), library);
 
                     for reference_element in flattened_reference_elements {
-                        elements.extend(self.get_elements_in_grid(&reference_element).into_iter());
+                        elements.extend(self.get_elements_in_grid(&reference_element));
                     }
                 }
             },
@@ -1225,7 +1225,7 @@ mod tests {
         );
 
         let mut cell = crate::Cell::new("test_cell");
-        cell.add(polygon.clone());
+        cell.add(polygon);
         library.add_cell(cell);
 
         let grid = Grid::default()

--- a/crates/gdsr/src/geometry/area.rs
+++ b/crates/gdsr/src/geometry/area.rs
@@ -15,7 +15,7 @@ pub fn area(points: &[Point]) -> Unit {
     let units = first_point.units().0;
 
     let points = ensure_points_same_units(points, units);
-    let closed = get_correct_polygon_points_format(points.clone());
+    let closed = get_correct_polygon_points_format(points);
 
     let mut sum = 0.0;
     for i in 0..closed.len() - 1 {

--- a/crates/gdsr/src/geometry/mod.rs
+++ b/crates/gdsr/src/geometry/mod.rs
@@ -2,7 +2,7 @@ mod area;
 mod bounding_box;
 mod is_point_inside;
 mod is_point_on_edge;
-pub(crate) mod path_expansion;
+mod path_expansion;
 mod perimeter;
 mod round;
 

--- a/crates/gdsr/src/geometry/path_expansion.rs
+++ b/crates/gdsr/src/geometry/path_expansion.rs
@@ -111,7 +111,7 @@ fn apply_extensions(
 fn direction(a: (f64, f64), b: (f64, f64)) -> (f64, f64) {
     let dx = b.0 - a.0;
     let dy = b.1 - a.1;
-    let len = (dx * dx + dy * dy).sqrt();
+    let len = dx.hypot(dy);
     if len < f64::EPSILON {
         return (0.0, 0.0);
     }

--- a/crates/gdsr/src/geometry/perimeter.rs
+++ b/crates/gdsr/src/geometry/perimeter.rs
@@ -21,7 +21,7 @@ pub fn perimeter(points: &[Point]) -> Unit {
     for i in 0..points.len() - 1 {
         let dx = points[i + 1].x().float_value() - points[i].x().float_value();
         let dy = points[i + 1].y().float_value() - points[i].y().float_value();
-        length += (dx * dx + dy * dy).sqrt();
+        length += dx.hypot(dy);
     }
 
     Unit::float(length, units)
@@ -99,7 +99,7 @@ mod property_tests {
         let b = Point::float(f64::from(x2), f64::from(y2), 1e-6);
         let dx = f64::from(x2) - f64::from(x1);
         let dy = f64::from(y2) - f64::from(y1);
-        let expected = (dx * dx + dy * dy).sqrt();
+        let expected = dx.hypot(dy);
         (perimeter(&[a, b]).float_value() - expected).abs() < 1e-10
     }
 }

--- a/crates/gdsr/src/io/write/svg.rs
+++ b/crates/gdsr/src/io/write/svg.rs
@@ -234,7 +234,8 @@ fn bounding_box_of_elements(elements: &[Element]) -> (Point, Point) {
         .iter()
         .flat_map(|e| {
             let (min, max) = e.bounding_box();
-            [min, max]
+            let corners: [Point; 2] = (min, max).into();
+            corners
         })
         .collect();
     if points.is_empty() {

--- a/crates/gdsr/src/library.rs
+++ b/crates/gdsr/src/library.rs
@@ -10,7 +10,7 @@ use crate::types::LayerMapping;
 use crate::{Element, Instance};
 
 /// A dangling reference: a cell contains a reference to a target that doesn't exist.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DanglingCellReference {
     /// The cell containing the dangling reference.
     pub cell_name: String,
@@ -305,7 +305,7 @@ impl Library {
     /// Uses DFS with three-state coloring to detect back edges, which indicate
     /// circular references.
     pub fn has_circular_references(&self) -> bool {
-        #[derive(Clone, Copy, PartialEq)]
+        #[derive(Clone, Copy, PartialEq, Eq)]
         enum State {
             Unvisited,
             InProgress,
@@ -634,11 +634,10 @@ mod tests {
         cell.add(Reference::new(polygon));
         library.add_cell(cell);
 
-        let mapping: crate::LayerMapping = [(
+        let mapping: crate::LayerMapping = std::iter::once((
             (Layer::new(1), DataType::new(0)),
             (Layer::new(50), DataType::new(60)),
-        )]
-        .into_iter()
+        ))
         .collect();
 
         library.remap_layers(&mapping);
@@ -679,11 +678,10 @@ mod tests {
         ));
         library.add_cell(cell);
 
-        let mapping: crate::LayerMapping = [(
+        let mapping: crate::LayerMapping = std::iter::once((
             (Layer::new(99), DataType::new(99)),
             (Layer::new(1), DataType::new(1)),
-        )]
-        .into_iter()
+        ))
         .collect();
 
         library.remap_layers(&mapping);

--- a/crates/gdsr/src/property_tests/polygon.rs
+++ b/crates/gdsr/src/property_tests/polygon.rs
@@ -112,7 +112,7 @@ fn regular_polygon_vertices_equidistant_from_center(num_sides: usize) -> bool {
     polygon.points().iter().take(num_sides).all(|p| {
         let dx = p.x().float_value();
         let dy = p.y().float_value();
-        let dist = (dx * dx + dy * dy).sqrt();
+        let dist = dx.hypot(dy);
         (dist - radius).abs() < 1e-9
     })
 }

--- a/crates/gdsr/src/property_tests/unit.rs
+++ b/crates/gdsr/src/property_tests/unit.rs
@@ -90,10 +90,7 @@ fn addition_inverse_property(a: Unit) -> bool {
 /// Verifies exact integer addition when units are identical.
 #[quickcheck]
 fn addition_same_units_no_scaling_error_integer(a: IntegerUnit, b: IntegerUnit) -> bool {
-    let a_unit = Unit::Integer(IntegerUnit {
-        value: a.value,
-        units: a.units,
-    });
+    let a_unit = Unit::Integer(a);
     let b_unit = Unit::Integer(IntegerUnit {
         value: b.value,
         units: a.units,
@@ -107,10 +104,7 @@ fn addition_same_units_no_scaling_error_integer(a: IntegerUnit, b: IntegerUnit) 
 /// Verifies precise float addition when units are identical.
 #[quickcheck]
 fn addition_same_units_no_scaling_error_float(a: FloatUnit, b: FloatUnit) -> bool {
-    let a_unit = Unit::Float(FloatUnit {
-        value: a.value,
-        units: a.units,
-    });
+    let a_unit = Unit::Float(a);
     let b_unit = Unit::Float(FloatUnit {
         value: b.value,
         units: a.units,

--- a/crates/gdsr/src/property_tests/validation.rs
+++ b/crates/gdsr/src/property_tests/validation.rs
@@ -303,7 +303,7 @@ fn test_library_roundtrip_mixed_elements() {
         DataType::new(0),
     );
 
-    let reference = Reference::new(ref_polygon.clone()).with_grid(
+    let reference = Reference::new(ref_polygon).with_grid(
         Grid::default()
             .with_origin(Point::integer(0, 25, units))
             .with_columns(2)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.96.1"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+edition = "2024"
+style_edition = "2024"


### PR DESCRIPTION
## Summary

Adds Karva/Ruff-style repository standards to GDSR: agent guidance, contributing/style/security/conduct docs, pinned toolchain formatting config, Dependabot/actionlint config, stricter prek hooks, and tighter CI defaults. It also includes the small lint-driven cleanups needed for the expanded workspace lint profile to pass.

## Test Plan

`uvx prek run -a` and `cargo nextest run`