### PR TITLE
Add selected element deletion

### DIFF
--- a/crates/gdsr-viewer/src/app.rs
+++ b/crates/gdsr-viewer/src/app.rs
@@ -178,6 +178,28 @@ impl ViewerApp {
         self.file_load.loading = true;
         self.file_load.error_message = None;
     }
+
+    fn delete_selected_element(&mut self) -> bool {
+        let Some(index) = self.selected_element else {
+            return false;
+        };
+        let Some(cell) = self.cell.as_mut() else {
+            self.selected_element = None;
+            return false;
+        };
+        if cell.elements_loading {
+            return false;
+        }
+        if !cell.delete_element(index) {
+            self.selected_element = None;
+            return false;
+        }
+
+        self.selected_element = None;
+        self.hovered_element = None;
+        self.render_cache.clear();
+        true
+    }
 }
 
 fn hit_test_element(
@@ -293,6 +315,15 @@ impl eframe::App for ViewerApp {
             && !self.recent_picker.is_open()
         {
             self.ruler.cancel();
+        }
+        let delete_pressed =
+            ctx.input(|i| i.key_pressed(egui::Key::Delete) || i.key_pressed(egui::Key::Backspace));
+        if delete_pressed
+            && !self.cell_picker.is_open()
+            && !self.recent_picker.is_open()
+            && self.delete_selected_element()
+        {
+            ctx.request_repaint();
         }
         if self.ruler.start.is_some() {
             ctx.request_repaint();
@@ -524,6 +555,7 @@ impl eframe::App for ViewerApp {
         let view_mode = self.cell_view_mode;
         let scroll_to_selected = &mut self.scroll_to_selected;
         let selected_element_idx = self.selected_element;
+        let mut delete_selected = false;
         egui::SidePanel::left("side_panel")
             .default_width(200.0)
             .width_range(40.0..=800.0)
@@ -533,7 +565,7 @@ impl eframe::App for ViewerApp {
                 if let Some(cell) = cell.as_mut() {
                     let selected_element =
                         selected_element_idx.and_then(|idx| cell.elements.get(idx));
-                    panels::draw_side_panel(
+                    delete_selected = panels::draw_side_panel(
                         ui,
                         active_tab,
                         &cell.cell_tree,
@@ -550,6 +582,10 @@ impl eframe::App for ViewerApp {
                     );
                 }
             });
+
+        if delete_selected && self.delete_selected_element() {
+            ctx.request_repaint();
+        }
 
         if cell_changed {
             if let Some(name) = self.cell.as_ref().and_then(|c| c.selected_cell.clone()) {
@@ -678,5 +714,43 @@ mod tests {
             hit_test_element(&elements, &grid, &mut query_buf, 20.0, 20.0, 1.0),
             None
         );
+    }
+
+    #[test]
+    fn delete_selected_element_removes_element_and_clears_selection() {
+        let mut app = ViewerApp::default();
+        let mut cell = CellState::new(gdsr::Library::new("test"));
+        cell.elements = test_elements();
+        let Some(bounds) = viewport::compute_bounds(&cell.elements) else {
+            panic!("test elements should have bounds");
+        };
+        cell.spatial_grid = Some(SpatialGrid::build(&cell.elements, &bounds));
+        app.cell = Some(cell);
+        app.selected_element = Some(0);
+        app.hovered_element = Some(0);
+
+        assert!(app.delete_selected_element());
+
+        let cell = app.cell.expect("cell should remain loaded");
+        assert!(cell.elements.is_empty());
+        assert!(cell.spatial_grid.is_none());
+        assert!(app.selected_element.is_none());
+        assert!(app.hovered_element.is_none());
+    }
+
+    #[test]
+    fn delete_selected_element_waits_for_streaming_to_finish() {
+        let mut app = ViewerApp::default();
+        let mut cell = CellState::new(gdsr::Library::new("test"));
+        cell.elements = test_elements();
+        cell.elements_loading = true;
+        app.cell = Some(cell);
+        app.selected_element = Some(0);
+
+        assert!(!app.delete_selected_element());
+
+        let cell = app.cell.expect("cell should remain loaded");
+        assert_eq!(cell.elements.len(), 1);
+        assert_eq!(app.selected_element, Some(0));
     }
 }

--- a/crates/gdsr-viewer/src/panels.rs
+++ b/crates/gdsr-viewer/src/panels.rs
@@ -25,9 +25,10 @@ pub fn draw_side_panel(
     layers: &BTreeSet<(Layer, DataType)>,
     layer_state: &mut LayerState,
     selected_element: Option<&Element>,
-) {
+) -> bool {
+    let mut delete_selected = false;
     if let Some(element) = selected_element {
-        draw_element_panel(ui, element);
+        delete_selected = draw_element_panel(ui, element);
         ui.separator();
     }
 
@@ -50,52 +51,63 @@ pub fn draw_side_panel(
             draw_layer_panel(ui, layers, layer_state, color_changed);
         }
     }
+
+    delete_selected
 }
 
-fn draw_element_panel(ui: &mut Ui, element: &Element) {
+fn draw_element_panel(ui: &mut Ui, element: &Element) -> bool {
+    let mut delete_selected = false;
     egui::CollapsingHeader::new("Selected element")
         .default_open(true)
-        .show(ui, |ui| match element {
-            Element::Path(path) => {
-                draw_layer_data(ui, "Path", path.layer(), path.data_type());
-                ui.label(format!("Vertices: {}", path.points().len()));
-                ui.label(format!(
-                    "Width: {}",
-                    path.width()
-                        .map_or_else(|| "Unset".to_string(), |width| width.to_string())
-                ));
-                draw_points(ui, path.points());
+        .show(ui, |ui| {
+            if ui.button("Delete").clicked() {
+                delete_selected = true;
             }
-            Element::Polygon(polygon) => {
-                draw_layer_data(ui, "Polygon", polygon.layer(), polygon.data_type());
-                ui.label(format!(
-                    "Vertices: {}",
-                    polygon.points().len().saturating_sub(1)
-                ));
-                draw_points(ui, polygon.points());
-            }
-            Element::Box(gds_box) => {
-                draw_layer_data(ui, "Box", gds_box.layer(), gds_box.box_type());
-                draw_points(ui, &gds_box.points());
-            }
-            Element::Node(node) => {
-                draw_layer_data(ui, "Node", node.layer(), node.node_type());
-                ui.label(format!("Points: {}", node.points().len()));
-                draw_points(ui, node.points());
-            }
-            Element::Text(text) => {
-                draw_layer_data(ui, "Text", text.layer(), text.data_type());
-                ui.label(format!("Value: {}", text.text()));
-                ui.label(format!("Origin: {}", format_point(text.origin())));
-            }
-            Element::Reference(reference) => {
-                ui.label("Type: Reference");
-                ui.label(format!(
-                    "Grid origin: {}",
-                    format_point(&reference.grid().origin())
-                ));
+            ui.separator();
+
+            match element {
+                Element::Path(path) => {
+                    draw_layer_data(ui, "Path", path.layer(), path.data_type());
+                    ui.label(format!("Vertices: {}", path.points().len()));
+                    ui.label(format!(
+                        "Width: {}",
+                        path.width()
+                            .map_or_else(|| "Unset".to_string(), |width| width.to_string())
+                    ));
+                    draw_points(ui, path.points());
+                }
+                Element::Polygon(polygon) => {
+                    draw_layer_data(ui, "Polygon", polygon.layer(), polygon.data_type());
+                    ui.label(format!(
+                        "Vertices: {}",
+                        polygon.points().len().saturating_sub(1)
+                    ));
+                    draw_points(ui, polygon.points());
+                }
+                Element::Box(gds_box) => {
+                    draw_layer_data(ui, "Box", gds_box.layer(), gds_box.box_type());
+                    draw_points(ui, &gds_box.points());
+                }
+                Element::Node(node) => {
+                    draw_layer_data(ui, "Node", node.layer(), node.node_type());
+                    ui.label(format!("Points: {}", node.points().len()));
+                    draw_points(ui, node.points());
+                }
+                Element::Text(text) => {
+                    draw_layer_data(ui, "Text", text.layer(), text.data_type());
+                    ui.label(format!("Value: {}", text.text()));
+                    ui.label(format!("Origin: {}", format_point(text.origin())));
+                }
+                Element::Reference(reference) => {
+                    ui.label("Type: Reference");
+                    ui.label(format!(
+                        "Grid origin: {}",
+                        format_point(&reference.grid().origin())
+                    ));
+                }
             }
         });
+    delete_selected
 }
 
 fn draw_layer_data(ui: &mut Ui, kind: &str, layer: Layer, data_type: DataType) {

--- a/crates/gdsr-viewer/src/state.rs
+++ b/crates/gdsr-viewer/src/state.rs
@@ -7,8 +7,10 @@ use emath::{TSTransform, Vec2};
 use gdsr::{CellStats, DataType, Element, Layer, Library};
 
 use crate::colors::LayerColorMap;
+use crate::drawable::Drawable;
 use crate::hierarchy::{self, CellTreeNode, ExpandState};
 use crate::spatial::SpatialGrid;
+use crate::viewport;
 
 /// Tracks an in-flight file-open operation.
 #[derive(Default)]
@@ -60,6 +62,27 @@ impl CellState {
             cell_stats: None,
             render_depth: 1,
         }
+    }
+
+    pub fn delete_element(&mut self, index: usize) -> bool {
+        if index >= self.elements.len() {
+            return false;
+        }
+
+        self.elements.remove(index);
+        self.rebuild_render_indexes();
+        self.cell_stats = None;
+        true
+    }
+
+    fn rebuild_render_indexes(&mut self) {
+        self.layers.clear();
+        for element in &self.elements {
+            self.layers.extend(element.layer_keys());
+        }
+        self.spatial_grid = viewport::compute_bounds(&self.elements)
+            .map(|bounds| SpatialGrid::build(&self.elements, &bounds));
+        self.tessellation_cache.clear();
     }
 }
 
@@ -201,6 +224,9 @@ impl RenderCache {
 mod tests {
     use super::*;
     use egui::Rect;
+    use gdsr::Library;
+
+    use crate::testutil::helpers::polygon;
 
     fn test_rect() -> Rect {
         Rect::from_min_size(Pos2::ZERO, egui::Vec2::new(800.0, 600.0))
@@ -220,6 +246,43 @@ mod tests {
             1,
         );
         cache
+    }
+
+    #[test]
+    fn delete_element_rebuilds_render_indexes() {
+        let mut cell = CellState::new(Library::new("test"));
+        cell.elements = vec![
+            polygon(vec![(0, 0), (100, 0), (100, 100)], 1, 0),
+            polygon(vec![(1000, 1000), (1100, 1000), (1100, 1100)], 2, 0),
+        ];
+        cell.tessellation_cache.insert(0, vec![0, 1, 2]);
+        cell.rebuild_render_indexes();
+
+        assert!(cell.delete_element(0));
+
+        assert_eq!(cell.elements.len(), 1);
+        assert_eq!(
+            cell.layers,
+            BTreeSet::from([(Layer::new(2), DataType::new(0))])
+        );
+        assert!(cell.spatial_grid.is_some());
+        assert!(cell.tessellation_cache.is_empty());
+    }
+
+    #[test]
+    fn delete_element_rejects_missing_index() {
+        let mut cell = CellState::new(Library::new("test"));
+        cell.elements = vec![polygon(vec![(0, 0), (100, 0), (100, 100)], 1, 0)];
+        cell.rebuild_render_indexes();
+
+        assert!(!cell.delete_element(1));
+
+        assert_eq!(cell.elements.len(), 1);
+        assert_eq!(
+            cell.layers,
+            BTreeSet::from([(Layer::new(1), DataType::new(0))])
+        );
+        assert!(cell.spatial_grid.is_some());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds selected-element deletion in the viewer through Delete/Backspace and a Delete button in the selected element panel. Deletion updates the loaded element list, clears hover/selection, rebuilds layer and spatial indexes, clears tessellation/render caches, and leaves file persistence to the separate save/export work.

Closes #152.

## Test Plan

cargo nextest run -p gdsr-viewer; cargo clippy --workspace --all-targets --all-features -- -D warnings; cargo nextest run; uvx prek run -a.