### PR TITLE
Add selected element move drag

### DIFF
--- a/crates/gdsr-viewer/src/app.rs
+++ b/crates/gdsr-viewer/src/app.rs
@@ -1,6 +1,8 @@
 use std::path::{Path, PathBuf};
 use std::sync::mpsc;
 
+use gdsr::Point;
+
 use crate::drawable::{Drawable, cell_world_bbox};
 use crate::panels;
 use crate::quick_pick::{QuickPick, QuickPickResult};
@@ -169,6 +171,24 @@ impl ViewerApp {
 
         self.selected_element = None;
         self.hovered_element = None;
+        self.render_cache.clear();
+        true
+    }
+
+    fn move_selected_element(&mut self, delta: Point) -> bool {
+        let Some(index) = self.selected_element else {
+            return false;
+        };
+        let Some(cell) = self.cell.as_mut() else {
+            self.selected_element = None;
+            return false;
+        };
+        if !cell.move_element(index, delta) {
+            self.selected_element = None;
+            return false;
+        }
+
+        self.hovered_element = Some(index);
         self.render_cache.clear();
         true
     }
@@ -545,6 +565,7 @@ impl eframe::App for ViewerApp {
         let render_depth = cell.as_ref().map_or(1, |c| c.render_depth);
         let selected_cell_name: Option<String> =
             cell.as_ref().and_then(|c| c.selected_cell.clone());
+        let mut selected_element_drag_delta = None;
         egui::CentralPanel::default().show(ctx, |ui| {
             let mut empty_cache = std::collections::HashMap::new();
             let (elements, spatial_grid, library, tessellation_cache) =
@@ -577,6 +598,7 @@ impl eframe::App for ViewerApp {
                 render_depth,
                 selected_cell_name.as_deref(),
             );
+            selected_element_drag_delta = interaction.selected_element_drag_delta;
             *mouse_world_pos = interaction.mouse_world;
 
             let prev_hovered = *hovered_element;
@@ -595,6 +617,11 @@ impl eframe::App for ViewerApp {
                 ctx.request_repaint();
             }
         });
+        if let Some((dx, dy)) = selected_element_drag_delta {
+            if self.move_selected_element(Point::float(dx, dy, 1.0)) {
+                ctx.request_repaint();
+            }
+        }
     }
 }
 
@@ -670,6 +697,29 @@ mod tests {
         assert!(cell.spatial_grid.is_none());
         assert!(app.selected_element.is_none());
         assert!(app.hovered_element.is_none());
+    }
+
+    #[test]
+    fn move_selected_element_moves_element_and_keeps_selection() {
+        let mut cell = CellState::new(gdsr::Library::new("test"));
+        cell.elements = test_elements();
+        let mut app = ViewerApp {
+            cell: Some(cell),
+            selected_element: Some(0),
+            ..Default::default()
+        };
+
+        assert!(app.move_selected_element(Point::float(2.0, 3.0, 1.0)));
+
+        let cell = app.cell.expect("cell should remain loaded");
+        let bbox = cell.elements[0]
+            .world_bbox()
+            .expect("moved element has bbox");
+        assert!((bbox.min_x - 2.0).abs() < 1e-12);
+        assert!((bbox.min_y - 3.0).abs() < 1e-12);
+        assert_eq!(app.selected_element, Some(0));
+        assert_eq!(app.hovered_element, Some(0));
+        assert!(cell.spatial_grid.is_some());
     }
 
     #[test]

--- a/crates/gdsr-viewer/src/state.rs
+++ b/crates/gdsr-viewer/src/state.rs
@@ -4,7 +4,7 @@ use std::sync::mpsc;
 
 use egui::{Mesh, Pos2, Shape};
 use emath::{TSTransform, Vec2};
-use gdsr::{CellStats, DataType, Element, Layer, Library};
+use gdsr::{CellStats, DataType, Element, Layer, Library, Movable, Point};
 
 use crate::colors::LayerColorMap;
 use crate::drawable::Drawable;
@@ -91,6 +91,17 @@ impl CellState {
             &mut self.layers,
             &mut visiting,
         );
+        true
+    }
+
+    pub fn move_element(&mut self, index: usize, delta: Point) -> bool {
+        let Some(element) = self.elements.get_mut(index) else {
+            return false;
+        };
+
+        *element = element.clone().move_by(delta);
+        self.rebuild_render_indexes();
+        self.cell_stats = None;
         true
     }
 
@@ -350,6 +361,43 @@ mod tests {
             cell.layers,
             BTreeSet::from([(Layer::new(1), DataType::new(0))])
         );
+        assert!(cell.spatial_grid.is_some());
+    }
+
+    #[test]
+    fn move_element_rebuilds_render_indexes() {
+        let mut cell = CellState::new(Library::new("test"));
+        cell.elements = vec![polygon(vec![(0, 0), (100, 0), (100, 100)], 1, 0)];
+        cell.tessellation_cache.insert(0, vec![0, 1, 2]);
+        cell.rebuild_render_indexes();
+
+        assert!(cell.move_element(0, Point::default_integer(1000, 2000)));
+
+        let bbox = cell.elements[0]
+            .world_bbox()
+            .expect("moved element has bbox");
+        assert!((bbox.min_x - 1000.0e-9).abs() < 1e-15);
+        assert!((bbox.min_y - 2000.0e-9).abs() < 1e-15);
+        assert_eq!(
+            cell.layers,
+            BTreeSet::from([(Layer::new(1), DataType::new(0))])
+        );
+        assert!(cell.spatial_grid.is_some());
+        assert!(cell.tessellation_cache.is_empty());
+    }
+
+    #[test]
+    fn move_element_rejects_missing_index() {
+        let mut cell = CellState::new(Library::new("test"));
+        cell.elements = vec![polygon(vec![(0, 0), (100, 0), (100, 100)], 1, 0)];
+        cell.rebuild_render_indexes();
+
+        assert!(!cell.move_element(1, Point::default_integer(1000, 2000)));
+
+        let bbox = cell.elements[0]
+            .world_bbox()
+            .expect("unchanged element has bbox");
+        assert!((bbox.min_x - 0.0).abs() < 1e-15);
         assert!(cell.spatial_grid.is_some());
     }
 

--- a/crates/gdsr-viewer/src/viewport/mod.rs
+++ b/crates/gdsr-viewer/src/viewport/mod.rs
@@ -24,6 +24,7 @@ pub struct Viewport {
 pub struct ViewportInteraction {
     pub mouse_world: Option<(f64, f64)>,
     pub clicked: bool,
+    pub selected_element_drag_delta: Option<(f64, f64)>,
 }
 
 impl Default for Viewport {
@@ -151,7 +152,19 @@ impl Viewport {
         }
         let clicked = response.clicked() && !ruler_was_active;
 
-        if response.dragged() {
+        let move_selected_element =
+            selected_element.is_some() && ui.input(|i| i.modifiers.shift) && response.dragged();
+        let selected_element_drag_delta = if move_selected_element {
+            let delta = response.drag_delta();
+            Some((
+                f64::from(delta.x) / self.zoom,
+                -f64::from(delta.y) / self.zoom,
+            ))
+        } else {
+            None
+        };
+
+        if response.dragged() && !move_selected_element {
             let delta = response.drag_delta();
             self.center_x -= f64::from(delta.x) / self.zoom;
             self.center_y += f64::from(delta.y) / self.zoom;
@@ -257,6 +270,7 @@ impl Viewport {
             return ViewportInteraction {
                 mouse_world,
                 clicked,
+                selected_element_drag_delta,
             };
         }
 
@@ -306,6 +320,7 @@ impl Viewport {
             return ViewportInteraction {
                 mouse_world,
                 clicked,
+                selected_element_drag_delta,
             };
         }
 
@@ -465,6 +480,7 @@ impl Viewport {
         ViewportInteraction {
             mouse_world,
             clicked,
+            selected_element_drag_delta,
         }
     }
 }


### PR DESCRIPTION
## Summary

This adds Shift-drag movement for the selected top-level viewer element and rebuilds the render indexes after each move. The change preserves selection while clearing stale render cache state.

Closes #153.

## Test Plan

Ran `cargo nextest run -p gdsr-viewer --status-level fail`, `cargo nextest run --status-level fail`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and `uvx prek run -a`.