### PR TITLE
Add filtered GDS reader

### DIFF
--- a/crates/gdsr/src/io/read/mod.rs
+++ b/crates/gdsr/src/io/read/mod.rs
@@ -15,6 +15,19 @@ pub fn from_gds<P: AsRef<std::path::Path>>(
     file_name: P,
     units: Option<f64>,
 ) -> Result<Library, GdsError> {
+    from_gds_filtered(file_name, units, |_, _| true)
+}
+
+#[allow(clippy::too_many_lines)]
+pub fn from_gds_filtered<P, F>(
+    file_name: P,
+    units: Option<f64>,
+    layer_filter: F,
+) -> Result<Library, GdsError>
+where
+    P: AsRef<std::path::Path>,
+    F: Fn(Layer, DataType) -> bool,
+{
     let mut library = Library::new("Library");
 
     let file = File::open(file_name)?;
@@ -108,6 +121,13 @@ pub fn from_gds<P: AsRef<std::path::Path>>(
                         }
                     }
                 }
+                GDSRecord::TextType => {
+                    if let GDSRecordData::I16(data_type) = data {
+                        if let Some(text) = &mut text {
+                            text.datatype = DataType::new(data_type[0] as u16);
+                        }
+                    }
+                }
                 GDSRecord::BoxType => {
                     if let GDSRecordData::I16(data_type) = data {
                         if let Some(gds_box) = &mut gds_box {
@@ -133,6 +153,18 @@ pub fn from_gds<P: AsRef<std::path::Path>>(
                 }
                 GDSRecord::XY => {
                     if let GDSRecordData::I32(xy) = data {
+                        if !should_parse_xy(
+                            &layer_filter,
+                            polygon.as_ref(),
+                            gds_box.as_ref(),
+                            node.as_ref(),
+                            path.as_ref(),
+                            text.as_ref(),
+                            reference.as_ref(),
+                        ) {
+                            continue;
+                        }
+
                         let points = get_points_from_i32_vec(&xy, db_units)
                             .iter()
                             .map(|p| {
@@ -200,17 +232,27 @@ pub fn from_gds<P: AsRef<std::path::Path>>(
                 GDSRecord::EndEl => {
                     if let Some(cell) = &mut cell {
                         if let Some(polygon) = polygon.take() {
-                            cell.add(polygon);
+                            if layer_filter(polygon.layer, polygon.data_type) {
+                                cell.add(polygon);
+                            }
                         } else if let Some(gds_box) = gds_box.take() {
-                            cell.add(gds_box);
+                            if layer_filter(gds_box.layer, gds_box.box_type) {
+                                cell.add(gds_box);
+                            }
                         } else if let Some(node) = node.take() {
-                            cell.add(node);
+                            if layer_filter(node.layer, node.node_type) {
+                                cell.add(node);
+                            }
                         } else if let Some(path) = path.take() {
-                            cell.add(path);
+                            if layer_filter(path.layer, path.data_type) {
+                                cell.add(path);
+                            }
                         } else if let Some(reference) = reference.take() {
                             cell.add(reference);
                         } else if let Some(text) = text.take() {
-                            cell.add(text);
+                            if layer_filter(text.layer, text.datatype) {
+                                cell.add(text);
+                            }
                         }
                     }
                     polygon = None;
@@ -316,6 +358,39 @@ pub fn from_gds<P: AsRef<std::path::Path>>(
     }
 
     Ok(library)
+}
+
+fn should_parse_xy<F>(
+    layer_filter: &F,
+    polygon: Option<&Polygon>,
+    gds_box: Option<&GdsBox>,
+    node: Option<&Node>,
+    path: Option<&Path>,
+    text: Option<&Text>,
+    reference: Option<&Reference>,
+) -> bool
+where
+    F: Fn(Layer, DataType) -> bool,
+{
+    if reference.is_some() {
+        return true;
+    }
+    if let Some(polygon) = polygon {
+        return layer_filter(polygon.layer, polygon.data_type);
+    }
+    if let Some(gds_box) = gds_box {
+        return layer_filter(gds_box.layer, gds_box.box_type);
+    }
+    if let Some(node) = node {
+        return layer_filter(node.layer, node.node_type);
+    }
+    if let Some(path) = path {
+        return layer_filter(path.layer, path.data_type);
+    }
+    if let Some(text) = text {
+        return layer_filter(text.layer, text.datatype);
+    }
+    true
 }
 
 pub struct RecordReader<R: Read> {

--- a/crates/gdsr/src/io/write/mod.rs
+++ b/crates/gdsr/src/io/write/mod.rs
@@ -432,7 +432,7 @@ pub fn write_text(text: &Text, db_units: f64) -> Result<Vec<u8>, GdsError> {
         &mut buffer,
         &record_header(GDSRecord::TextType, GDSDataType::TwoByteSignedInteger, 1),
     )?;
-    write_u16_array(&mut buffer, &[0])?;
+    write_u16_array(&mut buffer, &[text.data_type().value()])?;
     write_u16_array(
         &mut buffer,
         &record_header(GDSRecord::Presentation, GDSDataType::BitArray, 1),

--- a/crates/gdsr/src/library.rs
+++ b/crates/gdsr/src/library.rs
@@ -4,10 +4,10 @@ use std::io::Write;
 
 use crate::cell::Cell;
 use crate::error::GdsError;
-use crate::io::read::from_gds;
+use crate::io::read::{from_gds, from_gds_filtered};
 use crate::io::write::{GdsFileWriter, GdsWriter};
 use crate::types::LayerMapping;
-use crate::{Element, Instance};
+use crate::{DataType, Element, Instance, Layer};
 
 /// A dangling reference: a cell contains a reference to a target that doesn't exist.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -431,6 +431,23 @@ impl Library {
     ) -> Result<Self, GdsError> {
         from_gds(file_name, units)
     }
+
+    /// Read a library from a GDS file, keeping only elements whose layer/data type
+    /// pair matches the given filter.
+    ///
+    /// References are preserved because they do not carry layer/data type metadata.
+    /// The given units behave the same way as [`Self::read_file`].
+    pub fn read_file_filtered<P, F>(
+        file_name: P,
+        units: Option<f64>,
+        layer_filter: F,
+    ) -> Result<Self, GdsError>
+    where
+        P: AsRef<std::path::Path>,
+        F: Fn(Layer, DataType) -> bool,
+    {
+        from_gds_filtered(file_name, units, layer_filter)
+    }
 }
 
 impl std::fmt::Display for Library {
@@ -441,8 +458,11 @@ impl std::fmt::Display for Library {
 
 #[cfg(test)]
 mod tests {
-    use crate::elements::{Polygon, Reference};
-    use crate::{DataType, Layer, Point};
+    use crate::elements::{Path, Polygon, Reference, Text};
+    use crate::{
+        DEFAULT_INTEGER_UNITS, DataType, HorizontalPresentation, Layer, Point, Radians, Unit,
+        VerticalPresentation,
+    };
 
     use super::*;
 
@@ -465,6 +485,100 @@ mod tests {
         assert_eq!(library.cells.len(), 1);
         assert!(library.cells.contains_key("test_cell"));
         assert_eq!(library.cells.get("test_cell"), Some(&cell));
+    }
+
+    #[test]
+    fn read_file_filtered_keeps_only_matching_layer_data_type() {
+        let dir = tempfile::tempdir().expect("temporary directory should be created");
+        let path = dir.path().join("filtered.gds");
+
+        let mut cell = Cell::new("top");
+        cell.add(Polygon::new(
+            [
+                Point::integer(0, 0, DEFAULT_INTEGER_UNITS),
+                Point::integer(10, 0, DEFAULT_INTEGER_UNITS),
+                Point::integer(10, 10, DEFAULT_INTEGER_UNITS),
+                Point::integer(0, 10, DEFAULT_INTEGER_UNITS),
+            ],
+            Layer::new(1),
+            DataType::new(0),
+        ));
+        cell.add(Path::new(
+            [
+                Point::integer(20, 0, DEFAULT_INTEGER_UNITS),
+                Point::integer(30, 0, DEFAULT_INTEGER_UNITS),
+            ],
+            Layer::new(2),
+            DataType::new(0),
+            None,
+            Some(Unit::float(1.0, DEFAULT_INTEGER_UNITS)),
+            None,
+            None,
+        ));
+
+        let mut library = Library::new("test");
+        library.add_cell(cell);
+        library
+            .write_file(&path, DEFAULT_INTEGER_UNITS, DEFAULT_INTEGER_UNITS)
+            .expect("library should be writable");
+
+        let read =
+            Library::read_file_filtered(&path, Some(DEFAULT_INTEGER_UNITS), |layer, data| {
+                layer == Layer::new(1) && data == DataType::new(0)
+            })
+            .expect("filtered library should be readable");
+        let top = read.get_cell("top").expect("top cell should exist");
+
+        assert_eq!(top.elements().len(), 1);
+        assert!(matches!(top.elements()[0], Element::Polygon(_)));
+    }
+
+    #[test]
+    fn read_file_filtered_uses_text_type() {
+        let dir = tempfile::tempdir().expect("temporary directory should be created");
+        let path = dir.path().join("filtered_text.gds");
+
+        let mut cell = Cell::new("top");
+        cell.add(Polygon::new(
+            [
+                Point::integer(0, 0, DEFAULT_INTEGER_UNITS),
+                Point::integer(10, 0, DEFAULT_INTEGER_UNITS),
+                Point::integer(10, 10, DEFAULT_INTEGER_UNITS),
+                Point::integer(0, 10, DEFAULT_INTEGER_UNITS),
+            ],
+            Layer::new(3),
+            DataType::new(0),
+        ));
+        cell.add(Text::new(
+            "label",
+            Point::integer(20, 0, DEFAULT_INTEGER_UNITS),
+            Layer::new(3),
+            DataType::new(7),
+            1.0,
+            Radians::new(0.0),
+            false,
+            VerticalPresentation::default(),
+            HorizontalPresentation::default(),
+        ));
+
+        let mut library = Library::new("test");
+        library.add_cell(cell);
+        library
+            .write_file(&path, DEFAULT_INTEGER_UNITS, DEFAULT_INTEGER_UNITS)
+            .expect("library should be writable");
+
+        let read =
+            Library::read_file_filtered(&path, Some(DEFAULT_INTEGER_UNITS), |layer, data| {
+                layer == Layer::new(3) && data == DataType::new(7)
+            })
+            .expect("filtered library should be readable");
+        let top = read.get_cell("top").expect("top cell should exist");
+
+        assert_eq!(top.elements().len(), 1);
+        let Element::Text(text) = &top.elements()[0] else {
+            panic!("filtered element should be text");
+        };
+        assert_eq!(text.data_type(), DataType::new(7));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Add filtered GDS reading by layer and datatype while preserving references and correctly handling text datatypes. Closes #121.

## Test Plan

Ran nextest, strict workspace Clippy, and `uvx prek run -a`.