### PR TITLE
Render viewer hierarchy with reference LOD

### DIFF
--- a/crates/gdsr-viewer/src/app.rs
+++ b/crates/gdsr-viewer/src/app.rs
@@ -1,6 +1,5 @@
 use std::path::{Path, PathBuf};
 use std::sync::mpsc;
-use std::thread;
 
 use crate::drawable::{Drawable, cell_world_bbox};
 use crate::panels;
@@ -12,9 +11,7 @@ use crate::state::{
     CellState, CellViewMode, DisplayUnit, FileLoadState, GridSpacing, LayerState, RenderCache,
     SidePanelTab,
 };
-use crate::viewport::{self, Viewport};
-
-const MAX_STREAMED_ELEMENTS_PER_FRAME: usize = 20_000;
+use crate::viewport::Viewport;
 
 /// Returns shortcut text with the platform-appropriate modifier (⌘ on macOS, Ctrl on others).
 fn shortcut_text(key: &str) -> String {
@@ -117,54 +114,30 @@ impl ViewerApp {
         self.file_load.loading = false;
     }
 
-    /// Switches to a new cell, cancelling any in-flight element streaming and starting
-    /// a new streaming thread for the selected cell's elements.
+    /// Switches to a new cell, keeping hierarchy intact for draw-time expansion.
     fn select_cell(&mut self, name: &str) {
         if let Some(cell) = self.cell.as_mut() {
             cell.selected_cell = Some(name.to_string());
             cell.expand_state.set_expanded(name, true);
             self.scroll_to_selected = true;
-            cell.element_receiver = None;
-            cell.elements.clear();
             self.hovered_element = None;
             self.selected_element = None;
-            cell.layers.clear();
-            cell.spatial_grid = None;
-            cell.tessellation_cache.clear();
-            cell.cell_stats = cell.library.get_cell(name).map(gdsr::CellStats::from_cell);
-
-            let depth = cell.render_depth;
-            if depth == 0 {
-                cell.elements_loading = false;
-                return;
-            }
-
-            if let Some(cell_data) = cell.library.get_cell(name) {
-                let cell_data = cell_data.clone();
-                let library = cell.library.clone();
-                let (tx, rx) = mpsc::channel();
-                let stream_depth = Some((depth - 1) as usize);
-
-                thread::spawn(move || {
-                    cell_data.stream_elements(stream_depth, &library, &tx);
-                });
-
-                cell.element_receiver = Some(rx);
-                cell.elements_loading = true;
+            if cell.load_direct_cell_elements(name) {
+                for &(layer, data_type) in &cell.layers {
+                    self.layer_state.layer_colors.get(layer, data_type);
+                }
             }
         }
+        self.render_cache.clear();
     }
 
     /// Adjusts the viewport to fit all currently loaded elements.
     fn zoom_to_fit(&mut self) {
         if let Some(cell) = self.cell.as_ref() {
-            let bounds = if cell.render_depth == 0 {
-                cell.selected_cell
-                    .as_ref()
-                    .and_then(|name| cell_world_bbox(name, &cell.library))
-            } else {
-                viewport::compute_bounds(&cell.elements)
-            };
+            let bounds = cell
+                .selected_cell
+                .as_ref()
+                .and_then(|name| cell_world_bbox(name, &cell.library));
             if let Some(bounds) = bounds {
                 let rect =
                     egui::Rect::from_min_size(egui::Pos2::ZERO, egui::Vec2::new(800.0, 600.0));
@@ -189,9 +162,6 @@ impl ViewerApp {
             self.selected_element = None;
             return false;
         };
-        if cell.elements_loading {
-            return false;
-        }
         if !cell.delete_element(index) {
             self.selected_element = None;
             return false;
@@ -223,14 +193,6 @@ fn hit_test_element(
     None
 }
 
-fn should_render_elements(elements_loading: bool, has_spatial_grid: bool) -> bool {
-    !elements_loading || has_spatial_grid
-}
-
-fn should_continue_streaming_drain(received_this_frame: usize) -> bool {
-    received_this_frame < MAX_STREAMED_ELEMENTS_PER_FRAME
-}
-
 impl eframe::App for ViewerApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         // Poll background loader
@@ -255,53 +217,13 @@ impl eframe::App for ViewerApp {
             }
         }
 
-        // Drain element streaming channel
-        let mut streaming_finished = false;
         if let Some(cell) = self.cell.as_mut() {
-            if let Some(rx) = &cell.element_receiver {
-                let mut received_this_frame = 0;
-                loop {
-                    if !should_continue_streaming_drain(received_this_frame) {
-                        break;
-                    }
-                    match rx.try_recv() {
-                        Ok(element) => {
-                            received_this_frame += 1;
-                            for key in element.layer_keys() {
-                                if cell.layers.insert(key) {
-                                    self.layer_state.layer_colors.get(key.0, key.1);
-                                }
-                            }
-                            cell.elements.push(element);
-                        }
-                        Err(mpsc::TryRecvError::Empty) => break,
-                        Err(mpsc::TryRecvError::Disconnected) => {
-                            cell.elements_loading = false;
-                            cell.element_receiver = None;
-                            if let Some(bounds) = viewport::compute_bounds(&cell.elements) {
-                                cell.spatial_grid =
-                                    Some(SpatialGrid::build(&cell.elements, &bounds));
-                            }
-                            streaming_finished = true;
-                            break;
-                        }
-                    }
-                }
-            }
-
-            if cell.elements_loading {
-                ctx.request_repaint();
-            }
             if self
                 .selected_element
                 .is_some_and(|idx| idx >= cell.elements.len())
             {
                 self.selected_element = None;
             }
-        }
-
-        if streaming_finished {
-            self.zoom_to_fit();
         }
 
         // Global keyboard shortcuts
@@ -473,11 +395,6 @@ impl eframe::App for ViewerApp {
 
                 if self.file_load.loading {
                     ui.label("Loading...");
-                } else if self.cell.as_ref().is_some_and(|c| c.elements_loading) {
-                    ui.label(format!(
-                        "Expanding elements... ({})",
-                        self.cell.as_ref().map_or(0, |c| c.elements.len())
-                    ));
                 } else if let Some(err) = &self.file_load.error_message {
                     ui.colored_label(egui::Color32::RED, format!("Error: {err}"));
                 } else if let Some(path) = &self.file_load.file_path {
@@ -626,29 +543,15 @@ impl eframe::App for ViewerApp {
         let query_buf = &mut self.query_buf;
         let drawn_element_marks = &mut self.drawn_element_marks;
         let render_depth = cell.as_ref().map_or(1, |c| c.render_depth);
-        let render_elements = cell
-            .as_ref()
-            .is_none_or(|c| should_render_elements(c.elements_loading, c.spatial_grid.is_some()));
-        let viewport_render_depth = if render_elements { render_depth } else { 0 };
         let selected_cell_name: Option<String> =
             cell.as_ref().and_then(|c| c.selected_cell.clone());
         egui::CentralPanel::default().show(ctx, |ui| {
             let mut empty_cache = std::collections::HashMap::new();
             let (elements, spatial_grid, library, tessellation_cache) =
                 if let Some(cell) = cell.as_mut() {
-                    let elements = if render_elements {
-                        cell.elements.as_slice()
-                    } else {
-                        &[] as &[gdsr::Element]
-                    };
-                    let spatial_grid = if render_elements {
-                        cell.spatial_grid.as_ref()
-                    } else {
-                        None
-                    };
                     (
-                        elements,
-                        spatial_grid,
+                        cell.elements.as_slice(),
+                        cell.spatial_grid.as_ref(),
                         Some(&cell.library),
                         &mut cell.tessellation_cache,
                     )
@@ -671,7 +574,7 @@ impl eframe::App for ViewerApp {
                 grid_spacing,
                 *hovered_element,
                 *selected_element,
-                viewport_render_depth,
+                render_depth,
                 selected_cell_name.as_deref(),
             );
             *mouse_world_pos = interaction.mouse_world;
@@ -698,7 +601,7 @@ impl eframe::App for ViewerApp {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use gdsr::{DataType, Element, Layer, Point, Polygon};
+    use gdsr::{Cell, DataType, Element, Layer, Library, Point, Polygon, Reference};
 
     fn p(x: f64, y: f64) -> Point {
         Point::float(x, y, 1.0)
@@ -716,30 +619,9 @@ mod tests {
     }
 
     #[test]
-    fn suppress_element_rendering_until_streaming_grid_exists() {
-        assert!(!should_render_elements(true, false));
-    }
-
-    #[test]
-    fn render_elements_when_grid_exists_or_streaming_finished() {
-        assert!(should_render_elements(true, true));
-        assert!(should_render_elements(false, false));
-    }
-
-    #[test]
-    fn stop_streaming_drain_at_frame_budget() {
-        assert!(should_continue_streaming_drain(
-            MAX_STREAMED_ELEMENTS_PER_FRAME - 1
-        ));
-        assert!(!should_continue_streaming_drain(
-            MAX_STREAMED_ELEMENTS_PER_FRAME
-        ));
-    }
-
-    #[test]
     fn hit_test_element_returns_matching_index() {
         let elements = test_elements();
-        let Some(bounds) = viewport::compute_bounds(&elements) else {
+        let Some(bounds) = crate::viewport::compute_bounds(&elements) else {
             panic!("test elements should have bounds");
         };
         let grid = SpatialGrid::build(&elements, &bounds);
@@ -754,7 +636,7 @@ mod tests {
     #[test]
     fn hit_test_element_returns_none_for_miss() {
         let elements = test_elements();
-        let Some(bounds) = viewport::compute_bounds(&elements) else {
+        let Some(bounds) = crate::viewport::compute_bounds(&elements) else {
             panic!("test elements should have bounds");
         };
         let grid = SpatialGrid::build(&elements, &bounds);
@@ -768,16 +650,18 @@ mod tests {
 
     #[test]
     fn delete_selected_element_removes_element_and_clears_selection() {
-        let mut app = ViewerApp::default();
         let mut cell = CellState::new(gdsr::Library::new("test"));
         cell.elements = test_elements();
-        let Some(bounds) = viewport::compute_bounds(&cell.elements) else {
+        let Some(bounds) = crate::viewport::compute_bounds(&cell.elements) else {
             panic!("test elements should have bounds");
         };
         cell.spatial_grid = Some(SpatialGrid::build(&cell.elements, &bounds));
-        app.cell = Some(cell);
-        app.selected_element = Some(0);
-        app.hovered_element = Some(0);
+        let mut app = ViewerApp {
+            cell: Some(cell),
+            selected_element: Some(0),
+            hovered_element: Some(0),
+            ..Default::default()
+        };
 
         assert!(app.delete_selected_element());
 
@@ -789,18 +673,32 @@ mod tests {
     }
 
     #[test]
-    fn delete_selected_element_waits_for_streaming_to_finish() {
-        let mut app = ViewerApp::default();
-        let mut cell = CellState::new(gdsr::Library::new("test"));
-        cell.elements = test_elements();
-        cell.elements_loading = true;
-        app.cell = Some(cell);
-        app.selected_element = Some(0);
+    fn select_cell_loads_direct_elements_without_flattening_references() {
+        let mut leaf = Cell::new("leaf");
+        leaf.add(test_elements().remove(0));
 
-        assert!(!app.delete_selected_element());
+        let mut top = Cell::new("top");
+        top.add(Reference::new("leaf"));
 
-        let cell = app.cell.expect("cell should remain loaded");
+        let mut library = Library::new("test");
+        library.add_cell(leaf);
+        library.add_cell(top);
+
+        let mut cell_state = CellState::new(library);
+        cell_state.render_depth = 8;
+        let mut app = ViewerApp {
+            cell: Some(cell_state),
+            ..Default::default()
+        };
+
+        app.select_cell("top");
+
+        let cell = app.cell.expect("cell should be loaded");
         assert_eq!(cell.elements.len(), 1);
-        assert_eq!(app.selected_element, Some(0));
+        assert!(matches!(cell.elements[0], Element::Reference(_)));
+        assert_eq!(
+            cell.layers,
+            std::collections::BTreeSet::from([(Layer::new(1), DataType::new(0))])
+        );
     }
 }

--- a/crates/gdsr-viewer/src/drawable.rs
+++ b/crates/gdsr-viewer/src/drawable.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use egui::epaint;
 use egui::{Color32, FontId, Mesh, Pos2, Rect, Shape, Stroke, StrokeKind};
-use gdsr::{DataType, Dimensions, Element, Layer, Library};
+use gdsr::{DataType, Dimensions, Element, Layer, Library, Point};
 
 use crate::state::LayerState;
 use crate::viewport::Viewport;
@@ -45,27 +45,37 @@ impl WorldBBox {
 
 pub fn cell_world_bbox(cell_name: &str, library: &Library) -> Option<WorldBBox> {
     let mut visiting = HashSet::new();
-    named_cell_world_bbox(cell_name, library, &mut visiting)
+    let mut cache = HashMap::new();
+    named_cell_world_bbox(cell_name, library, &mut visiting, &mut cache)
 }
 
 fn named_cell_world_bbox(
     cell_name: &str,
     library: &Library,
     visiting: &mut HashSet<String>,
+    cache: &mut HashMap<String, Option<WorldBBox>>,
 ) -> Option<WorldBBox> {
+    if let Some(bbox) = cache.get(cell_name) {
+        return *bbox;
+    }
     if !visiting.insert(cell_name.to_owned()) {
         return None;
     }
 
-    let cell = library.get_cell(cell_name)?;
+    let Some(cell) = library.get_cell(cell_name) else {
+        visiting.remove(cell_name);
+        cache.insert(cell_name.to_owned(), None);
+        return None;
+    };
     let mut result = None;
     for element in cell.iter_elements() {
-        if let Some(bbox) = element_world_bbox(element, library, visiting) {
+        if let Some(bbox) = element_world_bbox(element, library, visiting, cache) {
             merge_bbox(&mut result, bbox);
         }
     }
 
     visiting.remove(cell_name);
+    cache.insert(cell_name.to_owned(), result);
     result
 }
 
@@ -73,9 +83,10 @@ fn element_world_bbox(
     element: &Element,
     library: &Library,
     visiting: &mut HashSet<String>,
+    cache: &mut HashMap<String, Option<WorldBBox>>,
 ) -> Option<WorldBBox> {
     match element {
-        Element::Reference(reference) => reference_world_bbox(reference, library, visiting),
+        Element::Reference(reference) => reference_world_bbox(reference, library, visiting, cache),
         _ => element.world_bbox(),
     }
 }
@@ -84,22 +95,88 @@ fn reference_world_bbox(
     reference: &gdsr::Reference,
     library: &Library,
     visiting: &mut HashSet<String>,
+    cache: &mut HashMap<String, Option<WorldBBox>>,
 ) -> Option<WorldBBox> {
     let source_bbox = if let Some(cell_name) = reference.instance().as_cell() {
-        named_cell_world_bbox(cell_name, library, visiting)?
+        named_cell_world_bbox(cell_name, library, visiting, cache)?
     } else {
         let element = reference.instance().as_element()?;
-        element_world_bbox(element.as_ref().as_ref(), library, visiting)?
+        element_world_bbox(element.as_ref().as_ref(), library, visiting, cache)?
     };
 
-    let bbox_element = Element::Polygon(bbox_polygon(source_bbox));
+    reference_bbox_from_source_bbox(reference, source_bbox)
+}
+
+fn reference_bbox_from_source_bbox(
+    reference: &gdsr::Reference,
+    source_bbox: WorldBBox,
+) -> Option<WorldBBox> {
+    let grid = reference.grid();
+    if grid.columns() == 0 || grid.rows() == 0 {
+        return None;
+    }
+
     let mut result = None;
-    for element in reference.get_elements_in_grid(&bbox_element) {
-        if let Some(bbox) = element.world_bbox() {
-            merge_bbox(&mut result, bbox);
+    let bbox_element = Element::Polygon(bbox_polygon(source_bbox));
+    let spacing_x = grid.spacing_x().unwrap_or_default();
+    let spacing_y = grid.spacing_y().unwrap_or_default();
+
+    for column_index in [0, grid.columns() - 1] {
+        for row_index in [0, grid.rows() - 1] {
+            let offset = (spacing_x * column_index) + (spacing_y * row_index);
+            let rotated_offset = offset.rotate_around_point(grid.angle(), &Point::default());
+            let final_position = grid.origin() + rotated_offset;
+            let single_grid = grid
+                .clone()
+                .with_columns(1)
+                .with_rows(1)
+                .with_spacing_x(None)
+                .with_spacing_y(None)
+                .with_origin(final_position);
+            let single_reference = reference.clone().with_grid(single_grid);
+
+            for element in single_reference.get_elements_in_grid(&bbox_element) {
+                if let Some(bbox) = element.world_bbox() {
+                    merge_bbox(&mut result, bbox);
+                }
+            }
         }
     }
+
     result
+}
+
+fn reference_grid_count(reference: &gdsr::Reference) -> u64 {
+    let grid = reference.grid();
+    u64::from(grid.columns()) * u64::from(grid.rows())
+}
+
+fn reference_screen_size(bbox: WorldBBox, ctx: &DrawContext) -> (f32, f32, Rect) {
+    let s_min = ctx
+        .viewport
+        .world_to_screen(bbox.min_x, bbox.min_y, ctx.rect);
+    let s_max = ctx
+        .viewport
+        .world_to_screen(bbox.max_x, bbox.max_y, ctx.rect);
+    let sw = (s_max.x - s_min.x).abs();
+    let sh = (s_min.y - s_max.y).abs();
+    (sw, sh, Rect::from_two_pos(s_min, s_max))
+}
+
+fn reference_instance_bbox(
+    reference: &gdsr::Reference,
+    ctx: &mut DrawContext,
+) -> Option<WorldBBox> {
+    if reference.instance().as_cell().is_some() {
+        let lib = ctx.library?;
+        let mut visiting = HashSet::new();
+        reference_world_bbox(reference, lib, &mut visiting, ctx.cell_bbox_cache)
+    } else if let Some(element) = reference.instance().as_element() {
+        let source_bbox = element.as_ref().as_ref().world_bbox()?;
+        reference_bbox_from_source_bbox(reference, source_bbox)
+    } else {
+        None
+    }
 }
 
 fn bbox_polygon(bbox: WorldBBox) -> gdsr::Polygon {
@@ -146,6 +223,9 @@ pub struct DrawContext<'a> {
     /// When true, un-flattened cell references draw as outlined bounding boxes
     /// with the cell name centered, instead of expanding their contents.
     pub show_ref_bbox: bool,
+    pub reference_depth: u32,
+    pub reference_stack: Vec<String>,
+    pub cell_bbox_cache: &'a mut HashMap<String, Option<WorldBBox>>,
 }
 
 /// Fill alpha for normal and highlighted elements.
@@ -154,6 +234,10 @@ const HIGHLIGHT_FILL_ALPHA: u8 = 160;
 /// Stroke width for normal and highlighted outlines.
 const STROKE_WIDTH: f32 = 1.0;
 const HIGHLIGHT_STROKE_WIDTH: f32 = 3.0;
+const REF_LOAD_THRESHOLD_PX: f32 = 24.0;
+const REF_DENSE_GRID_MIN_INSTANCES: u64 = 128;
+const REF_LOAD_MIN_AVG_INSTANCE_AREA_PX: f32 = 16.0;
+const REF_MAX_GRID_EXPANSION: u64 = 8_192;
 
 impl DrawContext<'_> {
     /// Returns the fill and stroke colors for the given layer, brightened when highlighted.
@@ -909,44 +993,57 @@ impl Drawable for gdsr::Node {
     }
 }
 
-/// Draws an un-flattened reference as an outlined bounding box with a centered cell name label.
-fn draw_ref_as_bbox(reference: &gdsr::Reference, ctx: &mut DrawContext) {
-    let (label, bbox) = if let Some(cell_name) = reference.instance().as_cell() {
-        let Some(lib) = ctx.library else { return };
-        let mut visiting = HashSet::new();
-        match reference_world_bbox(reference, lib, &mut visiting) {
-            Some(bbox) => (Some(cell_name.as_str()), bbox),
-            None => return,
-        }
-    } else if let Some(element) = reference.instance().as_element() {
-        let mut merged: Option<WorldBBox> = None;
-        for el in reference.get_elements_in_grid(element) {
-            if let Some(bb) = el.world_bbox() {
-                merged = Some(match merged {
-                    Some(acc) => acc.merge(&bb),
-                    None => bb,
-                });
-            }
-        }
-        match merged {
-            Some(bb) => (None, bb),
-            None => return,
-        }
-    } else {
-        return;
-    };
+fn should_draw_reference_bbox(
+    reference: &gdsr::Reference,
+    bbox: WorldBBox,
+    ctx: &DrawContext,
+) -> bool {
+    let (sw, sh, _) = reference_screen_size(bbox, ctx);
+    should_collapse_reference(
+        sw,
+        sh,
+        reference_grid_count(reference),
+        ctx.reference_depth,
+        ctx.show_ref_bbox,
+    )
+}
 
+fn should_collapse_reference(
+    width_px: f32,
+    height_px: f32,
+    instance_count: u64,
+    reference_depth: u32,
+    force_bbox: bool,
+) -> bool {
+    if force_bbox || reference_depth <= 1 {
+        return true;
+    }
+
+    if width_px < REF_LOAD_THRESHOLD_PX && height_px < REF_LOAD_THRESHOLD_PX {
+        return true;
+    }
+
+    if instance_count > REF_MAX_GRID_EXPANSION {
+        return true;
+    }
+    if instance_count < REF_DENSE_GRID_MIN_INSTANCES {
+        return false;
+    }
+
+    let area_px = width_px * height_px;
+    area_px.is_finite() && area_px / instance_count as f32 <= REF_LOAD_MIN_AVG_INSTANCE_AREA_PX
+}
+
+fn draw_ref_bbox(reference: &gdsr::Reference, bbox: WorldBBox, ctx: &mut DrawContext) {
     if !bbox.overlaps(ctx.visible) {
         return;
     }
 
-    let s_min = ctx
-        .viewport
-        .world_to_screen(bbox.min_x, bbox.min_y, ctx.rect);
-    let s_max = ctx
-        .viewport
-        .world_to_screen(bbox.max_x, bbox.max_y, ctx.rect);
-    let screen_rect = Rect::from_two_pos(s_min, s_max);
+    let (sw, sh, screen_rect) = reference_screen_size(bbox, ctx);
+    if sw < 1.0 && sh < 1.0 {
+        return;
+    }
+
     let stroke_color = Color32::from_rgb(180, 180, 180);
     ctx.rect_stroke(
         screen_rect,
@@ -955,9 +1052,7 @@ fn draw_ref_as_bbox(reference: &gdsr::Reference, ctx: &mut DrawContext) {
         StrokeKind::Outside,
     );
 
-    if let Some(name) = label {
-        let sw = (s_max.x - s_min.x).abs();
-        let sh = (s_min.y - s_max.y).abs();
+    if let Some(name) = reference.instance().as_cell() {
         if sw >= 40.0 && sh >= 20.0 {
             let char_count = name.len().max(1) as f32;
             let fit_w = sw * 0.9 / (char_count * 0.6);
@@ -987,16 +1082,7 @@ impl Drawable for gdsr::Reference {
 
     fn world_bbox(&self) -> Option<WorldBBox> {
         let element = self.instance().as_element()?;
-        let mut result: Option<WorldBBox> = None;
-        for el in self.get_elements_in_grid(element) {
-            if let Some(bbox) = el.world_bbox() {
-                result = Some(match result {
-                    Some(acc) => acc.merge(&bbox),
-                    None => bbox,
-                });
-            }
-        }
-        result
+        reference_bbox_from_source_bbox(self, element.as_ref().as_ref().world_bbox()?)
     }
 
     fn hit_test(&self, wx: f64, wy: f64, zoom: f64) -> bool {
@@ -1011,15 +1097,31 @@ impl Drawable for gdsr::Reference {
     }
 
     fn draw(&self, ctx: &mut DrawContext) {
-        if ctx.show_ref_bbox {
-            draw_ref_as_bbox(self, ctx);
+        let Some(bbox) = reference_instance_bbox(self, ctx) else {
+            return;
+        };
+        if !bbox.overlaps(ctx.visible) {
             return;
         }
+        if should_draw_reference_bbox(self, bbox, ctx) {
+            draw_ref_bbox(self, bbox, ctx);
+            return;
+        }
+
+        let previous_depth = ctx.reference_depth;
+        ctx.reference_depth = ctx.reference_depth.saturating_sub(1);
+
         if let Some(element) = self.instance().as_element() {
             for el in self.get_elements_in_grid(element) {
                 el.draw(ctx);
             }
         } else if let Some(cell_name) = self.instance().as_cell() {
+            if ctx.reference_stack.iter().any(|name| name == cell_name) {
+                draw_ref_bbox(self, bbox, ctx);
+                ctx.reference_depth = previous_depth;
+                return;
+            }
+            ctx.reference_stack.push(cell_name.clone());
             if let Some(lib) = ctx.library {
                 if let Some(cell) = lib.get_cell(cell_name) {
                     for element in cell.iter_elements() {
@@ -1029,7 +1131,10 @@ impl Drawable for gdsr::Reference {
                     }
                 }
             }
+            ctx.reference_stack.pop();
         }
+
+        ctx.reference_depth = previous_depth;
     }
 }
 
@@ -1094,6 +1199,7 @@ pub fn draw_highlight(
     let mut layer_meshes = HashMap::new();
     let mut extra_shapes = Vec::new();
     let mut screen_pts_buf = Vec::new();
+    let mut cell_bbox_cache = HashMap::new();
     let mut ctx = DrawContext {
         painter,
         layer_meshes: &mut layer_meshes,
@@ -1108,6 +1214,9 @@ pub fn draw_highlight(
         screen_pts_buf: &mut screen_pts_buf,
         highlight: true,
         show_ref_bbox: false,
+        reference_depth: u32::MAX,
+        reference_stack: Vec::new(),
+        cell_bbox_cache: &mut cell_bbox_cache,
     };
     element.draw(&mut ctx);
     for (_, mesh) in layer_meshes {
@@ -1314,6 +1423,37 @@ mod tests {
     fn reference_empty_world_bbox() {
         let r = gdsr::Reference::default();
         assert!(r.world_bbox().is_none());
+    }
+
+    #[test]
+    fn reference_load_collapses_at_depth_limit() {
+        assert!(should_collapse_reference(400.0, 400.0, 1, 1, false));
+    }
+
+    #[test]
+    fn reference_load_collapses_tiny_references() {
+        assert!(should_collapse_reference(12.0, 20.0, 1, 2, false));
+    }
+
+    #[test]
+    fn reference_load_collapses_huge_grids() {
+        assert!(should_collapse_reference(
+            10_000.0,
+            10_000.0,
+            REF_MAX_GRID_EXPANSION + 1,
+            2,
+            false,
+        ));
+    }
+
+    #[test]
+    fn reference_load_draws_sparse_large_references() {
+        assert!(!should_collapse_reference(400.0, 400.0, 100, 2, false));
+    }
+
+    #[test]
+    fn reference_load_collapses_dense_screen_area() {
+        assert!(should_collapse_reference(400.0, 200.0, 10_000, 2, false));
     }
 
     #[test]

--- a/crates/gdsr-viewer/src/state.rs
+++ b/crates/gdsr-viewer/src/state.rs
@@ -21,7 +21,7 @@ pub struct FileLoadState {
     pub error_message: Option<String>,
 }
 
-/// Holds the loaded library, selected cell, and its streamed elements.
+/// Holds the loaded library, selected cell, and render indexes.
 pub struct CellState {
     pub library: Library,
     pub cell_names: Vec<String>,
@@ -30,8 +30,6 @@ pub struct CellState {
     pub expand_state: ExpandState,
     pub selected_cell: Option<String>,
     pub elements: Vec<Element>,
-    pub element_receiver: Option<mpsc::Receiver<Element>>,
-    pub elements_loading: bool,
     pub layers: BTreeSet<(Layer, DataType)>,
     pub spatial_grid: Option<SpatialGrid>,
     pub tessellation_cache: HashMap<u32, Vec<usize>>,
@@ -54,8 +52,6 @@ impl CellState {
             expand_state,
             selected_cell: None,
             elements: Vec::new(),
-            element_receiver: None,
-            elements_loading: false,
             layers: BTreeSet::new(),
             spatial_grid: None,
             tessellation_cache: HashMap::new(),
@@ -75,6 +71,29 @@ impl CellState {
         true
     }
 
+    pub fn load_direct_cell_elements(&mut self, name: &str) -> bool {
+        self.cell_stats = self.library.get_cell(name).map(CellStats::from_cell);
+
+        let Some(cell) = self.library.get_cell(name) else {
+            self.elements.clear();
+            self.rebuild_render_indexes();
+            return false;
+        };
+        self.elements = cell.elements().to_vec();
+        self.rebuild_render_indexes();
+
+        self.layers.clear();
+        let mut visiting = HashSet::new();
+        collect_layers_from_cell(
+            name,
+            &self.library,
+            self.render_depth,
+            &mut self.layers,
+            &mut visiting,
+        );
+        true
+    }
+
     fn rebuild_render_indexes(&mut self) {
         self.layers.clear();
         for element in &self.elements {
@@ -83,6 +102,55 @@ impl CellState {
         self.spatial_grid = viewport::compute_bounds(&self.elements)
             .map(|bounds| SpatialGrid::build(&self.elements, &bounds));
         self.tessellation_cache.clear();
+    }
+}
+
+fn collect_layers_from_cell(
+    cell_name: &str,
+    library: &Library,
+    depth: u32,
+    layers: &mut BTreeSet<(Layer, DataType)>,
+    visiting: &mut HashSet<String>,
+) {
+    if depth == 0 || !visiting.insert(cell_name.to_owned()) {
+        return;
+    }
+
+    if let Some(cell) = library.get_cell(cell_name) {
+        for element in cell.iter_elements() {
+            collect_layers_from_element(element, library, depth, layers, visiting);
+        }
+    }
+
+    visiting.remove(cell_name);
+}
+
+fn collect_layers_from_element(
+    element: &Element,
+    library: &Library,
+    depth: u32,
+    layers: &mut BTreeSet<(Layer, DataType)>,
+    visiting: &mut HashSet<String>,
+) {
+    let Element::Reference(reference) = element else {
+        layers.extend(element.layer_keys());
+        return;
+    };
+
+    if depth <= 1 {
+        return;
+    }
+
+    if let Some(cell_name) = reference.instance().as_cell() {
+        collect_layers_from_cell(cell_name, library, depth - 1, layers, visiting);
+    } else if let Some(inner) = reference.instance().as_element() {
+        collect_layers_from_element(
+            inner.as_ref().as_ref(),
+            library,
+            depth - 1,
+            layers,
+            visiting,
+        );
     }
 }
 

--- a/crates/gdsr-viewer/src/viewport/mod.rs
+++ b/crates/gdsr-viewer/src/viewport/mod.rs
@@ -323,7 +323,7 @@ impl Viewport {
         let mut layer_meshes = HashMap::new();
         let mut extra_shapes = Vec::new();
         let mut screen_pts_buf = Vec::new();
-        let show_ref_bbox = render_depth > 0;
+        let mut cell_bbox_cache = HashMap::new();
         let mut ctx = DrawContext {
             painter: &painter,
             layer_meshes: &mut layer_meshes,
@@ -337,7 +337,10 @@ impl Viewport {
             tessellation_cache,
             screen_pts_buf: &mut screen_pts_buf,
             highlight: false,
-            show_ref_bbox,
+            show_ref_bbox: false,
+            reference_depth: render_depth,
+            reference_stack: selected_cell.map_or_else(Vec::new, |name| vec![name.to_string()]),
+            cell_bbox_cache: &mut cell_bbox_cache,
         };
 
         if let Some(grid) = spatial_grid {
@@ -391,16 +394,14 @@ impl Viewport {
                 }
             }
 
-            // Cell references (Instance::Cell) have no world_bbox so the spatial
-            // grid never contains them. Draw any unseen references in a second pass.
-            if show_ref_bbox {
-                for (i, element) in elements.iter().enumerate() {
-                    if matches!(element, Element::Reference(_))
-                        && !drawn_element_marks.get(i).copied().unwrap_or_default()
-                    {
-                        ctx.current_element_idx = Some(i as u32);
-                        element.draw(&mut ctx);
-                    }
+            // Cell references have no direct world bbox, so the spatial grid never
+            // contains them. Draw any unseen references in a second pass.
+            for (i, element) in elements.iter().enumerate() {
+                if matches!(element, Element::Reference(_))
+                    && !drawn_element_marks.get(i).copied().unwrap_or_default()
+                {
+                    ctx.current_element_idx = Some(i as u32);
+                    element.draw(&mut ctx);
                 }
             }
 


### PR DESCRIPTION
## Summary

This changes the viewer to keep selected-cell hierarchy intact and expand references during drawing only when they survive viewport, depth, and screen-size checks. It also collapses tiny, dense, and huge reference arrays to bounding boxes so increasing render depth no longer eagerly materializes every descendant element.

## Test Plan

Ran `cargo nextest run --status-level fail`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and `uvx prek run -a`.