### PR TITLE
Stop Codecov uploads on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,9 @@ jobs:
 
     if: ${{ (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
 
+    permissions:
+      id-token: write
+
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
@@ -191,11 +194,12 @@ jobs:
         run: cargo llvm-cov nextest --lcov --output-path lcov.info
 
       - name: Upload coverage to Codecov
+        if: ${{ github.event_name != 'pull_request' }}
         uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
           slug: MatthewMckee4/gdsr
+          use_oidc: true
           use_pypi: true
           fail_ci_if_error: true
 


### PR DESCRIPTION
## Summary

This keeps the coverage job on pull requests, but skips the Codecov upload step there so forks and Dependabot are not blocked by unavailable upload credentials. Uploads still run outside pull_request using OIDC instead of the repository secret.

## Test Plan

uvx prek run -a