### PR TITLE
Add viewer element inspector

### DIFF
--- a/crates/gdsr-viewer/src/app.rs
+++ b/crates/gdsr-viewer/src/app.rs
@@ -34,6 +34,7 @@ pub struct ViewerApp {
     ruler: RulerState,
     show_grid: bool,
     hovered_element: Option<usize>,
+    selected_element: Option<usize>,
     /// Reusable scratch buffer for spatial grid point queries.
     query_buf: Vec<u32>,
     side_panel_tab: SidePanelTab,
@@ -58,6 +59,7 @@ impl Default for ViewerApp {
             ruler: RulerState::default(),
             show_grid: true,
             hovered_element: None,
+            selected_element: None,
             query_buf: Vec::new(),
             side_panel_tab: SidePanelTab::default(),
             cell_view_mode: CellViewMode::default(),
@@ -104,6 +106,8 @@ impl ViewerApp {
 
         let cell_state = CellState::new(library);
         self.cell = Some(cell_state);
+        self.hovered_element = None;
+        self.selected_element = None;
         self.file_load.file_path = Some(path);
         self.file_load.loading = false;
     }
@@ -117,6 +121,8 @@ impl ViewerApp {
             self.scroll_to_selected = true;
             cell.element_receiver = None;
             cell.elements.clear();
+            self.hovered_element = None;
+            self.selected_element = None;
             cell.layers.clear();
             cell.spatial_grid = None;
             cell.tessellation_cache.clear();
@@ -169,6 +175,25 @@ impl ViewerApp {
         self.file_load.loading = true;
         self.file_load.error_message = None;
     }
+}
+
+fn hit_test_element(
+    elements: &[gdsr::Element],
+    grid: &SpatialGrid,
+    query_buf: &mut Vec<u32>,
+    wx: f64,
+    wy: f64,
+    zoom: f64,
+) -> Option<usize> {
+    let candidates = grid.query_point(wx, wy, query_buf);
+    for &idx in candidates.iter().rev() {
+        if let Some(el) = elements.get(idx as usize) {
+            if el.hit_test(wx, wy, zoom) {
+                return Some(idx as usize);
+            }
+        }
+    }
+    None
 }
 
 impl eframe::App for ViewerApp {
@@ -226,6 +251,12 @@ impl eframe::App for ViewerApp {
 
             if cell.elements_loading {
                 ctx.request_repaint();
+            }
+            if self
+                .selected_element
+                .is_some_and(|idx| idx >= cell.elements.len())
+            {
+                self.selected_element = None;
             }
         }
 
@@ -489,6 +520,7 @@ impl eframe::App for ViewerApp {
         let active_tab = self.side_panel_tab;
         let view_mode = self.cell_view_mode;
         let scroll_to_selected = &mut self.scroll_to_selected;
+        let selected_element_idx = self.selected_element;
         egui::SidePanel::left("side_panel")
             .default_width(200.0)
             .width_range(40.0..=800.0)
@@ -496,6 +528,8 @@ impl eframe::App for ViewerApp {
             .show(ctx, |ui| {
                 ui.allocate_at_least(egui::vec2(ui.available_width(), 0.0), egui::Sense::hover());
                 if let Some(cell) = cell.as_mut() {
+                    let selected_element =
+                        selected_element_idx.and_then(|idx| cell.elements.get(idx));
                     panels::draw_side_panel(
                         ui,
                         active_tab,
@@ -509,6 +543,7 @@ impl eframe::App for ViewerApp {
                         scroll_to_selected,
                         &cell.layers,
                         layer_state,
+                        selected_element,
                     );
                 }
             });
@@ -533,6 +568,7 @@ impl eframe::App for ViewerApp {
         let show_grid = self.show_grid;
         let grid_spacing = self.grid_spacing;
         let hovered_element = &mut self.hovered_element;
+        let selected_element = &mut self.selected_element;
         let query_buf = &mut self.query_buf;
         let render_depth = cell.as_ref().map_or(1, |c| c.render_depth);
         let selected_cell_name: Option<String> =
@@ -551,7 +587,7 @@ impl eframe::App for ViewerApp {
                     (&[] as &[gdsr::Element], None, None, &mut empty_cache)
                 };
 
-            *mouse_world_pos = viewport.draw(
+            let interaction = viewport.draw(
                 ui,
                 elements,
                 layer_state,
@@ -563,28 +599,78 @@ impl eframe::App for ViewerApp {
                 show_grid,
                 grid_spacing,
                 *hovered_element,
+                *selected_element,
                 render_depth,
                 selected_cell_name.as_deref(),
             );
+            *mouse_world_pos = interaction.mouse_world;
 
             let prev_hovered = *hovered_element;
+            let prev_selected = *selected_element;
             *hovered_element = None;
             if let Some((wx, wy)) = *mouse_world_pos {
                 if let Some(grid) = spatial_grid {
-                    let candidates = grid.query_point(wx, wy, query_buf);
-                    for &idx in candidates.iter().rev() {
-                        if let Some(el) = elements.get(idx as usize) {
-                            if el.hit_test(wx, wy, viewport.zoom) {
-                                *hovered_element = Some(idx as usize);
-                                break;
-                            }
-                        }
-                    }
+                    *hovered_element =
+                        hit_test_element(elements, grid, query_buf, wx, wy, viewport.zoom);
                 }
             }
-            if *hovered_element != prev_hovered {
+            if interaction.clicked {
+                *selected_element = *hovered_element;
+            }
+            if *hovered_element != prev_hovered || *selected_element != prev_selected {
                 ctx.request_repaint();
             }
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gdsr::{DataType, Element, Layer, Point, Polygon};
+
+    fn p(x: f64, y: f64) -> Point {
+        Point::float(x, y, 1.0)
+    }
+
+    fn test_elements() -> Vec<Element> {
+        vec![
+            Polygon::new(
+                [p(0.0, 0.0), p(10.0, 0.0), p(10.0, 10.0), p(0.0, 10.0)],
+                Layer::new(1),
+                DataType::new(0),
+            )
+            .into(),
+        ]
+    }
+
+    #[test]
+    fn hit_test_element_returns_matching_index() {
+        let elements = test_elements();
+        let Some(bounds) = viewport::compute_bounds(&elements) else {
+            panic!("test elements should have bounds");
+        };
+        let grid = SpatialGrid::build(&elements, &bounds);
+        let mut query_buf = Vec::new();
+
+        assert_eq!(
+            hit_test_element(&elements, &grid, &mut query_buf, 5.0, 5.0, 1.0),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn hit_test_element_returns_none_for_miss() {
+        let elements = test_elements();
+        let Some(bounds) = viewport::compute_bounds(&elements) else {
+            panic!("test elements should have bounds");
+        };
+        let grid = SpatialGrid::build(&elements, &bounds);
+        let mut query_buf = Vec::new();
+
+        assert_eq!(
+            hit_test_element(&elements, &grid, &mut query_buf, 20.0, 20.0, 1.0),
+            None
+        );
     }
 }

--- a/crates/gdsr-viewer/src/panels.rs
+++ b/crates/gdsr-viewer/src/panels.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 
 use egui::{Color32, Pos2, Stroke, Ui};
-use gdsr::{CellStats, DataType, Layer};
+use gdsr::{CellStats, DataType, Element, Layer, Point};
 
 use crate::hierarchy::{CellTreeNode, ExpandState};
 use crate::state::{CellViewMode, LayerState, SidePanelTab};
@@ -24,7 +24,13 @@ pub fn draw_side_panel(
     scroll_to_selected: &mut bool,
     layers: &BTreeSet<(Layer, DataType)>,
     layer_state: &mut LayerState,
+    selected_element: Option<&Element>,
 ) {
+    if let Some(element) = selected_element {
+        draw_element_panel(ui, element);
+        ui.separator();
+    }
+
     match active_tab {
         SidePanelTab::Cells => {
             let tree = match view_mode {
@@ -44,6 +50,80 @@ pub fn draw_side_panel(
             draw_layer_panel(ui, layers, layer_state, color_changed);
         }
     }
+}
+
+fn draw_element_panel(ui: &mut Ui, element: &Element) {
+    egui::CollapsingHeader::new("Selected element")
+        .default_open(true)
+        .show(ui, |ui| match element {
+            Element::Path(path) => {
+                draw_layer_data(ui, "Path", path.layer(), path.data_type());
+                ui.label(format!("Vertices: {}", path.points().len()));
+                ui.label(format!(
+                    "Width: {}",
+                    path.width()
+                        .map_or_else(|| "Unset".to_string(), |width| width.to_string())
+                ));
+                draw_points(ui, path.points());
+            }
+            Element::Polygon(polygon) => {
+                draw_layer_data(ui, "Polygon", polygon.layer(), polygon.data_type());
+                ui.label(format!(
+                    "Vertices: {}",
+                    polygon.points().len().saturating_sub(1)
+                ));
+                draw_points(ui, polygon.points());
+            }
+            Element::Box(gds_box) => {
+                draw_layer_data(ui, "Box", gds_box.layer(), gds_box.box_type());
+                draw_points(ui, &gds_box.points());
+            }
+            Element::Node(node) => {
+                draw_layer_data(ui, "Node", node.layer(), node.node_type());
+                ui.label(format!("Points: {}", node.points().len()));
+                draw_points(ui, node.points());
+            }
+            Element::Text(text) => {
+                draw_layer_data(ui, "Text", text.layer(), text.data_type());
+                ui.label(format!("Value: {}", text.text()));
+                ui.label(format!("Origin: {}", format_point(text.origin())));
+            }
+            Element::Reference(reference) => {
+                ui.label("Type: Reference");
+                ui.label(format!(
+                    "Grid origin: {}",
+                    format_point(&reference.grid().origin())
+                ));
+            }
+        });
+}
+
+fn draw_layer_data(ui: &mut Ui, kind: &str, layer: Layer, data_type: DataType) {
+    ui.label(format!("Type: {kind}"));
+    ui.label(format!("Layer: {layer}"));
+    ui.label(format!("Datatype: {data_type}"));
+}
+
+fn draw_points(ui: &mut Ui, points: &[Point]) {
+    egui::ScrollArea::vertical()
+        .id_salt("selected_element_points")
+        .max_height(160.0)
+        .show(ui, |ui| {
+            egui::Grid::new("selected_element_points_grid")
+                .num_columns(2)
+                .striped(true)
+                .show(ui, |ui| {
+                    for (idx, point) in points.iter().enumerate() {
+                        ui.label(format!("#{idx}"));
+                        ui.monospace(format_point(point));
+                        ui.end_row();
+                    }
+                });
+        });
+}
+
+fn format_point(point: &Point) -> String {
+    format!("({}, {})", point.x(), point.y())
 }
 
 fn draw_cell_panel(

--- a/crates/gdsr-viewer/src/viewport/mod.rs
+++ b/crates/gdsr-viewer/src/viewport/mod.rs
@@ -21,6 +21,11 @@ pub struct Viewport {
     pub zoom: f64,
 }
 
+pub struct ViewportInteraction {
+    pub mouse_world: Option<(f64, f64)>,
+    pub clicked: bool,
+}
+
 impl Default for Viewport {
     fn default() -> Self {
         Self {
@@ -106,9 +111,10 @@ impl Viewport {
         show_grid: bool,
         grid_spacing: GridSpacing,
         hovered_element: Option<usize>,
+        selected_element: Option<usize>,
         render_depth: u32,
         selected_cell: Option<&str>,
-    ) -> Option<(f64, f64)> {
+    ) -> ViewportInteraction {
         let (response, painter) = ui.allocate_painter(ui.available_size(), Sense::click_and_drag());
         let rect = response.rect;
 
@@ -120,12 +126,14 @@ impl Viewport {
         }
 
         // Handle ruler clicks before drag so ruler gets priority when active.
-        if ruler.active && response.clicked() {
+        let ruler_was_active = ruler.active;
+        if ruler_was_active && response.clicked() {
             if let Some(pos) = response.interact_pointer_pos() {
                 let (wx, wy) = self.screen_to_world(pos.x, pos.y, rect);
                 ruler.handle_click(wx, wy);
             }
         }
+        let clicked = response.clicked() && !ruler_was_active;
 
         if response.dragged() {
             let delta = response.drag_delta();
@@ -204,24 +212,36 @@ impl Viewport {
                 s.transform(tsf);
                 painter.add(s);
             }
-            if let Some(idx) = hovered_element {
-                if let Some(el) = elements.get(idx) {
-                    draw_highlight(
-                        el,
-                        self,
-                        &painter,
-                        rect,
-                        layer_state,
-                        library,
-                        tessellation_cache,
-                    );
-                }
+            draw_element_highlight(
+                selected_element,
+                elements,
+                self,
+                &painter,
+                rect,
+                layer_state,
+                library,
+                tessellation_cache,
+            );
+            if hovered_element != selected_element {
+                draw_element_highlight(
+                    hovered_element,
+                    elements,
+                    self,
+                    &painter,
+                    rect,
+                    layer_state,
+                    library,
+                    tessellation_cache,
+                );
             }
             let mouse_world = response
                 .hover_pos()
                 .map(|pos| self.screen_to_world(pos.x, pos.y, rect));
             ruler.draw(&painter, self, rect, mouse_world);
-            return mouse_world;
+            return ViewportInteraction {
+                mouse_world,
+                clicked,
+            };
         }
 
         // Depth-0: draw just the selected cell's bounding box with its name.
@@ -267,7 +287,10 @@ impl Viewport {
                 .hover_pos()
                 .map(|pos| self.screen_to_world(pos.x, pos.y, rect));
             ruler.draw(&painter, self, rect, mouse_world);
-            return mouse_world;
+            return ViewportInteraction {
+                mouse_world,
+                clicked,
+            };
         }
 
         // Full render: query a 3× expanded region so the cache has margin for panning.
@@ -382,25 +405,60 @@ impl Viewport {
             render_depth,
         );
 
-        if let Some(idx) = hovered_element {
-            if let Some(el) = elements.get(idx) {
-                draw_highlight(
-                    el,
-                    self,
-                    &painter,
-                    rect,
-                    layer_state,
-                    library,
-                    tessellation_cache,
-                );
-            }
+        draw_element_highlight(
+            selected_element,
+            elements,
+            self,
+            &painter,
+            rect,
+            layer_state,
+            library,
+            tessellation_cache,
+        );
+        if hovered_element != selected_element {
+            draw_element_highlight(
+                hovered_element,
+                elements,
+                self,
+                &painter,
+                rect,
+                layer_state,
+                library,
+                tessellation_cache,
+            );
         }
 
         let mouse_world = response
             .hover_pos()
             .map(|pos| self.screen_to_world(pos.x, pos.y, rect));
         ruler.draw(&painter, self, rect, mouse_world);
-        mouse_world
+        ViewportInteraction {
+            mouse_world,
+            clicked,
+        }
+    }
+}
+
+fn draw_element_highlight(
+    idx: Option<usize>,
+    elements: &[Element],
+    viewport: &Viewport,
+    painter: &egui::Painter,
+    rect: Rect,
+    layer_state: &mut LayerState,
+    library: Option<&Library>,
+    tessellation_cache: &mut HashMap<u32, Vec<usize>>,
+) {
+    if let Some(el) = idx.and_then(|idx| elements.get(idx)) {
+        draw_highlight(
+            el,
+            viewport,
+            painter,
+            rect,
+            layer_state,
+            library,
+            tessellation_cache,
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

Adds viewport click selection for elements and shows the selected element properties in the existing side panel. The selection reuses the spatial grid hit-test path and clears when cells change.

Closes #144.

## Test Plan

uvx prek run -a and cargo nextest run.