### PR TITLE
Add Bevy renderer hierarchy LOD

### DIFF
--- a/crates/gdsr-viewer/src/bevy_renderer.rs
+++ b/crates/gdsr-viewer/src/bevy_renderer.rs
@@ -1,10 +1,13 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
 use bevy_asset::RenderAssetUsages;
 use bevy_mesh::{Indices, Mesh, PrimitiveTopology};
-use gdsr::{DataType, Element, Layer, Point};
+use gdsr::{DataType, Element, Layer, Library, Point};
 
-use crate::drawable::WorldBBox;
+use crate::drawable::{
+    Drawable, WorldBBox, reference_draw_units_for_depth, reference_grid_count,
+    reference_instance_bbox, should_collapse_reference,
+};
 use crate::spatial::SpatialGrid;
 
 pub struct BevyLayerBatch {
@@ -13,10 +16,23 @@ pub struct BevyLayerBatch {
     pub element_count: usize,
 }
 
+pub struct BevyReferenceLoad {
+    pub bbox: WorldBBox,
+    pub cell_name: Option<String>,
+}
+
 pub struct BevyRenderScene {
     pub batches: Vec<BevyLayerBatch>,
+    pub reference_lods: Vec<BevyReferenceLoad>,
     pub batched_element_count: usize,
     pub skipped_element_count: usize,
+}
+
+pub struct BevySceneOptions<'a> {
+    pub visible: &'a WorldBBox,
+    pub zoom: f64,
+    pub library: Option<&'a Library>,
+    pub render_depth: u32,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -36,50 +52,35 @@ pub fn build_visible_scene(
     visible_indices: &[u32],
     hidden_layers: &BTreeSet<(Layer, DataType)>,
 ) -> Result<BevyRenderScene, BevyRenderError> {
-    let mut builders = BTreeMap::new();
-    let mut skipped_element_count = 0;
+    let visible = WorldBBox::new(f64::MIN, f64::MIN, f64::MAX, f64::MAX);
+    build_visible_scene_with_options(
+        elements,
+        visible_indices,
+        hidden_layers,
+        &BevySceneOptions {
+            visible: &visible,
+            zoom: 1.0,
+            library: None,
+            render_depth: 1,
+        },
+    )
+}
 
+pub fn build_visible_scene_with_options(
+    elements: &[Element],
+    visible_indices: &[u32],
+    hidden_layers: &BTreeSet<(Layer, DataType)>,
+    options: &BevySceneOptions<'_>,
+) -> Result<BevyRenderScene, BevyRenderError> {
+    let mut builder = SceneBuilder::new(hidden_layers, options);
     for &idx in visible_indices {
         let Some(element) = elements.get(idx as usize) else {
-            skipped_element_count += 1;
+            builder.skipped_element_count += 1;
             continue;
         };
-        let Some((layer, points)) = element_polygon_points(element) else {
-            skipped_element_count += 1;
-            continue;
-        };
-        if hidden_layers.contains(&layer) {
-            continue;
-        }
-
-        let builder = builders.entry(layer).or_insert_with(MeshBuilder::default);
-        if builder.push_polygon(layer, &points)? {
-            builder.element_count += 1;
-        } else {
-            skipped_element_count += 1;
-        }
+        builder.push_element(element, options.render_depth)?;
     }
-
-    let mut batched_element_count = 0;
-    let batches = builders
-        .into_iter()
-        .filter_map(|(layer, builder)| {
-            let element_count = builder.element_count;
-            let mesh = builder.into_mesh()?;
-            batched_element_count += element_count;
-            Some(BevyLayerBatch {
-                layer,
-                mesh,
-                element_count,
-            })
-        })
-        .collect();
-
-    Ok(BevyRenderScene {
-        batches,
-        batched_element_count,
-        skipped_element_count,
-    })
+    Ok(builder.into_scene())
 }
 
 pub fn build_visible_scene_from_grid(
@@ -91,6 +92,187 @@ pub fn build_visible_scene_from_grid(
 ) -> Result<BevyRenderScene, BevyRenderError> {
     let visible_indices = grid.query_visible_indices(visible, query_buf);
     build_visible_scene(elements, visible_indices, hidden_layers)
+}
+
+pub fn build_visible_scene_from_grid_with_options(
+    elements: &[Element],
+    grid: &SpatialGrid,
+    visible: &WorldBBox,
+    hidden_layers: &BTreeSet<(Layer, DataType)>,
+    query_buf: &mut Vec<u32>,
+    options: &BevySceneOptions<'_>,
+) -> Result<BevyRenderScene, BevyRenderError> {
+    let visible_indices = grid.query_visible_indices(visible, query_buf);
+    let mut builder = SceneBuilder::new(hidden_layers, options);
+    for &idx in visible_indices {
+        let Some(element) = elements.get(idx as usize) else {
+            builder.skipped_element_count += 1;
+            continue;
+        };
+        builder.push_element(element, options.render_depth)?;
+    }
+
+    for element in elements {
+        if matches!(element, Element::Reference(_)) {
+            builder.push_element(element, options.render_depth)?;
+        }
+    }
+
+    Ok(builder.into_scene())
+}
+
+struct SceneBuilder<'a> {
+    hidden_layers: &'a BTreeSet<(Layer, DataType)>,
+    options: &'a BevySceneOptions<'a>,
+    builders: BTreeMap<(Layer, DataType), MeshBuilder>,
+    reference_lods: Vec<BevyReferenceLoad>,
+    skipped_element_count: usize,
+    cell_bbox_cache: HashMap<String, Option<WorldBBox>>,
+    cell_complexity_cache: HashMap<(String, u32), u64>,
+    reference_stack: HashSet<String>,
+}
+
+impl<'a> SceneBuilder<'a> {
+    fn new(
+        hidden_layers: &'a BTreeSet<(Layer, DataType)>,
+        options: &'a BevySceneOptions<'a>,
+    ) -> Self {
+        Self {
+            hidden_layers,
+            options,
+            builders: BTreeMap::new(),
+            reference_lods: Vec::new(),
+            skipped_element_count: 0,
+            cell_bbox_cache: HashMap::new(),
+            cell_complexity_cache: HashMap::new(),
+            reference_stack: HashSet::new(),
+        }
+    }
+
+    fn into_scene(self) -> BevyRenderScene {
+        let mut batched_element_count = 0;
+        let batches = self
+            .builders
+            .into_iter()
+            .filter_map(|(layer, builder)| {
+                let element_count = builder.element_count;
+                let mesh = builder.into_mesh()?;
+                batched_element_count += element_count;
+                Some(BevyLayerBatch {
+                    layer,
+                    mesh,
+                    element_count,
+                })
+            })
+            .collect();
+
+        BevyRenderScene {
+            batches,
+            reference_lods: self.reference_lods,
+            batched_element_count,
+            skipped_element_count: self.skipped_element_count,
+        }
+    }
+
+    fn push_element(&mut self, element: &Element, depth: u32) -> Result<(), BevyRenderError> {
+        if let Element::Reference(reference) = element {
+            self.push_reference(reference, depth)?;
+            return Ok(());
+        }
+
+        let Some(bbox) = element.world_bbox() else {
+            self.skipped_element_count += 1;
+            return Ok(());
+        };
+        if !bbox.overlaps(self.options.visible) {
+            return Ok(());
+        }
+
+        let Some((layer, points)) = element_polygon_points(element) else {
+            self.skipped_element_count += 1;
+            return Ok(());
+        };
+        if self.hidden_layers.contains(&layer) {
+            return Ok(());
+        }
+
+        let builder = self.builders.entry(layer).or_default();
+        if builder.push_polygon(layer, &points)? {
+            builder.element_count += 1;
+        } else {
+            self.skipped_element_count += 1;
+        }
+        Ok(())
+    }
+
+    fn push_reference(
+        &mut self,
+        reference: &gdsr::Reference,
+        depth: u32,
+    ) -> Result<(), BevyRenderError> {
+        let Some(bbox) =
+            reference_instance_bbox(reference, self.options.library, &mut self.cell_bbox_cache)
+        else {
+            self.skipped_element_count += 1;
+            return Ok(());
+        };
+        if !bbox.overlaps(self.options.visible) {
+            return Ok(());
+        }
+
+        let width_px = ((bbox.max_x - bbox.min_x) * self.options.zoom) as f32;
+        let height_px = ((bbox.max_y - bbox.min_y) * self.options.zoom) as f32;
+        let draw_unit_count = reference_draw_units_for_depth(
+            reference,
+            self.options.library,
+            depth,
+            &mut self.cell_complexity_cache,
+            &mut self.reference_stack,
+        );
+        if should_collapse_reference(
+            width_px.abs(),
+            height_px.abs(),
+            reference_grid_count(reference),
+            draw_unit_count,
+            depth,
+            false,
+        ) {
+            self.reference_lods.push(BevyReferenceLoad {
+                bbox,
+                cell_name: reference.instance().as_cell().cloned(),
+            });
+            return Ok(());
+        }
+
+        let next_depth = depth.saturating_sub(1);
+        if let Some(element) = reference.instance().as_element() {
+            for element in reference.get_elements_in_grid(element.as_ref().as_ref()) {
+                self.push_element(&element, next_depth)?;
+            }
+        } else if let Some(cell_name) = reference.instance().as_cell() {
+            if !self.reference_stack.insert(cell_name.clone()) {
+                self.reference_lods.push(BevyReferenceLoad {
+                    bbox,
+                    cell_name: Some(cell_name.clone()),
+                });
+                return Ok(());
+            }
+            if let Some(cell) = self
+                .options
+                .library
+                .and_then(|library| library.get_cell(cell_name))
+            {
+                for element in cell.iter_elements() {
+                    for transformed in reference.get_elements_in_grid(element) {
+                        self.push_element(&transformed, next_depth)?;
+                    }
+                }
+            }
+            self.reference_stack.remove(cell_name);
+        }
+
+        Ok(())
+    }
 }
 
 impl MeshBuilder {
@@ -190,6 +372,10 @@ mod tests {
         }
     }
 
+    fn visible() -> WorldBBox {
+        WorldBBox::new(-1.0, -1.0, 1.0, 1.0)
+    }
+
     #[test]
     fn build_visible_scene_batches_polygon_meshes_by_layer() {
         let elements = vec![
@@ -202,6 +388,7 @@ mod tests {
             .expect("test scene should build");
 
         assert_eq!(scene.batches.len(), 1);
+        assert_eq!(scene.reference_lods.len(), 0);
         assert_eq!(scene.batched_element_count, 2);
         assert_eq!(scene.skipped_element_count, 0);
         assert_eq!(scene.batches[0].element_count, 2);
@@ -213,12 +400,12 @@ mod tests {
     fn build_visible_scene_uses_spatial_indices() {
         let scale = 1e-9;
         let elements = vec![
-            polygon(vec![(0, 0), (100, 0), (100, 100), (0, 100)], 1, 0),
+            polygon(vec![(0, 0), (100, 0), (100, 100)], 1, 0),
             polygon(vec![(9900, 9900), (10000, 9900), (10000, 10000)], 2, 0),
         ];
         let bounds = compute_bounds(&elements).expect("test elements should have bounds");
         let grid = SpatialGrid::build(&elements, &bounds);
-        let visible = crate::drawable::WorldBBox::new(0.0, 0.0, 1000.0 * scale, 1000.0 * scale);
+        let visible = WorldBBox::new(0.0, 0.0, 1000.0 * scale, 1000.0 * scale);
         let mut query_buf = Vec::new();
         let scene = build_visible_scene_from_grid(
             &elements,
@@ -237,8 +424,8 @@ mod tests {
     #[test]
     fn build_visible_scene_skips_hidden_layers_and_unsupported_elements() {
         let elements = vec![
-            polygon(vec![(0, 0), (100, 0), (100, 100), (0, 100)], 1, 0),
-            polygon(vec![(200, 0), (300, 0), (300, 100), (200, 100)], 2, 0),
+            polygon(vec![(0, 0), (100, 0), (100, 100)], 1, 0),
+            polygon(vec![(200, 0), (300, 0), (300, 100)], 2, 0),
             text("label", 0, 0, 3),
         ];
         let hidden_layers = BTreeSet::from([(Layer::new(2), DataType::new(0))]);
@@ -263,5 +450,70 @@ mod tests {
         assert_eq!(scene.batches[0].layer, (Layer::new(7), DataType::new(2)));
         assert!(!mesh_positions(&scene.batches[0].mesh).is_empty());
         assert!(scene.batches[0].mesh.indices().is_some());
+    }
+
+    #[test]
+    fn bevy_scene_collapses_dense_referenced_cell_to_load() {
+        let mut leaf = gdsr::Cell::new("leaf");
+        for i in 0..200 {
+            let x = i * 20;
+            leaf.add(polygon(
+                vec![(x, 0), (x + 10, 0), (x + 10, 10), (x, 10)],
+                1,
+                0,
+            ));
+        }
+        let mut library = Library::new("lib");
+        library.add_cell(leaf);
+        let elements = vec![Element::Reference(gdsr::Reference::new("leaf"))];
+        let visible = visible();
+
+        let scene = build_visible_scene_with_options(
+            &elements,
+            &[0],
+            &BTreeSet::new(),
+            &BevySceneOptions {
+                visible: &visible,
+                zoom: 1.0e6,
+                library: Some(&library),
+                render_depth: 2,
+            },
+        )
+        .expect("scene should build");
+
+        assert_eq!(scene.batched_element_count, 0);
+        assert_eq!(scene.reference_lods.len(), 1);
+        assert_eq!(scene.reference_lods[0].cell_name.as_deref(), Some("leaf"));
+    }
+
+    #[test]
+    fn bevy_scene_expands_sparse_referenced_cell() {
+        let mut leaf = gdsr::Cell::new("leaf");
+        leaf.add(polygon(vec![(0, 0), (100, 0), (100, 100), (0, 100)], 1, 0));
+        leaf.add(polygon(
+            vec![(200, 0), (300, 0), (300, 100), (200, 100)],
+            1,
+            0,
+        ));
+        let mut library = Library::new("lib");
+        library.add_cell(leaf);
+        let elements = vec![Element::Reference(gdsr::Reference::new("leaf"))];
+        let visible = visible();
+
+        let scene = build_visible_scene_with_options(
+            &elements,
+            &[0],
+            &BTreeSet::new(),
+            &BevySceneOptions {
+                visible: &visible,
+                zoom: 1.0e12,
+                library: Some(&library),
+                render_depth: 2,
+            },
+        )
+        .expect("scene should build");
+
+        assert_eq!(scene.reference_lods.len(), 0);
+        assert_eq!(scene.batched_element_count, 2);
     }
 }

--- a/crates/gdsr-viewer/src/drawable.rs
+++ b/crates/gdsr-viewer/src/drawable.rs
@@ -146,7 +146,7 @@ fn reference_bbox_from_source_bbox(
     result
 }
 
-fn reference_grid_count(reference: &gdsr::Reference) -> u64 {
+pub fn reference_grid_count(reference: &gdsr::Reference) -> u64 {
     let grid = reference.grid();
     u64::from(grid.columns()) * u64::from(grid.rows())
 }
@@ -163,14 +163,15 @@ fn reference_screen_size(bbox: WorldBBox, ctx: &DrawContext) -> (f32, f32, Rect)
     (sw, sh, Rect::from_two_pos(s_min, s_max))
 }
 
-fn reference_instance_bbox(
+pub fn reference_instance_bbox(
     reference: &gdsr::Reference,
-    ctx: &mut DrawContext,
+    library: Option<&Library>,
+    cell_bbox_cache: &mut HashMap<String, Option<WorldBBox>>,
 ) -> Option<WorldBBox> {
     if reference.instance().as_cell().is_some() {
-        let lib = ctx.library?;
+        let lib = library?;
         let mut visiting = HashSet::new();
-        reference_world_bbox(reference, lib, &mut visiting, ctx.cell_bbox_cache)
+        reference_world_bbox(reference, lib, &mut visiting, cell_bbox_cache)
     } else if let Some(element) = reference.instance().as_element() {
         let source_bbox = element.as_ref().as_ref().world_bbox()?;
         reference_bbox_from_source_bbox(reference, source_bbox)
@@ -226,6 +227,7 @@ pub struct DrawContext<'a> {
     pub reference_depth: u32,
     pub reference_stack: Vec<String>,
     pub cell_bbox_cache: &'a mut HashMap<String, Option<WorldBBox>>,
+    pub cell_complexity_cache: &'a mut HashMap<(String, u32), u64>,
 }
 
 /// Fill alpha for normal and highlighted elements.
@@ -993,25 +995,121 @@ impl Drawable for gdsr::Node {
     }
 }
 
+fn reference_draw_units(reference: &gdsr::Reference, ctx: &mut DrawContext) -> u64 {
+    let mut visiting = HashSet::new();
+    reference_draw_units_for_depth(
+        reference,
+        ctx.library,
+        ctx.reference_depth,
+        ctx.cell_complexity_cache,
+        &mut visiting,
+    )
+}
+
+pub fn reference_draw_units_for_depth(
+    reference: &gdsr::Reference,
+    library: Option<&Library>,
+    depth: u32,
+    cache: &mut HashMap<(String, u32), u64>,
+    visiting: &mut HashSet<String>,
+) -> u64 {
+    let grid_count = reference_grid_count(reference);
+    if grid_count == 0 {
+        return 0;
+    }
+
+    let source_count = if depth <= 1 {
+        1
+    } else if let Some(cell_name) = reference.instance().as_cell() {
+        library
+            .and_then(|lib| cell_draw_units(cell_name, lib, depth - 1, cache, visiting))
+            .unwrap_or(1)
+    } else if let Some(element) = reference.instance().as_element() {
+        element_draw_units(
+            element.as_ref().as_ref(),
+            library,
+            depth - 1,
+            cache,
+            visiting,
+        )
+    } else {
+        1
+    };
+
+    grid_count.saturating_mul(source_count)
+}
+
+fn cell_draw_units(
+    cell_name: &str,
+    library: &Library,
+    depth: u32,
+    cache: &mut HashMap<(String, u32), u64>,
+    visiting: &mut HashSet<String>,
+) -> Option<u64> {
+    let key = (cell_name.to_owned(), depth);
+    if let Some(count) = cache.get(&key) {
+        return Some(*count);
+    }
+    let cell = library.get_cell(cell_name)?;
+    if !visiting.insert(cell_name.to_owned()) {
+        return Some(1);
+    }
+
+    let mut count = 0_u64;
+    for element in cell.iter_elements() {
+        count = count.saturating_add(element_draw_units(
+            element,
+            Some(library),
+            depth,
+            cache,
+            visiting,
+        ));
+    }
+    visiting.remove(cell_name);
+
+    let count = count.max(1);
+    cache.insert(key, count);
+    Some(count)
+}
+
+fn element_draw_units(
+    element: &Element,
+    library: Option<&Library>,
+    depth: u32,
+    cache: &mut HashMap<(String, u32), u64>,
+    visiting: &mut HashSet<String>,
+) -> u64 {
+    match element {
+        Element::Reference(reference) => {
+            reference_draw_units_for_depth(reference, library, depth, cache, visiting)
+        }
+        _ => 1,
+    }
+}
+
 fn should_draw_reference_bbox(
     reference: &gdsr::Reference,
     bbox: WorldBBox,
-    ctx: &DrawContext,
+    ctx: &mut DrawContext,
 ) -> bool {
     let (sw, sh, _) = reference_screen_size(bbox, ctx);
+    let grid_count = reference_grid_count(reference);
+    let draw_unit_count = reference_draw_units(reference, ctx);
     should_collapse_reference(
         sw,
         sh,
-        reference_grid_count(reference),
+        grid_count,
+        draw_unit_count,
         ctx.reference_depth,
         ctx.show_ref_bbox,
     )
 }
 
-fn should_collapse_reference(
+pub fn should_collapse_reference(
     width_px: f32,
     height_px: f32,
-    instance_count: u64,
+    grid_count: u64,
+    draw_unit_count: u64,
     reference_depth: u32,
     force_bbox: bool,
 ) -> bool {
@@ -1023,15 +1121,15 @@ fn should_collapse_reference(
         return true;
     }
 
-    if instance_count > REF_MAX_GRID_EXPANSION {
+    if grid_count > REF_MAX_GRID_EXPANSION {
         return true;
     }
-    if instance_count < REF_DENSE_GRID_MIN_INSTANCES {
+    if draw_unit_count < REF_DENSE_GRID_MIN_INSTANCES {
         return false;
     }
 
     let area_px = width_px * height_px;
-    area_px.is_finite() && area_px / instance_count as f32 <= REF_LOAD_MIN_AVG_INSTANCE_AREA_PX
+    area_px.is_finite() && area_px / draw_unit_count as f32 <= REF_LOAD_MIN_AVG_INSTANCE_AREA_PX
 }
 
 fn draw_ref_bbox(reference: &gdsr::Reference, bbox: WorldBBox, ctx: &mut DrawContext) {
@@ -1097,7 +1195,7 @@ impl Drawable for gdsr::Reference {
     }
 
     fn draw(&self, ctx: &mut DrawContext) {
-        let Some(bbox) = reference_instance_bbox(self, ctx) else {
+        let Some(bbox) = reference_instance_bbox(self, ctx.library, ctx.cell_bbox_cache) else {
             return;
         };
         if !bbox.overlaps(ctx.visible) {
@@ -1200,6 +1298,7 @@ pub fn draw_highlight(
     let mut extra_shapes = Vec::new();
     let mut screen_pts_buf = Vec::new();
     let mut cell_bbox_cache = HashMap::new();
+    let mut cell_complexity_cache = HashMap::new();
     let mut ctx = DrawContext {
         painter,
         layer_meshes: &mut layer_meshes,
@@ -1217,6 +1316,7 @@ pub fn draw_highlight(
         reference_depth: u32::MAX,
         reference_stack: Vec::new(),
         cell_bbox_cache: &mut cell_bbox_cache,
+        cell_complexity_cache: &mut cell_complexity_cache,
     };
     element.draw(&mut ctx);
     for (_, mesh) in layer_meshes {
@@ -1427,12 +1527,12 @@ mod tests {
 
     #[test]
     fn reference_load_collapses_at_depth_limit() {
-        assert!(should_collapse_reference(400.0, 400.0, 1, 1, false));
+        assert!(should_collapse_reference(400.0, 400.0, 1, 1, 1, false));
     }
 
     #[test]
     fn reference_load_collapses_tiny_references() {
-        assert!(should_collapse_reference(12.0, 20.0, 1, 2, false));
+        assert!(should_collapse_reference(12.0, 20.0, 1, 1, 2, false));
     }
 
     #[test]
@@ -1441,6 +1541,7 @@ mod tests {
             10_000.0,
             10_000.0,
             REF_MAX_GRID_EXPANSION + 1,
+            REF_MAX_GRID_EXPANSION + 1,
             2,
             false,
         ));
@@ -1448,12 +1549,44 @@ mod tests {
 
     #[test]
     fn reference_load_draws_sparse_large_references() {
-        assert!(!should_collapse_reference(400.0, 400.0, 100, 2, false));
+        assert!(!should_collapse_reference(400.0, 400.0, 1, 100, 2, false));
     }
 
     #[test]
     fn reference_load_collapses_dense_screen_area() {
-        assert!(should_collapse_reference(400.0, 200.0, 10_000, 2, false));
+        assert!(should_collapse_reference(400.0, 200.0, 1, 10_000, 2, false,));
+    }
+
+    #[test]
+    fn reference_draw_units_include_cell_contents_and_grid() {
+        let mut leaf = gdsr::Cell::new("leaf");
+        leaf.add(polygon(vec![(0, 0), (10, 0), (10, 10)], 1, 0));
+        leaf.add(polygon(vec![(20, 0), (30, 0), (30, 10)], 1, 0));
+        leaf.add(polygon(vec![(40, 0), (50, 0), (50, 10)], 1, 0));
+
+        let mut library = gdsr::Library::new("lib");
+        library.add_cell(leaf);
+
+        let reference = gdsr::Reference::new("leaf").with_grid(
+            gdsr::Grid::default()
+                .with_columns(2)
+                .with_rows(3)
+                .with_spacing_x(Some(gdsr::Point::default_integer(20, 0)))
+                .with_spacing_y(Some(gdsr::Point::default_integer(0, 20))),
+        );
+        let mut cache = HashMap::new();
+        let mut visiting = HashSet::new();
+
+        assert_eq!(
+            reference_draw_units_for_depth(
+                &reference,
+                Some(&library),
+                2,
+                &mut cache,
+                &mut visiting,
+            ),
+            18,
+        );
     }
 
     #[test]

--- a/crates/gdsr-viewer/src/viewport/mod.rs
+++ b/crates/gdsr-viewer/src/viewport/mod.rs
@@ -339,6 +339,7 @@ impl Viewport {
         let mut extra_shapes = Vec::new();
         let mut screen_pts_buf = Vec::new();
         let mut cell_bbox_cache = HashMap::new();
+        let mut cell_complexity_cache = HashMap::new();
         let mut ctx = DrawContext {
             painter: &painter,
             layer_meshes: &mut layer_meshes,
@@ -356,6 +357,7 @@ impl Viewport {
             reference_depth: render_depth,
             reference_stack: selected_cell.map_or_else(Vec::new, |name| vec![name.to_string()]),
             cell_bbox_cache: &mut cell_bbox_cache,
+            cell_complexity_cache: &mut cell_complexity_cache,
         };
 
         if let Some(grid) = spatial_grid {


### PR DESCRIPTION
## Summary

Add hierarchy-aware level-of-detail handling to the Bevy scene builder and share reference-complexity data with the current renderer to bound dense-layout expansion.

## Test Plan

Ran nextest, strict workspace Clippy, and `uvx prek run -a`.