### PR TITLE
Add viewer GDS save and dirty state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2073,6 +2073,7 @@ dependencies = [
  "quickcheck",
  "quickcheck_macros",
  "rfd",
+ "tempfile",
 ]
 
 [[package]]

--- a/crates/gdsr-viewer/Cargo.toml
+++ b/crates/gdsr-viewer/Cargo.toml
@@ -26,6 +26,7 @@ rfd = { workspace = true }
 insta = { workspace = true }
 quickcheck = { workspace = true }
 quickcheck_macros = { workspace = true }
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/gdsr-viewer/src/app.rs
+++ b/crates/gdsr-viewer/src/app.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::sync::mpsc;
 
-use gdsr::Point;
+use gdsr::{DEFAULT_FLOAT_UNITS, DEFAULT_INTEGER_UNITS, Point};
 
 use crate::drawable::{Drawable, cell_world_bbox};
 use crate::panels;
@@ -48,6 +48,9 @@ pub struct ViewerApp {
     grid_spacing: GridSpacing,
     cell_picker: QuickPick<String>,
     recent_picker: QuickPick<RecentProjectItem>,
+    has_unsaved_changes: bool,
+    save_error: Option<String>,
+    show_unsaved_close_prompt: bool,
 }
 
 impl Default for ViewerApp {
@@ -73,6 +76,9 @@ impl Default for ViewerApp {
             recent_projects: RecentProjects::load(),
             cell_picker: QuickPick::new("Search cells…", true),
             recent_picker: QuickPick::new("Recent projects…", false),
+            has_unsaved_changes: false,
+            save_error: None,
+            show_unsaved_close_prompt: false,
         }
     }
 }
@@ -114,6 +120,9 @@ impl ViewerApp {
         self.selected_element = None;
         self.file_load.file_path = Some(path);
         self.file_load.loading = false;
+        self.has_unsaved_changes = false;
+        self.save_error = None;
+        self.show_unsaved_close_prompt = false;
     }
 
     /// Switches to a new cell, keeping hierarchy intact for draw-time expansion.
@@ -154,6 +163,81 @@ impl ViewerApp {
         self.file_load.load_receiver = Some((path, rx));
         self.file_load.loading = true;
         self.file_load.error_message = None;
+        self.save_error = None;
+    }
+
+    fn save_current_file(&mut self) -> bool {
+        if self.cell.is_none() {
+            self.save_error = Some("No GDS library loaded".to_string());
+            return false;
+        }
+
+        if let Some(path) = self.file_load.file_path.clone() {
+            return self.save_file_to_path(&path);
+        }
+
+        self.save_file_as_dialog()
+    }
+
+    fn save_file_as_dialog(&mut self) -> bool {
+        if self.cell.is_none() {
+            self.save_error = Some("No GDS library loaded".to_string());
+            return false;
+        }
+
+        let mut dialog = rfd::FileDialog::new().add_filter("GDS files", &["gds", "gds2", "gdsii"]);
+
+        if let Some(path) = &self.file_load.file_path {
+            if let Some(parent) = path.parent() {
+                dialog = dialog.set_directory(parent);
+            }
+            if let Some(file_name) = path.file_name().and_then(|name| name.to_str()) {
+                dialog = dialog.set_file_name(file_name);
+            }
+        } else {
+            dialog = dialog.set_file_name("layout.gds");
+        }
+
+        let Some(path) = dialog.save_file() else {
+            return false;
+        };
+
+        self.save_file_to_path(&path)
+    }
+
+    fn save_file_to_path(&mut self, path: &Path) -> bool {
+        let Some(cell) = self.cell.as_ref() else {
+            self.save_error = Some("No GDS library loaded".to_string());
+            return false;
+        };
+
+        match cell
+            .library
+            .write_file(path, DEFAULT_FLOAT_UNITS, DEFAULT_INTEGER_UNITS)
+        {
+            Ok(()) => {
+                self.file_load.file_path = Some(path.to_path_buf());
+                self.has_unsaved_changes = false;
+                self.save_error = None;
+                self.show_unsaved_close_prompt = false;
+                self.recent_projects.add(path);
+                self.recent_projects.save();
+                true
+            }
+            Err(err) => {
+                self.save_error = Some(err.to_string());
+                false
+            }
+        }
+    }
+
+    fn cancel_close_for_unsaved_changes(&mut self) -> bool {
+        if !self.has_unsaved_changes {
+            return false;
+        }
+
+        self.show_unsaved_close_prompt = true;
+        true
     }
 
     fn delete_selected_element(&mut self) -> bool {
@@ -172,6 +256,8 @@ impl ViewerApp {
         self.selected_element = None;
         self.hovered_element = None;
         self.render_cache.clear();
+        self.has_unsaved_changes = true;
+        self.save_error = None;
         true
     }
 
@@ -190,7 +276,36 @@ impl ViewerApp {
 
         self.hovered_element = Some(index);
         self.render_cache.clear();
+        self.has_unsaved_changes = true;
+        self.save_error = None;
         true
+    }
+
+    fn draw_unsaved_close_prompt(&mut self, ctx: &egui::Context) {
+        if !self.show_unsaved_close_prompt {
+            return;
+        }
+
+        egui::Window::new("Unsaved changes")
+            .collapsible(false)
+            .resizable(false)
+            .anchor(egui::Align2::CENTER_CENTER, egui::Vec2::ZERO)
+            .show(ctx, |ui| {
+                ui.label("Save changes before closing?");
+                ui.horizontal(|ui| {
+                    if ui.button("Save").clicked() && self.save_current_file() {
+                        ctx.send_viewport_cmd(egui::ViewportCommand::Close);
+                    }
+                    if ui.button("Discard").clicked() {
+                        self.has_unsaved_changes = false;
+                        self.show_unsaved_close_prompt = false;
+                        ctx.send_viewport_cmd(egui::ViewportCommand::Close);
+                    }
+                    if ui.button("Cancel").clicked() {
+                        self.show_unsaved_close_prompt = false;
+                    }
+                });
+            });
     }
 }
 
@@ -215,6 +330,11 @@ fn hit_test_element(
 
 impl eframe::App for ViewerApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        if ctx.input(|i| i.viewport().close_requested()) && self.cancel_close_for_unsaved_changes()
+        {
+            ctx.send_viewport_cmd(egui::ViewportCommand::CancelClose);
+        }
+
         // Poll background loader
         if let Some((path, rx)) = self.file_load.load_receiver.take() {
             match rx.try_recv() {
@@ -258,6 +378,11 @@ impl eframe::App for ViewerApp {
         }
         if ctx.input(|i| i.modifiers.command && i.modifiers.alt && i.key_pressed(egui::Key::O)) {
             self.recent_picker.toggle();
+        }
+        if ctx.input(|i| i.modifiers.command && i.modifiers.shift && i.key_pressed(egui::Key::S)) {
+            self.save_file_as_dialog();
+        } else if ctx.input(|i| i.modifiers.command && i.key_pressed(egui::Key::S)) {
+            self.save_current_file();
         }
         if ctx.input(|i| i.modifiers.command && i.key_pressed(egui::Key::P)) {
             self.cell_picker.toggle();
@@ -305,6 +430,27 @@ impl eframe::App for ViewerApp {
                     {
                         ui.close_kind(egui::UiKind::Menu);
                         self.recent_picker.open();
+                    }
+                    ui.separator();
+                    if ui
+                        .add_enabled(
+                            self.cell.is_some(),
+                            egui::Button::new("Save").shortcut_text(shortcut_text("S")),
+                        )
+                        .clicked()
+                    {
+                        ui.close_kind(egui::UiKind::Menu);
+                        self.save_current_file();
+                    }
+                    if ui
+                        .add_enabled(
+                            self.cell.is_some(),
+                            egui::Button::new("Save As...").shortcut_text(shortcut_text("Shift+S")),
+                        )
+                        .clicked()
+                    {
+                        ui.close_kind(egui::UiKind::Menu);
+                        self.save_file_as_dialog();
                     }
                 });
                 ui.menu_button("View", |ui| {
@@ -417,12 +563,18 @@ impl eframe::App for ViewerApp {
                     ui.label("Loading...");
                 } else if let Some(err) = &self.file_load.error_message {
                     ui.colored_label(egui::Color32::RED, format!("Error: {err}"));
+                } else if let Some(err) = &self.save_error {
+                    ui.colored_label(egui::Color32::RED, format!("Save error: {err}"));
                 } else if let Some(path) = &self.file_load.file_path {
-                    ui.label(
-                        path.file_name()
-                            .and_then(|n| n.to_str())
-                            .unwrap_or("unknown"),
-                    );
+                    let file_name = path
+                        .file_name()
+                        .and_then(|n| n.to_str())
+                        .unwrap_or("unknown");
+                    ui.label(if self.has_unsaved_changes {
+                        format!("{file_name}*")
+                    } else {
+                        file_name.to_string()
+                    });
                 }
 
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
@@ -622,6 +774,8 @@ impl eframe::App for ViewerApp {
                 ctx.request_repaint();
             }
         }
+
+        self.draw_unsaved_close_prompt(ctx);
     }
 }
 
@@ -643,6 +797,21 @@ mod tests {
             )
             .into(),
         ]
+    }
+
+    fn cell_state_with_test_elements() -> CellState {
+        let mut source_cell = Cell::new("top");
+        for element in test_elements() {
+            source_cell.add(element);
+        }
+
+        let mut library = Library::new("test");
+        library.add_cell(source_cell);
+
+        let mut cell = CellState::new(library);
+        cell.selected_cell = Some("top".to_string());
+        assert!(cell.load_direct_cell_elements("top"));
+        cell
     }
 
     #[test]
@@ -676,13 +845,8 @@ mod tests {
     }
 
     #[test]
-    fn delete_selected_element_removes_element_and_clears_selection() {
-        let mut cell = CellState::new(gdsr::Library::new("test"));
-        cell.elements = test_elements();
-        let Some(bounds) = crate::viewport::compute_bounds(&cell.elements) else {
-            panic!("test elements should have bounds");
-        };
-        cell.spatial_grid = Some(SpatialGrid::build(&cell.elements, &bounds));
+    fn delete_selected_element_removes_element_marks_dirty_and_clears_selection() {
+        let cell = cell_state_with_test_elements();
         let mut app = ViewerApp {
             cell: Some(cell),
             selected_element: Some(0),
@@ -694,15 +858,22 @@ mod tests {
 
         let cell = app.cell.expect("cell should remain loaded");
         assert!(cell.elements.is_empty());
+        assert!(
+            cell.library
+                .get_cell("top")
+                .expect("top cell should exist")
+                .elements()
+                .is_empty()
+        );
         assert!(cell.spatial_grid.is_none());
         assert!(app.selected_element.is_none());
         assert!(app.hovered_element.is_none());
+        assert!(app.has_unsaved_changes);
     }
 
     #[test]
-    fn move_selected_element_moves_element_and_keeps_selection() {
-        let mut cell = CellState::new(gdsr::Library::new("test"));
-        cell.elements = test_elements();
+    fn move_selected_element_moves_element_marks_dirty_and_keeps_selection() {
+        let cell = cell_state_with_test_elements();
         let mut app = ViewerApp {
             cell: Some(cell),
             selected_element: Some(0),
@@ -720,6 +891,71 @@ mod tests {
         assert_eq!(app.selected_element, Some(0));
         assert_eq!(app.hovered_element, Some(0));
         assert!(cell.spatial_grid.is_some());
+        assert!(app.has_unsaved_changes);
+
+        let library_bbox = cell
+            .library
+            .get_cell("top")
+            .expect("top cell should exist")
+            .elements()[0]
+            .world_bbox()
+            .expect("moved element has bbox");
+        assert!((library_bbox.min_x - 2.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn save_file_to_path_writes_library_and_clears_dirty_state() {
+        let dir = tempfile::tempdir().expect("temporary directory should be created");
+        let path = dir.path().join("saved.gds");
+        let mut app = ViewerApp {
+            cell: Some(cell_state_with_test_elements()),
+            has_unsaved_changes: true,
+            ..Default::default()
+        };
+
+        assert!(app.save_file_to_path(&path));
+
+        assert!(!app.has_unsaved_changes);
+        assert!(app.save_error.is_none());
+        assert_eq!(app.file_load.file_path.as_deref(), Some(path.as_path()));
+
+        let saved = Library::read_file(&path, Some(DEFAULT_INTEGER_UNITS))
+            .expect("saved GDS should be readable");
+        assert_eq!(
+            saved
+                .get_cell("top")
+                .expect("top cell should exist")
+                .elements()
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn save_current_file_without_loaded_library_sets_error() {
+        let mut app = ViewerApp::default();
+
+        assert!(!app.save_current_file());
+        assert_eq!(app.save_error.as_deref(), Some("No GDS library loaded"));
+    }
+
+    #[test]
+    fn dirty_close_request_opens_prompt_and_cancels_close() {
+        let mut app = ViewerApp {
+            has_unsaved_changes: true,
+            ..Default::default()
+        };
+
+        assert!(app.cancel_close_for_unsaved_changes());
+        assert!(app.show_unsaved_close_prompt);
+    }
+
+    #[test]
+    fn clean_close_request_does_not_open_prompt() {
+        let mut app = ViewerApp::default();
+
+        assert!(!app.cancel_close_for_unsaved_changes());
+        assert!(!app.show_unsaved_close_prompt);
     }
 
     #[test]

--- a/crates/gdsr-viewer/src/state.rs
+++ b/crates/gdsr-viewer/src/state.rs
@@ -61,14 +61,17 @@ impl CellState {
     }
 
     pub fn delete_element(&mut self, index: usize) -> bool {
-        if index >= self.elements.len() {
+        let Some(cell_name) = self.selected_cell.clone() else {
             return false;
-        }
+        };
 
-        self.elements.remove(index);
-        self.rebuild_render_indexes();
-        self.cell_stats = None;
-        true
+        let removed = self
+            .library
+            .get_cell_mut(&cell_name)
+            .and_then(|cell| cell.remove_element(index))
+            .is_some();
+
+        removed && self.load_direct_cell_elements(&cell_name)
     }
 
     pub fn load_direct_cell_elements(&mut self, name: &str) -> bool {
@@ -95,14 +98,20 @@ impl CellState {
     }
 
     pub fn move_element(&mut self, index: usize, delta: Point) -> bool {
-        let Some(element) = self.elements.get_mut(index) else {
+        let Some(cell_name) = self.selected_cell.clone() else {
             return false;
         };
 
-        *element = element.clone().move_by(delta);
-        self.rebuild_render_indexes();
-        self.cell_stats = None;
-        true
+        let moved = if let Some(cell) = self.library.get_cell_mut(&cell_name)
+            && let Some(element) = cell.element_mut(index)
+        {
+            *element = element.clone().move_by(delta);
+            true
+        } else {
+            false
+        };
+
+        moved && self.load_direct_cell_elements(&cell_name)
     }
 
     fn rebuild_render_indexes(&mut self) {
@@ -303,7 +312,7 @@ impl RenderCache {
 mod tests {
     use super::*;
     use egui::Rect;
-    use gdsr::Library;
+    use gdsr::{Cell, Element, Library};
 
     use crate::testutil::helpers::polygon;
 
@@ -327,19 +336,41 @@ mod tests {
         cache
     }
 
+    fn cell_state_with_elements(elements: Vec<Element>) -> CellState {
+        let mut source_cell = Cell::new("top");
+        for element in elements {
+            source_cell.add(element);
+        }
+
+        let mut library = Library::new("test");
+        library.add_cell(source_cell);
+
+        let mut cell = CellState::new(library);
+        cell.selected_cell = Some("top".to_string());
+        assert!(cell.load_direct_cell_elements("top"));
+        cell
+    }
+
     #[test]
     fn delete_element_rebuilds_render_indexes() {
-        let mut cell = CellState::new(Library::new("test"));
-        cell.elements = vec![
+        let mut cell = cell_state_with_elements(vec![
             polygon(vec![(0, 0), (100, 0), (100, 100)], 1, 0),
             polygon(vec![(1000, 1000), (1100, 1000), (1100, 1100)], 2, 0),
-        ];
+        ]);
         cell.tessellation_cache.insert(0, vec![0, 1, 2]);
         cell.rebuild_render_indexes();
 
         assert!(cell.delete_element(0));
 
         assert_eq!(cell.elements.len(), 1);
+        assert_eq!(
+            cell.library
+                .get_cell("top")
+                .expect("top cell should exist")
+                .elements()
+                .len(),
+            1
+        );
         assert_eq!(
             cell.layers,
             BTreeSet::from([(Layer::new(2), DataType::new(0))])
@@ -350,8 +381,8 @@ mod tests {
 
     #[test]
     fn delete_element_rejects_missing_index() {
-        let mut cell = CellState::new(Library::new("test"));
-        cell.elements = vec![polygon(vec![(0, 0), (100, 0), (100, 100)], 1, 0)];
+        let mut cell =
+            cell_state_with_elements(vec![polygon(vec![(0, 0), (100, 0), (100, 100)], 1, 0)]);
         cell.rebuild_render_indexes();
 
         assert!(!cell.delete_element(1));
@@ -366,8 +397,8 @@ mod tests {
 
     #[test]
     fn move_element_rebuilds_render_indexes() {
-        let mut cell = CellState::new(Library::new("test"));
-        cell.elements = vec![polygon(vec![(0, 0), (100, 0), (100, 100)], 1, 0)];
+        let mut cell =
+            cell_state_with_elements(vec![polygon(vec![(0, 0), (100, 0), (100, 100)], 1, 0)]);
         cell.tessellation_cache.insert(0, vec![0, 1, 2]);
         cell.rebuild_render_indexes();
 
@@ -384,12 +415,21 @@ mod tests {
         );
         assert!(cell.spatial_grid.is_some());
         assert!(cell.tessellation_cache.is_empty());
+
+        let library_bbox = cell
+            .library
+            .get_cell("top")
+            .expect("top cell should exist")
+            .elements()[0]
+            .world_bbox()
+            .expect("moved element has bbox");
+        assert!((library_bbox.min_x - 1000.0e-9).abs() < 1e-15);
     }
 
     #[test]
     fn move_element_rejects_missing_index() {
-        let mut cell = CellState::new(Library::new("test"));
-        cell.elements = vec![polygon(vec![(0, 0), (100, 0), (100, 100)], 1, 0)];
+        let mut cell =
+            cell_state_with_elements(vec![polygon(vec![(0, 0), (100, 0), (100, 100)], 1, 0)]);
         cell.rebuild_render_indexes();
 
         assert!(!cell.move_element(1, Point::default_integer(1000, 2000)));

--- a/crates/gdsr/src/cell.rs
+++ b/crates/gdsr/src/cell.rs
@@ -88,6 +88,20 @@ impl Cell {
         self.elements.push(element.into());
     }
 
+    /// Returns a mutable reference to the element at `index`.
+    pub fn element_mut(&mut self, index: usize) -> Option<&mut Element> {
+        self.elements.get_mut(index)
+    }
+
+    /// Removes and returns the element at `index`.
+    pub fn remove_element(&mut self, index: usize) -> Option<Element> {
+        if index >= self.elements.len() {
+            return None;
+        }
+
+        Some(self.elements.remove(index))
+    }
+
     /// Converts all elements to integer units.
     #[must_use]
     pub fn to_integer_unit(self) -> Self {
@@ -252,6 +266,36 @@ mod tests {
         cell.add(polygon.clone());
         assert_eq!(cell.polygons().count(), 1);
         assert_eq!(cell.polygons().next().unwrap(), &polygon);
+    }
+
+    #[test]
+    fn test_element_mut() {
+        let mut cell = Cell::new("test_cell");
+        cell.add(Polygon::default());
+
+        let Some(element) = cell.element_mut(0) else {
+            panic!("element should exist");
+        };
+        *element = Path::default().into();
+
+        assert_eq!(cell.polygons().count(), 0);
+        assert_eq!(cell.paths().count(), 1);
+    }
+
+    #[test]
+    fn test_remove_element() {
+        let mut cell = Cell::new("test_cell");
+        cell.add(Polygon::default());
+        cell.add(Path::default());
+
+        let Some(removed) = cell.remove_element(0) else {
+            panic!("element should be removed");
+        };
+
+        assert!(matches!(removed, Element::Polygon(_)));
+        assert_eq!(cell.elements().len(), 1);
+        assert!(matches!(cell.elements()[0], Element::Path(_)));
+        assert!(cell.remove_element(1).is_none());
     }
 
     #[test]

--- a/crates/gdsr/src/library.rs
+++ b/crates/gdsr/src/library.rs
@@ -66,6 +66,11 @@ impl Library {
         self.cells.get(name)
     }
 
+    /// Returns a mutable reference to the cell with the given name, if it exists.
+    pub fn get_cell_mut(&mut self, name: &str) -> Option<&mut Cell> {
+        self.cells.get_mut(name)
+    }
+
     /// Returns `true` if the library contains a cell with the same name.
     pub fn contains_cell(&self, cell: &Cell) -> bool {
         self.cells.contains_key(cell.name())
@@ -435,6 +440,26 @@ mod tests {
         assert_eq!(library.cells.len(), 1);
         assert!(library.cells.contains_key("test_cell"));
         assert_eq!(library.cells.get("test_cell"), Some(&cell));
+    }
+
+    #[test]
+    fn test_library_get_cell_mut() {
+        let mut library: Library = Library::new("test_lib");
+        library.add_cell(Cell::new("test_cell"));
+
+        let Some(cell) = library.get_cell_mut("test_cell") else {
+            panic!("cell should exist");
+        };
+        cell.add(Polygon::default());
+
+        assert_eq!(
+            library
+                .get_cell("test_cell")
+                .expect("cell should exist")
+                .elements()
+                .len(),
+            1
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Add viewer Save and Save As actions, dirty-state prompts, and model updates so saved files include direct edits. Closes #154.

## Test Plan

Ran nextest, strict workspace Clippy, and `uvx prek run -a`.