### PR TITLE
Use Bevy for bounded viewer rendering

### DIFF
--- a/.github/actions/setup-linux-deps/action.yml
+++ b/.github/actions/setup-linux-deps/action.yml
@@ -9,4 +9,4 @@ runs:
       shell: bash
       run: |
         sudo apt-get update
-        sudo apt-get install -y libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libssl-dev
+        sudo apt-get install -y libwayland-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libssl-dev

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,8 +36,9 @@ The main crates:
 
 - `gdsr` - the library crate. Contains the GDSII data model, binary reader and
   writer, units, element types, and geometry helpers.
-- `gdsr-viewer` - the `egui`/`eframe` viewer binary. Loads GDSII libraries,
-  renders cells, and provides the interactive inspection workflow.
+- `gdsr-viewer` - the Bevy-rendered viewer binary with an `egui` interface.
+  Loads GDSII libraries, renders cells, and provides the interactive inspection
+  workflow.
 
 Infrastructure and tooling:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
 
 [[package]]
+name = "accesskit"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf203f9d3bd8f29f98833d1fbef628df18f759248a547e7e01cfbf63cda36a99"
+
+[[package]]
+name = "accesskit_consumer"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db81010a6895d8707f9072e6ce98070579b43b717193d2614014abd5cb17dd43"
+dependencies = [
+ "accesskit",
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "accesskit_macos"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0089e5c0ac0ca281e13ea374773898d9354cc28d15af9f0f7394d44a495b575"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "hashbrown 0.15.5",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "accesskit_windows"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2d63dd5041e49c363d83f5419a896ecb074d309c414036f616dc0b04faca971"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "hashbrown 0.15.5",
+ "static_assertions",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "accesskit_winit"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8cfabe59d0eaca7412bfb1f70198dd31e3b0496fee7e15b066f9c36a1a140a0"
+dependencies = [
+ "accesskit",
+ "accesskit_macos",
+ "accesskit_windows",
+ "raw-window-handle",
+ "winit",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -196,6 +253,15 @@ name = "as-raw-xcb-connection"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
+
+[[package]]
+name = "ash"
+version = "0.38.0+1.3.281"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
+dependencies = [
+ "libloading",
+]
 
 [[package]]
 name = "ashpd"
@@ -412,16 +478,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "base64"
-version = "0.21.7"
+name = "bevy"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+checksum = "1fd310426290cec560221f9750c2f4484be4a8eeea7de3483c423329b465c40e"
+dependencies = [
+ "bevy_internal",
+]
+
+[[package]]
+name = "bevy_a11y"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e887b25c84f384ffe3278a17cf0e4b405eaa3c8fbc3db24d05d560a11780676d"
+dependencies = [
+ "accesskit",
+ "bevy_app",
+ "bevy_derive",
+ "bevy_ecs",
+ "bevy_reflect",
+]
+
+[[package]]
+name = "bevy_android"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8c58de772ac1148884112e8a456c4f127a94b95a0e42ab5b160b7a11895a241"
+dependencies = [
+ "android-activity",
+]
 
 [[package]]
 name = "bevy_app"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4491cc4c718ae76b4c6883df58b94cc88b32dcd894ea8d5b603c7c7da72ca967"
+checksum = "def9f41aa5bf9b9dec8beda307a332798609cffb9d44f71005e0cfb45164f2f6"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -442,22 +533,25 @@ dependencies = [
 
 [[package]]
 name = "bevy_asset"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f56111d9b88d8649f331a667d9d72163fb26bd09518ca16476d238653823db1e"
+checksum = "29f86fed15972b9fb1a3f7b092cf0390e67131caaedab15a2707c043e3a3c886"
 dependencies = [
  "async-broadcast",
+ "async-channel",
  "async-fs",
+ "async-io",
  "async-lock",
  "atomicow",
+ "bevy_android",
  "bevy_app",
  "bevy_asset_macros",
+ "bevy_diagnostic",
  "bevy_ecs",
  "bevy_platform",
  "bevy_reflect",
  "bevy_tasks",
  "bevy_utils",
- "bevy_window",
  "bitflags 2.11.0",
  "blake3",
  "crossbeam-channel",
@@ -467,8 +561,8 @@ dependencies = [
  "either",
  "futures-io",
  "futures-lite",
+ "futures-util",
  "js-sys",
- "parking_lot",
  "ron",
  "serde",
  "stackfuture",
@@ -482,9 +576,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_asset_macros"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4cca3e67c0ec760d8889d42293d987ce5da92eaf9c592bf5d503728a63b276d"
+checksum = "12cb8d948365b06561b43b7d709282e62a6abb756baac5d8e295206d5e156168"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -493,10 +587,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "bevy_color"
-version = "0.16.2"
+name = "bevy_camera"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c101cbe1e26b8d701eb77263b14346e2e0cbbd2a6e254b9b1aead814e5ca8d3"
+checksum = "37ed9eed054e14341852236d06a7244597b1ace39ff9ae023fbd188ffde88619"
+dependencies = [
+ "bevy_app",
+ "bevy_asset",
+ "bevy_color",
+ "bevy_derive",
+ "bevy_ecs",
+ "bevy_image",
+ "bevy_math",
+ "bevy_mesh",
+ "bevy_reflect",
+ "bevy_transform",
+ "bevy_utils",
+ "bevy_window",
+ "derive_more",
+ "downcast-rs 2.0.2",
+ "serde",
+ "smallvec",
+ "thiserror 2.0.18",
+ "wgpu-types",
+]
+
+[[package]]
+name = "bevy_color"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb41e8310a85811d14a4e75cfc2d6c07ac70661d6a4883509fc960f622970a8"
 dependencies = [
  "bevy_math",
  "bevy_reflect",
@@ -505,14 +625,44 @@ dependencies = [
  "encase",
  "serde",
  "thiserror 2.0.18",
- "wgpu-types 24.0.0",
+ "wgpu-types",
+]
+
+[[package]]
+name = "bevy_core_pipeline"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d0810e85c2436e50c67448d48a83bf0bb1b5849899619ae2c7ea817221e9172"
+dependencies = [
+ "bevy_app",
+ "bevy_asset",
+ "bevy_camera",
+ "bevy_color",
+ "bevy_derive",
+ "bevy_diagnostic",
+ "bevy_ecs",
+ "bevy_image",
+ "bevy_math",
+ "bevy_platform",
+ "bevy_reflect",
+ "bevy_render",
+ "bevy_shader",
+ "bevy_transform",
+ "bevy_utils",
+ "bevy_window",
+ "bitflags 2.11.0",
+ "nonmax",
+ "radsort",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
 name = "bevy_derive"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b837bf6c51806b10ebfa9edf1844ad80a3a0760d6c5fac4e90761df91a8901a"
+checksum = "318ee0532c3da93749859d18f89a889c638fbc56aabac4d866583df7b951d103"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -520,10 +670,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "bevy_ecs"
-version = "0.16.1"
+name = "bevy_diagnostic"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c2bf6521aae57a0ec3487c4bfb59e36c4a378e834b626a4bea6a885af2fdfe7"
+checksum = "ec8543a0f7afd56d3499ba80ffab6ef0bad12f93c2d2ca9aa7b1f1b8816c3980"
+dependencies = [
+ "atomic-waker",
+ "bevy_app",
+ "bevy_ecs",
+ "bevy_platform",
+ "bevy_tasks",
+ "bevy_time",
+ "const-fnv1a-hash",
+ "log",
+ "serde",
+]
+
+[[package]]
+name = "bevy_ecs"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9cf7a3ee41342dd7b5a5d82e200d0e8efb933169247fce853b4ad633d51e87d"
 dependencies = [
  "arrayvec",
  "bevy_ecs_macros",
@@ -536,12 +703,12 @@ dependencies = [
  "bumpalo",
  "concurrent-queue",
  "derive_more",
- "disqualified",
  "fixedbitset",
  "indexmap",
  "log",
  "nonmax",
  "serde",
+ "slotmap",
  "smallvec",
  "thiserror 2.0.18",
  "variadics_please",
@@ -549,9 +716,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_ecs_macros"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38748d6f3339175c582d751f410fb60a93baf2286c3deb7efebb0878dce7f413"
+checksum = "908baf585e2ea16bd53ef0da57b69580478af0059d2dbdb4369991ac9794b618"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -560,14 +727,124 @@ dependencies = [
 ]
 
 [[package]]
-name = "bevy_image"
-version = "0.16.1"
+name = "bevy_egui"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e6e900cfecadbc3149953169e36b9e26f922ed8b002d62339d8a9dc6129328"
+checksum = "8d0a7e4806f3f242326d2c6157531c36d710f3bf320ebc0a1678e44635ed0eac"
+dependencies = [
+ "arboard",
+ "bevy_app",
+ "bevy_asset",
+ "bevy_camera",
+ "bevy_color",
+ "bevy_core_pipeline",
+ "bevy_derive",
+ "bevy_ecs",
+ "bevy_image",
+ "bevy_input",
+ "bevy_log",
+ "bevy_math",
+ "bevy_mesh",
+ "bevy_platform",
+ "bevy_reflect",
+ "bevy_render",
+ "bevy_shader",
+ "bevy_time",
+ "bevy_transform",
+ "bevy_utils",
+ "bevy_window",
+ "bevy_winit",
+ "bytemuck",
+ "crossbeam-channel",
+ "egui",
+ "encase",
+ "getrandom 0.3.4",
+ "image",
+ "itertools 0.14.0",
+ "js-sys",
+ "thread_local",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webbrowser",
+ "wgpu-types",
+ "winit",
+]
+
+[[package]]
+name = "bevy_encase_derive"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fee46eeddcbc00a805ae00ffa973f224671fc5cf0fe1a796963804faeade90"
+dependencies = [
+ "bevy_macro_utils",
+ "encase_derive_impl",
+]
+
+[[package]]
+name = "bevy_gizmos"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aaff0dd5f405c83d290c5cd591835f1ae8009894947ab19dadcb323062bd7e7"
+dependencies = [
+ "bevy_app",
+ "bevy_asset",
+ "bevy_camera",
+ "bevy_color",
+ "bevy_ecs",
+ "bevy_gizmos_macros",
+ "bevy_math",
+ "bevy_reflect",
+ "bevy_time",
+ "bevy_transform",
+ "bevy_utils",
+]
+
+[[package]]
+name = "bevy_gizmos_macros"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6960ea308d7e94adcac5c712553ff86614bba6b663511f3f3812f6bec028b51e"
+dependencies = [
+ "bevy_macro_utils",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "bevy_gizmos_render"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a8d18c089102de4c5e9326023ad96ba618a6961029f8102a33640b966883237"
+dependencies = [
+ "bevy_app",
+ "bevy_asset",
+ "bevy_camera",
+ "bevy_core_pipeline",
+ "bevy_ecs",
+ "bevy_gizmos",
+ "bevy_image",
+ "bevy_math",
+ "bevy_mesh",
+ "bevy_render",
+ "bevy_shader",
+ "bevy_sprite_render",
+ "bevy_transform",
+ "bevy_utils",
+ "bytemuck",
+ "tracing",
+]
+
+[[package]]
+name = "bevy_image"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a71daf9b2afdd032c2b1122d1d501f99126218cb3e9983b3604ec381daa35f22"
 dependencies = [
  "bevy_app",
  "bevy_asset",
  "bevy_color",
+ "bevy_ecs",
  "bevy_math",
  "bevy_platform",
  "bevy_reflect",
@@ -579,38 +856,96 @@ dependencies = [
  "half",
  "image",
  "rectangle-pack",
+ "ruzstd",
  "serde",
  "thiserror 2.0.18",
  "tracing",
- "wgpu-types 24.0.0",
+ "wgpu-types",
 ]
 
 [[package]]
 name = "bevy_input"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d6b6516433f6f7d680f648d04eb1866bb3927a1782d52f74831b62042f3cd1"
+checksum = "dbc8ffbd02df34dfc52faf420a5263985973765e228043adf542fd0d790a6b21"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
  "bevy_math",
  "bevy_platform",
  "bevy_reflect",
- "bevy_utils",
  "derive_more",
+ "log",
+ "smol_str",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "bevy_input_focus"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d48a5bceccb9157549a39ab3de4017f5368b65db6471605e9a3f1c19d91bbc"
+dependencies = [
+ "bevy_app",
+ "bevy_ecs",
+ "bevy_input",
+ "bevy_math",
+ "bevy_reflect",
+ "bevy_window",
  "log",
  "thiserror 2.0.18",
 ]
 
 [[package]]
-name = "bevy_log"
-version = "0.16.1"
+name = "bevy_internal"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a61ee8aef17a974f5ca481dcedf0c2bd52670e231d4c4bc9ddef58328865f9"
+checksum = "6a11df62e49897def470471551c02f13c6fb488e55dddb5ab7ef098132e07754"
+dependencies = [
+ "bevy_a11y",
+ "bevy_android",
+ "bevy_app",
+ "bevy_asset",
+ "bevy_camera",
+ "bevy_color",
+ "bevy_core_pipeline",
+ "bevy_derive",
+ "bevy_diagnostic",
+ "bevy_ecs",
+ "bevy_gizmos_render",
+ "bevy_image",
+ "bevy_input",
+ "bevy_input_focus",
+ "bevy_log",
+ "bevy_math",
+ "bevy_mesh",
+ "bevy_platform",
+ "bevy_ptr",
+ "bevy_reflect",
+ "bevy_render",
+ "bevy_shader",
+ "bevy_sprite",
+ "bevy_sprite_render",
+ "bevy_state",
+ "bevy_tasks",
+ "bevy_text",
+ "bevy_time",
+ "bevy_transform",
+ "bevy_utils",
+ "bevy_window",
+ "bevy_winit",
+]
+
+[[package]]
+name = "bevy_log"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2aac1187f83a1ab2eae887564f7fb14b4abb3fbe8b2267a6426663463923120"
 dependencies = [
  "android_log-sys",
  "bevy_app",
  "bevy_ecs",
+ "bevy_platform",
  "bevy_utils",
  "tracing",
  "tracing-log",
@@ -621,99 +956,90 @@ dependencies = [
 
 [[package]]
 name = "bevy_macro_utils"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052eeebcb8e7e072beea5031b227d9a290f8a7fbbb947573ab6ec81df0fb94be"
+checksum = "3b147843b81a7ec548876ff97fa7bfdc646ef2567cb465566259237b39664438"
 dependencies = [
- "parking_lot",
  "proc-macro2",
  "quote",
  "syn",
- "toml_edit 0.22.27",
+ "toml_edit 0.23.10+spec-1.0.0",
 ]
 
 [[package]]
 name = "bevy_math"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68553e0090fe9c3ba066c65629f636bd58e4ebd9444fdba097b91af6cd3e243f"
+checksum = "e931fa969f89c83498b22c97432383afe90e90fd1a5e04fa07be8da4d3bcac84"
 dependencies = [
  "approx",
+ "arrayvec",
  "bevy_reflect",
  "derive_more",
  "glam",
  "itertools 0.14.0",
- "rand 0.8.7",
+ "libm",
+ "rand 0.9.2",
  "rand_distr",
  "serde",
- "smallvec",
  "thiserror 2.0.18",
  "variadics_please",
 ]
 
 [[package]]
 name = "bevy_mesh"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b10399c7027001edbc0406d7d0198596b1f07206c1aae715274106ba5bdcac40"
+checksum = "288f590c8173d4cca3cae5f2ba579accd5ed1a35dd3fab338f427eb39d55f05e"
 dependencies = [
+ "bevy_app",
  "bevy_asset",
  "bevy_derive",
  "bevy_ecs",
- "bevy_image",
  "bevy_math",
- "bevy_mikktspace",
  "bevy_platform",
  "bevy_reflect",
  "bevy_transform",
- "bevy_utils",
  "bitflags 2.11.0",
  "bytemuck",
+ "derive_more",
  "hexasphere",
- "serde",
  "thiserror 2.0.18",
  "tracing",
- "wgpu-types 24.0.0",
-]
-
-[[package]]
-name = "bevy_mikktspace"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb60c753b968a2de0fd279b76a3d19517695e771edb4c23575c7f92156315de"
-dependencies = [
- "glam",
+ "wgpu-types",
 ]
 
 [[package]]
 name = "bevy_platform"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7573dc824a1b08b4c93fdbe421c53e1e8188e9ca1dd74a414455fe571facb47"
+checksum = "ec6b36504169b644acd26a5469fd8d371aa6f1d73ee5c01b1b1181ae1cefbf9b"
 dependencies = [
- "cfg-if",
  "critical-section",
- "foldhash 0.1.5",
- "getrandom 0.2.17",
- "hashbrown 0.15.5",
+ "foldhash 0.2.0",
+ "futures-channel",
+ "hashbrown 0.16.1",
+ "js-sys",
  "portable-atomic",
  "portable-atomic-util",
  "serde",
  "spin",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
  "web-time",
 ]
 
 [[package]]
 name = "bevy_ptr"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df7370d0e46b60e071917711d0860721f5347bc958bf325975ae6913a5dfcf01"
+checksum = "c7a9329e8dc4e01ced480eeec4902e6d7cb56e56ec37f6fbc4323e5c937290a7"
 
 [[package]]
 name = "bevy_reflect"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daeb91a63a1a4df00aa58da8cc4ddbd4b9f16ab8bb647c5553eb156ce36fa8c2"
+checksum = "d1dfeb67a9fe4f59003a84f5f99ba6302141c70e926601cbc6abfd4a1eea9ca9"
 dependencies = [
  "assert_type_match",
  "bevy_platform",
@@ -724,24 +1050,27 @@ dependencies = [
  "disqualified",
  "downcast-rs 2.0.2",
  "erased-serde",
- "foldhash 0.1.5",
+ "foldhash 0.2.0",
  "glam",
+ "indexmap",
+ "inventory",
  "serde",
  "smallvec",
  "smol_str",
  "thiserror 2.0.18",
  "uuid",
  "variadics_please",
- "wgpu-types 24.0.0",
+ "wgpu-types",
 ]
 
 [[package]]
 name = "bevy_reflect_derive"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ddadc55fe16b45faaa54ab2f9cb00548013c74812e8b018aa172387103cce6"
+checksum = "475f68c93e9cd5f17e9167635c8533a4f388f12d38245a202359e4c2721d87ba"
 dependencies = [
  "bevy_macro_utils",
+ "indexmap",
  "proc-macro2",
  "quote",
  "syn",
@@ -749,30 +1078,232 @@ dependencies = [
 ]
 
 [[package]]
-name = "bevy_tasks"
-version = "0.16.1"
+name = "bevy_render"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b674242641cab680688fc3b850243b351c1af49d4f3417a576debd6cca8dcf5"
+checksum = "243523e33fe5dfcebc4240b1eb2fc16e855c5d4c0ea6a8393910740956770f44"
 dependencies = [
+ "async-channel",
+ "bevy_app",
+ "bevy_asset",
+ "bevy_camera",
+ "bevy_color",
+ "bevy_derive",
+ "bevy_diagnostic",
+ "bevy_ecs",
+ "bevy_encase_derive",
+ "bevy_image",
+ "bevy_math",
+ "bevy_mesh",
+ "bevy_platform",
+ "bevy_reflect",
+ "bevy_render_macros",
+ "bevy_shader",
+ "bevy_tasks",
+ "bevy_time",
+ "bevy_transform",
+ "bevy_utils",
+ "bevy_window",
+ "bitflags 2.11.0",
+ "bytemuck",
+ "derive_more",
+ "downcast-rs 2.0.2",
+ "encase",
+ "fixedbitset",
+ "glam",
+ "image",
+ "indexmap",
+ "js-sys",
+ "naga",
+ "nonmax",
+ "offset-allocator",
+ "send_wrapper",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tracing",
+ "variadics_please",
+ "wasm-bindgen",
+ "web-sys",
+ "wgpu",
+]
+
+[[package]]
+name = "bevy_render_macros"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b6325e9c495a71270446784611e8d7f446f927eac8506c4c099fd10cb4c3ed"
+dependencies = [
+ "bevy_macro_utils",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "bevy_shader"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eea95f0273c32be13d6a0b799a93bc256ad7830759ede595c404d5234302da2"
+dependencies = [
+ "bevy_asset",
+ "bevy_platform",
+ "bevy_reflect",
+ "naga",
+ "naga_oil",
+ "serde",
+ "thiserror 2.0.18",
+ "tracing",
+ "wgpu-types",
+]
+
+[[package]]
+name = "bevy_sprite"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96ec5bc0cbdee551b610a46f41d30374bbe42b8951ffc676253c6243ab2b9395"
+dependencies = [
+ "bevy_app",
+ "bevy_asset",
+ "bevy_camera",
+ "bevy_color",
+ "bevy_derive",
+ "bevy_ecs",
+ "bevy_image",
+ "bevy_math",
+ "bevy_mesh",
+ "bevy_reflect",
+ "bevy_text",
+ "bevy_transform",
+ "bevy_window",
+ "radsort",
+ "tracing",
+ "wgpu-types",
+]
+
+[[package]]
+name = "bevy_sprite_render"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b82cb08905e7ddcea2694a95f757ae7f1fd01e6a7304076bad595d2158e4bfe0"
+dependencies = [
+ "bevy_app",
+ "bevy_asset",
+ "bevy_camera",
+ "bevy_color",
+ "bevy_core_pipeline",
+ "bevy_derive",
+ "bevy_ecs",
+ "bevy_image",
+ "bevy_math",
+ "bevy_mesh",
+ "bevy_platform",
+ "bevy_reflect",
+ "bevy_render",
+ "bevy_shader",
+ "bevy_sprite",
+ "bevy_text",
+ "bevy_transform",
+ "bevy_utils",
+ "bitflags 2.11.0",
+ "bytemuck",
+ "derive_more",
+ "fixedbitset",
+ "nonmax",
+ "tracing",
+]
+
+[[package]]
+name = "bevy_state"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae0682968e97d29c1eccc8c6bb6283f2678d362779bc03f1bb990967059473b"
+dependencies = [
+ "bevy_app",
+ "bevy_ecs",
+ "bevy_platform",
+ "bevy_reflect",
+ "bevy_state_macros",
+ "bevy_utils",
+ "log",
+ "variadics_please",
+]
+
+[[package]]
+name = "bevy_state_macros"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73d32f90f9cfcef5a44401db7ce206770daaa1707b0fb95eb7a96a6933f54f1b"
+dependencies = [
+ "bevy_macro_utils",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "bevy_tasks"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384eb04d80aa38664d69988fd30cbbe03e937ecb65c66aa6abe60ce0bca826aa"
+dependencies = [
+ "async-channel",
  "async-executor",
  "async-task",
  "atomic-waker",
  "bevy_platform",
- "cfg-if",
+ "concurrent-queue",
  "crossbeam-queue",
  "derive_more",
- "futures-channel",
  "futures-lite",
  "heapless",
  "pin-project",
- "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "bevy_text"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc5233291dfc22e584de2535f2e37ae9766d37cb5a01652de2133ba202dcb9b"
+dependencies = [
+ "bevy_app",
+ "bevy_asset",
+ "bevy_color",
+ "bevy_derive",
+ "bevy_ecs",
+ "bevy_image",
+ "bevy_log",
+ "bevy_math",
+ "bevy_platform",
+ "bevy_reflect",
+ "bevy_utils",
+ "cosmic-text",
+ "serde",
+ "smallvec",
+ "sys-locale",
+ "thiserror 2.0.18",
+ "tracing",
+ "wgpu-types",
+]
+
+[[package]]
+name = "bevy_time"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5ef9af4e523195e561074cf60fbfad0f4cb8d1db504855fee3c4ce8896c7244"
+dependencies = [
+ "bevy_app",
+ "bevy_ecs",
+ "bevy_platform",
+ "bevy_reflect",
+ "crossbeam-channel",
+ "log",
+ "serde",
 ]
 
 [[package]]
 name = "bevy_transform"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df218e440bb9a19058e1b80a68a031c887bcf7bd3a145b55f361359a2fa3100d"
+checksum = "3c3bb3de7842fef699344beb03f22bdbff16599d788fe0f47fbb3b1e6fa320eb"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -788,52 +1319,60 @@ dependencies = [
 
 [[package]]
 name = "bevy_utils"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f7a8905a125d2017e8561beefb7f2f5e67e93ff6324f072ad87c5fd6ec3b99"
+checksum = "2111910cd7a4b1e6ce07eaaeb6f68a2c0ea0ca609ed0d0d506e3eb161101435b"
 dependencies = [
  "bevy_platform",
+ "disqualified",
  "thread_local",
 ]
 
 [[package]]
 name = "bevy_window"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df7e8ad0c17c3cc23ff5566ae2905c255e6986037fb041f74c446216f5c38431"
+checksum = "6df06e6993a0896bae2fe7644ae6def29a1a92b45dfb1bcebbd92af782be3638"
 dependencies = [
- "android-activity",
  "bevy_app",
  "bevy_ecs",
  "bevy_input",
  "bevy_math",
  "bevy_platform",
  "bevy_reflect",
- "bevy_utils",
  "log",
  "raw-window-handle",
  "serde",
- "smol_str",
 ]
 
 [[package]]
-name = "bindgen"
-version = "0.70.1"
+name = "bevy_winit"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
+checksum = "f2de1c13d32ab8528435b58eca7ab874a1068184c6d6f266ee11433ae99d4069"
 dependencies = [
- "bitflags 2.11.0",
- "cexpr",
- "clang-sys",
- "itertools 0.10.5",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn",
+ "accesskit",
+ "accesskit_winit",
+ "approx",
+ "bevy_a11y",
+ "bevy_android",
+ "bevy_app",
+ "bevy_derive",
+ "bevy_ecs",
+ "bevy_input",
+ "bevy_input_focus",
+ "bevy_log",
+ "bevy_math",
+ "bevy_platform",
+ "bevy_reflect",
+ "bevy_tasks",
+ "bevy_window",
+ "cfg-if",
+ "js-sys",
+ "tracing",
+ "wasm-bindgen",
+ "web-sys",
+ "winit",
 ]
 
 [[package]]
@@ -879,6 +1418,12 @@ dependencies = [
  "constant_time_eq",
  "cpufeatures",
 ]
+
+[[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "block2"
@@ -970,38 +1515,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "calloop"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dbf9978365bac10f54d1d4b04f7ce4427e51f71d61f2fe15e3fed5166474df7"
-dependencies = [
- "bitflags 2.11.0",
- "polling",
- "rustix 1.1.4",
- "slab",
- "tracing",
-]
-
-[[package]]
 name = "calloop-wayland-source"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
 dependencies = [
- "calloop 0.13.0",
+ "calloop",
  "rustix 0.38.44",
- "wayland-backend",
- "wayland-client",
-]
-
-[[package]]
-name = "calloop-wayland-source"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138efcf0940a02ebf0cc8d1eff41a1682a46b431630f4c52450d6265876021fa"
-dependencies = [
- "calloop 0.14.4",
- "rustix 1.1.4",
  "wayland-backend",
  "wayland-client",
 ]
@@ -1031,15 +1551,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1052,15 +1563,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "cgl"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ced0551234e87afee12411d535648dd89d2e7f34c78b753395567aff3d447ff"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1070,7 +1572,7 @@ dependencies = [
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1098,17 +1600,6 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
-]
-
-[[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
 ]
 
 [[package]]
@@ -1166,6 +1657,8 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
+ "serde",
+ "termcolor",
  "unicode-width",
 ]
 
@@ -1272,6 +1765,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-fnv1a-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b13ea120a812beba79e34316b3942a857c86ec1593cb34f27bb28272ce2cca"
+
+[[package]]
 name = "const_panic"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1299,6 +1798,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1aaf9b65849a68662ac6c0810c8893a765c960b907dd7cfab9c4a50bf764fbc"
 dependencies = [
  "const_soft_float",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -1335,7 +1843,7 @@ checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
- "core-graphics-types",
+ "core-graphics-types 0.1.3",
  "foreign-types",
  "libc",
 ]
@@ -1349,6 +1857,50 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
  "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.10.1",
+ "libc",
+]
+
+[[package]]
+name = "core_maths"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "cosmic-text"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4cadaea21e24c49c0c82116f2b465ae6a49d63c90e428b0f8d9ae1f638ac91f"
+dependencies = [
+ "bitflags 2.11.0",
+ "fontdb",
+ "harfrust",
+ "linebender_resource_handle",
+ "log",
+ "rangemap",
+ "rustc-hash",
+ "self_cell",
+ "skrifa 0.39.0",
+ "smol_str",
+ "swash",
+ "sys-locale",
+ "unicode-bidi",
+ "unicode-linebreak",
+ "unicode-script",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -1441,7 +1993,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
  "dispatch2",
- "nix 0.31.2",
+ "nix 0.31.3",
  "windows-sys 0.61.2",
 ]
 
@@ -1452,22 +2004,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
-name = "derive_more"
-version = "1.0.0"
+name = "data-encoding"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
  "derive_more-impl",
 ]
 
 [[package]]
 name = "derive_more-impl"
-version = "1.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
+ "convert_case",
  "proc-macro2",
  "quote",
+ "rustc_version",
  "syn",
  "unicode-xid",
 ]
@@ -1564,41 +2124,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "eframe"
-version = "0.33.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "457481173e6db5ca9fa2be93a58df8f4c7be639587aeb4853b526c6cf87db4e6"
-dependencies = [
- "ahash",
- "bytemuck",
- "document-features",
- "egui",
- "egui-wgpu",
- "egui-winit",
- "egui_glow",
- "glow",
- "glutin",
- "glutin-winit",
- "image",
- "js-sys",
- "log",
- "objc2 0.5.2",
- "objc2-app-kit 0.2.2",
- "objc2-foundation 0.2.2",
- "parking_lot",
- "percent-encoding",
- "profiling",
- "raw-window-handle",
- "static_assertions",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "web-time",
- "windows-sys 0.61.2",
- "winit",
-]
-
-[[package]]
 name = "egui"
 version = "0.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1613,64 +2138,6 @@ dependencies = [
  "profiling",
  "smallvec",
  "unicode-segmentation",
-]
-
-[[package]]
-name = "egui-wgpu"
-version = "0.33.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e4d209971c84b2352a06174abdba701af1e552ce56b144d96f2bd50a3c91236"
-dependencies = [
- "ahash",
- "bytemuck",
- "document-features",
- "egui",
- "epaint",
- "log",
- "profiling",
- "thiserror 2.0.18",
- "type-map",
- "web-time",
- "wgpu",
- "winit",
-]
-
-[[package]]
-name = "egui-winit"
-version = "0.33.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec6687e5bb551702f4ad10ac428bab12acf9d53047ebb1082d4a0ed8c6251a29"
-dependencies = [
- "arboard",
- "bytemuck",
- "egui",
- "log",
- "objc2 0.5.2",
- "objc2-foundation 0.2.2",
- "objc2-ui-kit",
- "profiling",
- "raw-window-handle",
- "smithay-clipboard",
- "web-time",
- "webbrowser",
- "winit",
-]
-
-[[package]]
-name = "egui_glow"
-version = "0.33.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6420863ea1d90e750f75075231a260030ad8a9f30a7cef82cdc966492dc4c4eb"
-dependencies = [
- "bytemuck",
- "egui",
- "glow",
- "log",
- "memoffset",
- "profiling",
- "wasm-bindgen",
- "web-sys",
- "winit",
 ]
 
 [[package]]
@@ -1690,29 +2157,29 @@ dependencies = [
 
 [[package]]
 name = "encase"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0a05902cf601ed11d564128448097b98ebe3c6574bd7b6a653a3d56d54aa020"
+checksum = "6e3e0ff2ee0b7aa97428308dd9e1e42369cb22f5fb8dc1c55546637443a60f1e"
 dependencies = [
  "const_panic",
  "encase_derive",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "encase_derive"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "181d475b694e2dd56ae919ce7699d344d1fd259292d590c723a50d1189a2ea85"
+checksum = "a4d90c5d7d527c6cb8a3b114efd26a6304d9ab772656e73d8f4e32b1f3d601a2"
 dependencies = [
  "encase_derive_impl",
 ]
 
 [[package]]
 name = "encase_derive_impl"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f97b51c5cc57ef7c5f7a0c57c250251c49ee4c28f819f87ac32f4aceabc36792"
+checksum = "c8bad72d8308f7a382de2391ec978ddd736e0103846b965d7e2a63a75768af30"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1768,10 +2235,7 @@ version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
 dependencies = [
- "anstream",
- "anstyle",
  "env_filter",
- "jiff",
  "log",
 ]
 
@@ -1932,6 +2396,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "font-types"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a654f404bbcbd48ea58c617c2993ee91d1cb63727a37bf2323a4edeed1b8c5"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "font-types"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b38ad915f6dadd993ced50848a8291a543bd41ca62bc10740d5e64e2ab4cfd7"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "fontconfig-parser"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
+dependencies = [
+ "roxmltree",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser",
+]
+
+[[package]]
 name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2059,14 +2564,11 @@ dependencies = [
 name = "gdsr-viewer"
 version = "0.0.1-alpha.3"
 dependencies = [
- "bevy_asset",
- "bevy_mesh",
+ "bevy",
+ "bevy_egui",
  "clap",
  "earcutr",
- "eframe",
  "egui",
- "emath",
- "env_logger",
  "gdsr",
  "insta",
  "log",
@@ -2083,7 +2585,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
  "rustix 1.1.4",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2093,10 +2595,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2106,9 +2606,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2126,25 +2628,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "gl_generator"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
-dependencies = [
- "khronos_api",
- "log",
- "xml-rs",
-]
-
-[[package]]
 name = "glam"
-version = "0.29.3"
+version = "0.30.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8babf46d4c1c9d92deac9f7be466f76dfc4482b6452fc5024b5e8daf6ffeb3ee"
+checksum = "19fc433e8437a212d1b6f1e68c7824af3aed907da60afa994e7f542d18d12aa9"
 dependencies = [
  "bytemuck",
- "rand 0.8.7",
- "serde",
+ "encase",
+ "libm",
+ "rand 0.9.2",
+ "serde_core",
 ]
 
 [[package]]
@@ -2154,81 +2647,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
-name = "glow"
-version = "0.16.0"
+name = "gpu-alloc"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e5ea60d70410161c8bf5da3fdfeaa1c72ed2c15f8bbb9d19fe3a4fad085f08"
-dependencies = [
- "js-sys",
- "slotmap",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "glutin"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12124de845cacfebedff80e877bb37b5b75c34c5a4c89e47e1cdd67fb6041325"
+checksum = "45cf04b2726f02df5508c6de726acdc90cdf97ac771a9a0ffd8ba10a6e696bf9"
 dependencies = [
  "bitflags 2.11.0",
- "cfg_aliases",
- "cgl",
- "dispatch2",
- "glutin_egl_sys",
- "glutin_glx_sys",
- "glutin_wgl_sys",
- "libloading",
- "objc2 0.6.4",
- "objc2-app-kit 0.3.2",
- "objc2-core-foundation",
- "objc2-foundation 0.3.2",
- "once_cell",
- "raw-window-handle",
- "wayland-sys",
- "windows-sys 0.52.0",
- "x11-dl",
+ "gpu-alloc-types",
 ]
 
 [[package]]
-name = "glutin-winit"
-version = "0.5.0"
+name = "gpu-alloc-types"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85edca7075f8fc728f28cb8fbb111a96c3b89e930574369e3e9c27eb75d3788f"
+checksum = "b2bbed164dd10ed526c2e4fe3e721ca4a71c61730e5aafac6844b417b3227058"
 dependencies = [
- "cfg_aliases",
- "glutin",
- "raw-window-handle",
- "winit",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
-name = "glutin_egl_sys"
-version = "0.7.1"
+name = "gpu-allocator"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4680ba6195f424febdc3ba46e7a42a0e58743f2edb115297b86d7f8ecc02d2"
+checksum = "c151a2a5ef800297b4e79efa4f4bec035c5f51d5ae587287c9b952bdf734cacd"
 dependencies = [
- "gl_generator",
- "windows-sys 0.52.0",
+ "log",
+ "presser",
+ "thiserror 1.0.69",
+ "windows 0.58.0",
 ]
 
 [[package]]
-name = "glutin_glx_sys"
-version = "0.6.1"
+name = "gpu-descriptor"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7bb2938045a88b612499fbcba375a77198e01306f52272e692f8c1f3751185"
+checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
 dependencies = [
- "gl_generator",
- "x11-dl",
+ "bitflags 2.11.0",
+ "gpu-descriptor-types",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
-name = "glutin_wgl_sys"
-version = "0.6.1"
+name = "gpu-descriptor-types"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c4ee00b289aba7a9e5306d57c2d05499b2e5dc427f84ac708bd2c090212cf3e"
+checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
- "gl_generator",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -2254,6 +2720,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "harfrust"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0caaee032384c10dd597af4579c67dee16650d862a9ccbe1233ff1a379abc07"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytemuck",
+ "core_maths",
+ "read-fonts 0.36.0",
+ "smallvec",
+]
+
+[[package]]
 name = "hash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2268,9 +2747,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "equivalent",
  "foldhash 0.1.5",
- "serde",
 ]
 
 [[package]]
@@ -2279,14 +2756,17 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
+ "equivalent",
  "foldhash 0.2.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "heapless"
-version = "0.8.0"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+checksum = "25ba4bd83f9415b58b4ed8dc5714c76e626a105be4646c02630ad730ad3b5aa4"
 dependencies = [
  "hash32",
  "portable-atomic",
@@ -2313,9 +2793,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hexasphere"
-version = "15.1.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c9e718d32b6e6b2b32354e1b0367025efdd0b11d6a740b905ddf5db1074679"
+checksum = "29a164ceff4500f2a72b1d21beaa8aa8ad83aec2b641844c659b190cb3ea2e0b"
 dependencies = [
  "constgebra",
  "glam",
@@ -2340,7 +2820,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -2499,6 +2979,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2538,30 +3027,6 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
-
-[[package]]
-name = "jiff"
-version = "0.2.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "jni"
@@ -2606,12 +3071,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "khronos_api"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2625,9 +3084,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -2636,7 +3095,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2656,6 +3115,12 @@ dependencies = [
  "plain",
  "redox_syscall 0.7.3",
 ]
+
+[[package]]
+name = "linebender_resource_handle"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2697,6 +3162,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2730,10 +3204,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
+name = "metal"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+checksum = "00c15a6f673ff72ddcc22394663290f870fb224c1bfce55734a75c414150e605"
+dependencies = [
+ "bitflags 2.11.0",
+ "block",
+ "core-graphics-types 0.2.0",
+ "foreign-types",
+ "log",
+ "objc",
+ "paste",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -2775,8 +3258,27 @@ dependencies = [
  "log",
  "num-traits",
  "once_cell",
- "rustc-hash 1.1.0",
+ "pp-rs",
+ "rustc-hash",
+ "spirv",
  "thiserror 2.0.18",
+ "unicode-ident",
+]
+
+[[package]]
+name = "naga_oil"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "310c347db1b30e69581f3b84dc9a5c311ed583f67851b39b77953cb7a066c97f"
+dependencies = [
+ "codespan-reporting",
+ "data-encoding",
+ "indexmap",
+ "naga",
+ "regex",
+ "rustc-hash",
+ "thiserror 2.0.18",
+ "tracing",
  "unicode-ident",
 ]
 
@@ -2824,9 +3326,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.31.2"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
@@ -2839,16 +3341,6 @@ name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
-]
 
 [[package]]
 name = "nonmax"
@@ -2895,6 +3387,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
 ]
 
 [[package]]
@@ -2947,7 +3448,6 @@ dependencies = [
  "bitflags 2.11.0",
  "block2 0.6.2",
  "objc2 0.6.4",
- "objc2-core-foundation",
  "objc2-core-graphics",
  "objc2-foundation 0.3.2",
 ]
@@ -3170,6 +3670,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "offset-allocator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e234d535da3521eb95106f40f0b73483d80bfb3aacf27c40d7e2b72f1a3e00a2"
+dependencies = [
+ "log",
+ "nonmax",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3195,6 +3705,15 @@ checksum = "52ad2c6bae700b7aa5d1cc30c59bdd3a1c180b09dbaea51e2ae2b8e1cf211fdd"
 dependencies = [
  "libc",
  "libredox",
+]
+
+[[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -3242,8 +3761,14 @@ dependencies = [
  "libc",
  "redox_syscall 0.5.18",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -3386,6 +3911,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pp-rs"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb458bb7f6e250e6eb79d5026badc10a3ebb8f9a15d1fff0f13d17c71f4d6dee"
+dependencies = [
+ "unicode-xid",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3393,6 +3927,12 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
+
+[[package]]
+name = "presser"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
 name = "prettyplease"
@@ -3493,15 +4033,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
-name = "rand"
-version = "0.8.7"
+name = "radsort"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
+checksum = "019b4b213425016d7d84a153c4c73afb0946fbb4840e4eece7ba8848b9d6da22"
 
 [[package]]
 name = "rand"
@@ -3509,7 +4044,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
 ]
 
@@ -3525,31 +4060,12 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -3569,13 +4085,25 @@ checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "rand_distr"
-version = "0.4.3"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
- "rand 0.8.7",
+ "rand 0.9.2",
 ]
+
+[[package]]
+name = "range-alloc"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
+
+[[package]]
+name = "rangemap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
 
 [[package]]
 name = "raw-window-handle"
@@ -3601,6 +4129,27 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "read-fonts"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eaa2941a4c05443ee3a7b26ab076a553c343ad5995230cc2b1d3e993bdc6345"
+dependencies = [
+ "bytemuck",
+ "core_maths",
+ "font-types 0.10.1",
+]
+
+[[package]]
+name = "read-fonts"
+version = "0.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4ed38b89c2c77ff968c524145ad65fb010f38af5c7a224b53b81d47ac2daa81"
+dependencies = [
+ "bytemuck",
+ "font-types 0.11.3",
 ]
 
 [[package]]
@@ -3703,15 +4252,23 @@ dependencies = [
 
 [[package]]
 name = "ron"
-version = "0.8.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
+checksum = "81116b9531d61eabc41aeb228e4b6b2435bcca3233b98cf3b3077d4e6e9debb3"
 dependencies = [
- "base64",
  "bitflags 2.11.0",
+ "once_cell",
  "serde",
  "serde_derive",
+ "typeid",
+ "unicode-ident",
 ]
+
+[[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "rstest"
@@ -3747,12 +4304,6 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc-hash"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -3796,6 +4347,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ruzstd"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7c1c839d570d835527c9a5e4db7cb2198683a988cb9d7293fc8674e6bd58fc8"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3817,10 +4377,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sctk-adwaita"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6277f0217056f77f1d8f49f2950ac6c278c0d607c45f5ee99328d792ede24ec"
+dependencies = [
+ "ab_glyph",
+ "log",
+ "memmap2",
+ "smithay-client-toolkit",
+ "tiny-skia",
+]
+
+[[package]]
+name = "self_cell"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
@@ -3914,6 +4499,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
+name = "skrifa"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9eb0b904a04d09bd68c65d946617b8ff733009999050f3b851c32fb3cfb60e"
+dependencies = [
+ "bytemuck",
+ "read-fonts 0.36.0",
+]
+
+[[package]]
+name = "skrifa"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c34617370ae968efb7161bb2beb517d9084659aae19e24b89e3db25b46e4564"
+dependencies = [
+ "bytemuck",
+ "read-fonts 0.39.2",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3941,8 +4546,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
 dependencies = [
  "bitflags 2.11.0",
- "calloop 0.13.0",
- "calloop-wayland-source 0.3.0",
+ "calloop",
+ "calloop-wayland-source",
  "cursor-icon",
  "libc",
  "log",
@@ -3960,44 +4565,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "smithay-client-toolkit"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0512da38f5e2b31201a93524adb8d3136276fa4fe4aafab4e1f727a82b534cc0"
-dependencies = [
- "bitflags 2.11.0",
- "calloop 0.14.4",
- "calloop-wayland-source 0.4.1",
- "cursor-icon",
- "libc",
- "log",
- "memmap2",
- "rustix 1.1.4",
- "thiserror 2.0.18",
- "wayland-backend",
- "wayland-client",
- "wayland-csd-frame",
- "wayland-cursor",
- "wayland-protocols",
- "wayland-protocols-experimental",
- "wayland-protocols-misc",
- "wayland-protocols-wlr",
- "wayland-scanner",
- "xkeysym",
-]
-
-[[package]]
-name = "smithay-clipboard"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71704c03f739f7745053bde45fa203a46c58d25bc5c4efba1d9a60e9dba81226"
-dependencies = [
- "libc",
- "smithay-client-toolkit 0.20.0",
- "wayland-backend",
-]
-
-[[package]]
 name = "smol_str"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4008,11 +4575,20 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "spirv"
+version = "0.3.0+sdk-1.3.268.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
+dependencies = [
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -4047,6 +4623,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4057,6 +4639,17 @@ name = "svg_fmt"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0193cc4331cfd2f3d2011ef287590868599a2f33c3e69bc22c1a3d3acf9e02fb"
+
+[[package]]
+name = "swash"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0811b01ca2c4e8718760713911feaf4675c24f94e50530a015ec646cfb622f7c"
+dependencies = [
+ "skrifa 0.42.1",
+ "yazi",
+ "zeno",
+]
 
 [[package]]
 name = "syn"
@@ -4081,6 +4674,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sys-locale"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4091,6 +4693,15 @@ dependencies = [
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -4157,6 +4768,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-skia"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4193,9 +4829,12 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.11"
+version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "toml_datetime"
@@ -4208,12 +4847,13 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.27"
+version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
  "indexmap",
- "toml_datetime 0.6.11",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
  "winnow",
 ]
 
@@ -4244,7 +4884,6 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -4284,15 +4923,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-oslog"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528bdd1f0e27b5dd9a4ededf154e824b0532731e4af73bb531de46276e0aab1e"
+checksum = "d76902d2a8d5f9f55a81155c08971734071968c90f2d9bfe645fe700579b2950"
 dependencies = [
- "bindgen",
  "cc",
  "cfg-if",
- "once_cell",
- "parking_lot",
  "tracing-core",
  "tracing-subscriber",
 ]
@@ -4331,15 +4967,15 @@ name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+dependencies = [
+ "core_maths",
+]
 
 [[package]]
-name = "type-map"
-version = "0.5.1"
+name = "twox-hash"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
-dependencies = [
- "rustc-hash 2.1.1",
-]
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typeid"
@@ -4365,10 +5001,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-script"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
 
 [[package]]
 name = "unicode-segmentation"
@@ -4642,32 +5296,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wayland-protocols-experimental"
-version = "20250721.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40a1f863128dcaaec790d7b4b396cc9b9a7a079e878e18c47e6c2d2c5a8dcbb1"
-dependencies = [
- "bitflags 2.11.0",
- "wayland-backend",
- "wayland-client",
- "wayland-protocols",
- "wayland-scanner",
-]
-
-[[package]]
-name = "wayland-protocols-misc"
-version = "0.3.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "791c58fdeec5406aa37169dd815327d1e47f334219b523444bc26d70ceb4c34e"
-dependencies = [
- "bitflags 2.11.0",
- "wayland-backend",
- "wayland-client",
- "wayland-protocols",
- "wayland-scanner",
-]
-
-[[package]]
 name = "wayland-protocols-plasma"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4712,7 +5340,6 @@ checksum = "1e6dbfc3ac5ef974c92a2235805cc0114033018ae1290a72e474aa8b28cbbdfd"
 dependencies = [
  "dlib",
  "log",
- "once_cell",
  "pkg-config",
 ]
 
@@ -4771,6 +5398,7 @@ dependencies = [
  "document-features",
  "hashbrown 0.16.1",
  "log",
+ "naga",
  "portable-atomic",
  "profiling",
  "raw-window-handle",
@@ -4778,7 +5406,7 @@ dependencies = [
  "static_assertions",
  "wgpu-core",
  "wgpu-hal",
- "wgpu-types 27.0.1",
+ "wgpu-types",
 ]
 
 [[package]]
@@ -4803,12 +5431,22 @@ dependencies = [
  "portable-atomic",
  "profiling",
  "raw-window-handle",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "smallvec",
  "thiserror 2.0.18",
+ "wgpu-core-deps-apple",
  "wgpu-core-deps-windows-linux-android",
  "wgpu-hal",
- "wgpu-types 27.0.1",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core-deps-apple"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0772ae958e9be0c729561d5e3fd9a19679bcdfb945b8b1a1969d9bfe8056d233"
+dependencies = [
+ "wgpu-hal",
 ]
 
 [[package]]
@@ -4826,31 +5464,40 @@ version = "27.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b21cb61c57ee198bc4aff71aeadff4cbb80b927beb912506af9c780d64313ce"
 dependencies = [
+ "android_system_properties",
+ "arrayvec",
+ "ash",
+ "bit-set",
  "bitflags 2.11.0",
+ "block",
+ "bytemuck",
  "cfg-if",
  "cfg_aliases",
+ "core-graphics-types 0.2.0",
+ "gpu-alloc",
+ "gpu-allocator",
+ "gpu-descriptor",
+ "hashbrown 0.16.1",
+ "libc",
  "libloading",
  "log",
+ "metal",
  "naga",
+ "objc",
+ "once_cell",
+ "ordered-float",
+ "parking_lot",
  "portable-atomic",
  "portable-atomic-util",
+ "profiling",
+ "range-alloc",
  "raw-window-handle",
  "renderdoc-sys",
+ "smallvec",
  "thiserror 2.0.18",
- "wgpu-types 27.0.1",
-]
-
-[[package]]
-name = "wgpu-types"
-version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50ac044c0e76c03a0378e7786ac505d010a873665e2d51383dcff8dd227dc69c"
-dependencies = [
- "bitflags 2.11.0",
- "js-sys",
- "log",
- "serde",
- "web-sys",
+ "wgpu-types",
+ "windows 0.58.0",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -4863,6 +5510,7 @@ dependencies = [
  "bytemuck",
  "js-sys",
  "log",
+ "serde",
  "thiserror 2.0.18",
  "web-sys",
 ]
@@ -4877,16 +5525,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.61.2",
+ "windows-future",
+ "windows-link 0.1.3",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
 dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-result",
- "windows-strings",
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading",
 ]
 
 [[package]]
@@ -4894,6 +5598,17 @@ name = "windows-implement"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4912,10 +5627,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
 
 [[package]]
 name = "windows-result"
@@ -4927,13 +5669,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -4969,7 +5729,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5001,6 +5761,15 @@ dependencies = [
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -5105,7 +5874,7 @@ dependencies = [
  "bitflags 2.11.0",
  "block2 0.5.1",
  "bytemuck",
- "calloop 0.13.0",
+ "calloop",
  "cfg_aliases",
  "concurrent-queue",
  "core-foundation 0.9.4",
@@ -5126,7 +5895,8 @@ dependencies = [
  "raw-window-handle",
  "redox_syscall 0.4.1",
  "rustix 0.38.44",
- "smithay-client-toolkit 0.19.2",
+ "sctk-adwaita",
+ "smithay-client-toolkit",
  "smol_str",
  "tracing",
  "unicode-segmentation",
@@ -5305,10 +6075,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
-name = "xml-rs"
-version = "0.8.28"
+name = "yazi"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+checksum = "e01738255b5a16e78bbb83e7fbba0a1e7dd506905cfc53f4622d89015a03fbb5"
 
 [[package]]
 name = "yoke"
@@ -5393,6 +6163,12 @@ dependencies = [
  "winnow",
  "zvariant",
 ]
+
+[[package]]
+name = "zeno"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6df3dc4292935e51816d896edcd52aa30bc297907c26167fec31e2b0c6a32524"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 # Please update rustfmt.toml when bumping the Rust edition.
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.89"
 homepage = "https://github.com/MatthewMckee4/gdsr"
 authors = ["Matthew Mckee <matthewmckee04@yahoo.co.uk>"]
 license = "MIT"
@@ -14,16 +14,43 @@ license = "MIT"
 gdsr = { path = "crates/gdsr", version = "0.0.1-alpha.3" }
 
 approx = "0.5"
-bevy_asset = "0.16.1"
-bevy_mesh = "0.16.1"
+bevy = { version = "0.18.1", default-features = false, features = [
+    "async_executor",
+    "bevy_asset",
+    "bevy_color",
+    "bevy_core_pipeline",
+    "bevy_image",
+    "bevy_log",
+    "bevy_mesh",
+    "bevy_render",
+    "bevy_shader",
+    "bevy_sprite",
+    "bevy_sprite_render",
+    "bevy_text",
+    "bevy_window",
+    "bevy_winit",
+    "default_font",
+    "keyboard",
+    "mouse",
+    "multi_threaded",
+    "png",
+    "reflect_auto_register",
+    "std",
+    "touch",
+    "wayland",
+    "x11",
+] }
+bevy_egui = { version = "0.39.1", default-features = false, features = [
+    "default_fonts",
+    "manage_clipboard",
+    "open_url",
+    "render",
+] }
 bytemuck = "1.25.0"
 chrono = "0.4.44"
 clap = "4.5.55"
 earcutr = "0.5"
-eframe = { version = "0.33.3", default-features = false, features = ["default_fonts", "glow", "x11", "wayland"] }
 egui = "0.33.3"
-emath = "0.33.3"
-env_logger = "0.11"
 insta = "1.46.3"
 log = "0.4"
 quickcheck = "1.1.0"

--- a/crates/gdsr-viewer/Cargo.toml
+++ b/crates/gdsr-viewer/Cargo.toml
@@ -10,14 +10,11 @@ authors = { workspace = true }
 license = { workspace = true }
 
 [dependencies]
-bevy_asset = { workspace = true }
-bevy_mesh = { workspace = true }
+bevy = { workspace = true }
+bevy_egui = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 earcutr = { workspace = true }
-eframe = { workspace = true }
 egui = { workspace = true }
-emath = { workspace = true }
-env_logger = { workspace = true }
 gdsr = { workspace = true }
 log = { workspace = true }
 rfd = { workspace = true }

--- a/crates/gdsr-viewer/README.md
+++ b/crates/gdsr-viewer/README.md
@@ -1,6 +1,7 @@
 # gdsr-viewer
 
-An interactive GDS file viewer built with [egui](https://github.com/emilk/egui).
+An interactive GDS file viewer rendered with [Bevy](https://bevyengine.org/) and
+using [egui](https://github.com/emilk/egui) for its interface.
 
 ## Features
 

--- a/crates/gdsr-viewer/src/app.rs
+++ b/crates/gdsr-viewer/src/app.rs
@@ -1,6 +1,8 @@
 use std::path::{Path, PathBuf};
 use std::sync::mpsc;
 
+use bevy::prelude::NonSendMut;
+use bevy_egui::EguiContexts;
 use gdsr::{
     DEFAULT_FLOAT_UNITS, DEFAULT_INTEGER_UNITS, DataType, Element, HorizontalPresentation, Layer,
     Movable, Path as GdsPath, PathType, Point, Polygon, Radians, Text, Unit, VerticalPresentation,
@@ -13,8 +15,7 @@ use crate::recent::{RecentProjectItem, RecentProjects};
 use crate::ruler::RulerState;
 use crate::spatial::SpatialGrid;
 use crate::state::{
-    CellState, CellViewMode, DisplayUnit, FileLoadState, GridSpacing, LayerState, RenderCache,
-    SidePanelTab,
+    CellState, CellViewMode, DisplayUnit, FileLoadState, GridSpacing, LayerState, SidePanelTab,
 };
 use crate::viewport::Viewport;
 
@@ -209,7 +210,6 @@ pub struct ViewerApp {
     layer_state: LayerState,
     viewport: Viewport,
     mouse_world_pos: Option<(f64, f64)>,
-    render_cache: RenderCache,
     ruler: RulerState,
     show_grid: bool,
     snap_to_grid: bool,
@@ -217,8 +217,6 @@ pub struct ViewerApp {
     selected_element: Option<usize>,
     /// Reusable scratch buffer for spatial grid point queries.
     query_buf: Vec<u32>,
-    /// Reusable mark buffer for deduplicating elements across visible spatial cells.
-    drawn_element_marks: Vec<bool>,
     side_panel_tab: SidePanelTab,
     cell_view_mode: CellViewMode,
     scroll_to_selected: bool,
@@ -239,6 +237,9 @@ pub struct ViewerApp {
     polygon_tool: Option<PolygonTool>,
     path_dialog: Option<PathDialog>,
     path_tool: Option<PathTool>,
+    viewport_rect: egui::Rect,
+    render_generation: u64,
+    geometry_generation: u64,
 }
 
 impl Default for ViewerApp {
@@ -249,14 +250,12 @@ impl Default for ViewerApp {
             layer_state: LayerState::default(),
             viewport: Viewport::default(),
             mouse_world_pos: None,
-            render_cache: RenderCache::default(),
             ruler: RulerState::default(),
             show_grid: true,
             snap_to_grid: false,
             hovered_element: None,
             selected_element: None,
             query_buf: Vec::new(),
-            drawn_element_marks: Vec::new(),
             side_panel_tab: SidePanelTab::default(),
             cell_view_mode: CellViewMode::default(),
             scroll_to_selected: false,
@@ -277,11 +276,65 @@ impl Default for ViewerApp {
             polygon_tool: None,
             path_dialog: None,
             path_tool: None,
+            viewport_rect: egui::Rect::NOTHING,
+            render_generation: 0,
+            geometry_generation: 0,
         }
     }
 }
 
 impl ViewerApp {
+    fn invalidate_render(&mut self) {
+        self.render_generation = self.render_generation.saturating_add(1);
+    }
+
+    fn invalidate_geometry(&mut self) {
+        self.geometry_generation = self.geometry_generation.saturating_add(1);
+        self.invalidate_render();
+    }
+
+    pub(crate) const fn geometry_generation(&self) -> u64 {
+        self.geometry_generation
+    }
+
+    pub(crate) const fn render_generation(&self) -> u64 {
+        self.render_generation
+    }
+
+    pub(crate) fn library(&self) -> Option<&gdsr::Library> {
+        self.cell.as_ref().map(|cell| &cell.library)
+    }
+
+    pub(crate) fn selected_cell_name(&self) -> Option<&str> {
+        self.cell
+            .as_ref()
+            .and_then(|cell| cell.selected_cell.as_deref())
+    }
+
+    pub(crate) fn render_depth(&self) -> u32 {
+        self.cell.as_ref().map_or(1, |cell| cell.render_depth)
+    }
+
+    pub(crate) const fn viewport_state(&self) -> (f64, f64, f64) {
+        (
+            self.viewport.center_x,
+            self.viewport.center_y,
+            self.viewport.zoom,
+        )
+    }
+
+    pub(crate) const fn viewport_rect(&self) -> egui::Rect {
+        self.viewport_rect
+    }
+
+    pub(crate) fn hidden_layers(&self) -> &std::collections::HashSet<(Layer, DataType)> {
+        &self.layer_state.hidden_layers
+    }
+
+    pub(crate) fn layer_color(&mut self, layer: Layer, data_type: DataType) -> egui::Color32 {
+        self.layer_state.layer_colors.get(layer, data_type)
+    }
+
     pub fn with_path(path: &Path) -> Self {
         let (path, rx) = crate::loader::load_request(path);
         let file_load = FileLoadState {
@@ -330,6 +383,7 @@ impl ViewerApp {
         self.polygon_tool = None;
         self.path_dialog = None;
         self.path_tool = None;
+        self.invalidate_geometry();
     }
 
     /// Switches to a new cell, keeping hierarchy intact for draw-time expansion.
@@ -346,7 +400,7 @@ impl ViewerApp {
                 }
             }
         }
-        self.render_cache.clear();
+        self.invalidate_render();
         self.polygon_dialog = None;
         self.polygon_tool = None;
         self.path_dialog = None;
@@ -610,7 +664,7 @@ impl ViewerApp {
     fn mark_cell_structure_changed(&mut self) {
         self.selected_element = None;
         self.hovered_element = None;
-        self.render_cache.clear();
+        self.invalidate_geometry();
         self.has_unsaved_changes = true;
         self.save_error = None;
         self.undo_stack.clear();
@@ -716,7 +770,7 @@ impl ViewerApp {
 
         self.selected_element = Some(index);
         self.hovered_element = Some(index);
-        self.render_cache.clear();
+        self.invalidate_geometry();
         self.has_unsaved_changes = true;
         self.save_error = None;
         self.record_edit(EditAction::Add {
@@ -755,7 +809,7 @@ impl ViewerApp {
 
         self.selected_element = Some(index);
         self.hovered_element = Some(index);
-        self.render_cache.clear();
+        self.invalidate_geometry();
         self.has_unsaved_changes = true;
         self.save_error = None;
         self.record_edit(EditAction::Add {
@@ -807,7 +861,7 @@ impl ViewerApp {
 
         self.selected_element = Some(index);
         self.hovered_element = Some(index);
-        self.render_cache.clear();
+        self.invalidate_geometry();
         self.has_unsaved_changes = true;
         self.save_error = None;
         self.record_edit(EditAction::Add {
@@ -1178,7 +1232,7 @@ impl ViewerApp {
 
         self.selected_element = action.selected_element_after_apply();
         self.hovered_element = self.selected_element;
-        self.render_cache.clear();
+        self.invalidate_geometry();
         self.has_unsaved_changes = true;
         self.save_error = None;
         true
@@ -1257,7 +1311,7 @@ impl ViewerApp {
 
         self.selected_element = Some(index);
         self.hovered_element = Some(index);
-        self.render_cache.clear();
+        self.invalidate_geometry();
         self.has_unsaved_changes = true;
         self.save_error = None;
         self.record_edit(EditAction::Add {
@@ -1291,7 +1345,7 @@ impl ViewerApp {
 
         self.selected_element = None;
         self.hovered_element = None;
-        self.render_cache.clear();
+        self.invalidate_geometry();
         self.has_unsaved_changes = true;
         self.save_error = None;
         self.record_edit(EditAction::Delete {
@@ -1330,7 +1384,7 @@ impl ViewerApp {
         }
 
         self.hovered_element = Some(index);
-        self.render_cache.clear();
+        self.invalidate_geometry();
         self.has_unsaved_changes = true;
         self.save_error = None;
         self.record_edit(EditAction::Move {
@@ -1388,8 +1442,8 @@ fn hit_test_element(
     None
 }
 
-impl eframe::App for ViewerApp {
-    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+impl ViewerApp {
+    fn update(&mut self, ctx: &egui::Context) {
         if ctx.input(|i| i.viewport().close_requested()) && self.cancel_close_for_unsaved_changes()
         {
             ctx.send_viewport_cmd(egui::ViewportCommand::CancelClose);
@@ -1858,10 +1912,13 @@ impl eframe::App for ViewerApp {
         });
 
         if depth_changed {
-            if let Some(name) = self.cell.as_ref().and_then(|c| c.selected_cell.clone()) {
-                self.select_cell(&name);
+            if let Some(cell) = self.cell.as_mut() {
+                cell.refresh_layers();
+                for &(layer, data_type) in &cell.layers {
+                    self.layer_state.layer_colors.get(layer, data_type);
+                }
             }
-            self.render_cache.clear();
+            self.invalidate_render();
         }
 
         // Cell picker (⌘P)
@@ -1941,26 +1998,22 @@ impl eframe::App for ViewerApp {
             }
         }
 
-        // Clearing render cache after changing color fixes the bug when color is not updated until user zooms out and back in.
+        // Layer changes require new Bevy materials and a new visible-scene plan.
         if color_changed {
-            self.render_cache.clear();
+            self.invalidate_render();
         }
 
         let cell = &mut self.cell;
         let viewport = &mut self.viewport;
         let layer_state = &mut self.layer_state;
         let mouse_world_pos = &mut self.mouse_world_pos;
-        let render_cache = &mut self.render_cache;
         let ruler = &mut self.ruler;
         let show_grid = self.show_grid;
         let grid_spacing = self.grid_spacing;
         let hovered_element = &mut self.hovered_element;
         let selected_element = &mut self.selected_element;
         let query_buf = &mut self.query_buf;
-        let drawn_element_marks = &mut self.drawn_element_marks;
-        let render_depth = cell.as_ref().map_or(1, |c| c.render_depth);
-        let selected_cell_name: Option<String> =
-            cell.as_ref().and_then(|c| c.selected_cell.clone());
+        let viewport_rect = &mut self.viewport_rect;
         let drawing_preview_points = self
             .polygon_tool
             .as_ref()
@@ -1969,64 +2022,61 @@ impl eframe::App for ViewerApp {
         let mut selected_element_drag_delta = None;
         let mut viewport_click_world = None;
         let mut viewport_double_clicked = false;
-        egui::CentralPanel::default().show(ctx, |ui| {
-            let mut empty_cache = std::collections::HashMap::new();
-            let (elements, spatial_grid, library, tessellation_cache) =
-                if let Some(cell) = cell.as_mut() {
-                    (
-                        cell.elements.as_slice(),
-                        cell.spatial_grid.as_ref(),
-                        Some(&cell.library),
-                        &mut cell.tessellation_cache,
-                    )
-                } else {
-                    (&[] as &[gdsr::Element], None, None, &mut empty_cache)
-                };
+        egui::CentralPanel::default()
+            .frame(egui::Frame::NONE)
+            .show(ctx, |ui| {
+                let mut empty_cache = std::collections::HashMap::new();
+                let (elements, spatial_grid, library, tessellation_cache) =
+                    if let Some(cell) = cell.as_mut() {
+                        (
+                            cell.elements.as_slice(),
+                            cell.spatial_grid.as_ref(),
+                            Some(&cell.library),
+                            &mut cell.tessellation_cache,
+                        )
+                    } else {
+                        (&[] as &[gdsr::Element], None, None, &mut empty_cache)
+                    };
 
-            let interaction = viewport.draw(
-                ui,
-                elements,
-                layer_state,
-                spatial_grid,
-                query_buf,
-                drawn_element_marks,
-                library,
-                render_cache,
-                tessellation_cache,
-                ruler,
-                show_grid,
-                grid_spacing,
-                *hovered_element,
-                *selected_element,
-                render_depth,
-                selected_cell_name.as_deref(),
-                drawing_preview_points.as_deref(),
-            );
-            selected_element_drag_delta = interaction.selected_element_drag_delta;
-            *mouse_world_pos = interaction.mouse_world;
-            if interaction.clicked || interaction.double_clicked {
-                viewport_click_world = interaction.mouse_world;
-                viewport_double_clicked = interaction.double_clicked;
-            }
+                let interaction = viewport.draw(
+                    ui,
+                    elements,
+                    layer_state,
+                    library,
+                    tessellation_cache,
+                    ruler,
+                    show_grid,
+                    grid_spacing,
+                    *hovered_element,
+                    *selected_element,
+                    drawing_preview_points.as_deref(),
+                );
+                *viewport_rect = interaction.rect;
+                selected_element_drag_delta = interaction.selected_element_drag_delta;
+                *mouse_world_pos = interaction.mouse_world;
+                if interaction.clicked || interaction.double_clicked {
+                    viewport_click_world = interaction.mouse_world;
+                    viewport_double_clicked = interaction.double_clicked;
+                }
 
-            let prev_hovered = *hovered_element;
-            let prev_selected = *selected_element;
-            *hovered_element = None;
-            if !drawing_tool_active {
-                if let Some((wx, wy)) = *mouse_world_pos {
-                    if let Some(grid) = spatial_grid {
-                        *hovered_element =
-                            hit_test_element(elements, grid, query_buf, wx, wy, viewport.zoom);
+                let prev_hovered = *hovered_element;
+                let prev_selected = *selected_element;
+                *hovered_element = None;
+                if !drawing_tool_active {
+                    if let Some((wx, wy)) = *mouse_world_pos {
+                        if let Some(grid) = spatial_grid {
+                            *hovered_element =
+                                hit_test_element(elements, grid, query_buf, wx, wy, viewport.zoom);
+                        }
+                    }
+                    if interaction.clicked {
+                        *selected_element = *hovered_element;
                     }
                 }
-                if interaction.clicked {
-                    *selected_element = *hovered_element;
+                if *hovered_element != prev_hovered || *selected_element != prev_selected {
+                    ctx.request_repaint();
                 }
-            }
-            if *hovered_element != prev_hovered || *selected_element != prev_selected {
-                ctx.request_repaint();
-            }
-        });
+            });
         if polygon_tool_active {
             if let Some((wx, wy)) = viewport_click_world {
                 if self.add_polygon_vertex(wx, wy) {
@@ -2057,6 +2107,14 @@ impl eframe::App for ViewerApp {
         self.draw_path_dialog(ctx);
         self.draw_unsaved_close_prompt(ctx);
     }
+}
+
+pub fn update_system(
+    mut contexts: EguiContexts,
+    mut viewer: NonSendMut<ViewerApp>,
+) -> bevy::prelude::Result {
+    viewer.update(contexts.ctx_mut()?);
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/gdsr-viewer/src/bevy_renderer.rs
+++ b/crates/gdsr-viewer/src/bevy_renderer.rs
@@ -1,620 +1,780 @@
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap};
 
-use bevy_asset::RenderAssetUsages;
-use bevy_mesh::{Indices, Mesh, PrimitiveTopology};
-use gdsr::{DataType, Element, Layer, Library, Point};
+use bevy::asset::RenderAssetUsages;
+use bevy::camera::{CameraOutputMode, Viewport, visibility::RenderLayers};
+use bevy::math::{DAffine2, DVec2};
+use bevy::mesh::{Indices, Mesh, PrimitiveTopology};
+use bevy::prelude::*;
+use bevy::render::render_resource::BlendState;
+use bevy::sprite::Anchor;
+use bevy::window::{PrimaryWindow, Window};
+use bevy_egui::{EguiGlobalSettings, PrimaryEguiContext};
+use gdsr::{DataType, Layer};
 
-use crate::drawable::{
-    Drawable, WorldBBox, reference_draw_units_for_depth, reference_grid_count,
-    reference_instance_bbox, should_collapse_reference,
-};
-use crate::spatial::SpatialGrid;
+use crate::app::ViewerApp;
+use crate::bevy_scene::{PreparedGeometry, PreparedLibrary, SceneOptions, ScenePlan};
+use crate::drawable::WorldBBox;
 
-pub struct BevyLayerBatch {
-    pub layer: (Layer, DataType),
-    pub mesh: Mesh,
-    pub element_count: usize,
+#[derive(Component)]
+pub struct GdsWorldCamera;
+
+#[derive(Component)]
+pub struct GdsSceneEntity;
+
+#[derive(Resource, Default)]
+pub struct BevyRendererState {
+    prepared: Option<PreparedLibrary>,
+    prepared_cell: Option<String>,
+    geometry_generation: Option<u64>,
+    render_generation: Option<u64>,
+    selected_cell: Option<String>,
+    render_depth: u32,
+    hidden_layers: Vec<(Layer, DataType)>,
+    render_origin: DVec2,
+    render_zoom: f64,
+    viewport_size: Vec2,
+    mesh_handles: Vec<Handle<Mesh>>,
+    material_handles: Vec<Handle<ColorMaterial>>,
 }
 
-pub struct BevyReferenceLoad {
-    pub bbox: WorldBBox,
-    pub cell_name: Option<String>,
+struct LayerAssets {
+    fill: Handle<ColorMaterial>,
+    stroke: Handle<ColorMaterial>,
+    color: Color,
 }
 
-pub struct BevyRenderScene {
-    pub batches: Vec<BevyLayerBatch>,
-    pub reference_lods: Vec<BevyReferenceLoad>,
-    pub batched_element_count: usize,
-    pub skipped_element_count: usize,
-}
-
-pub struct BevySceneOptions<'a> {
-    pub visible: &'a WorldBBox,
-    pub zoom: f64,
-    pub library: Option<&'a Library>,
-    pub render_depth: u32,
-}
-
-#[derive(Debug, PartialEq, Eq)]
-pub enum BevyRenderError {
-    TooManyVertices { layer: (Layer, DataType) },
-}
-
-#[derive(Default)]
-struct MeshBuilder {
-    positions: Vec<[f32; 3]>,
-    indices: Vec<u32>,
-    element_count: usize,
-}
-
-const MIN_VISIBLE_PX: f32 = 1.0;
-const BBOX_FALLBACK_PX: f32 = 8.0;
-
-pub fn build_visible_scene(
-    elements: &[Element],
-    visible_indices: &[u32],
-    hidden_layers: &BTreeSet<(Layer, DataType)>,
-) -> Result<BevyRenderScene, BevyRenderError> {
-    let visible = WorldBBox::new(f64::MIN, f64::MIN, f64::MAX, f64::MAX);
-    build_visible_scene_with_options(
-        elements,
-        visible_indices,
-        hidden_layers,
-        &BevySceneOptions {
-            visible: &visible,
-            zoom: 1.0,
-            library: None,
-            render_depth: 1,
+pub fn setup(mut commands: Commands, mut egui_settings: ResMut<EguiGlobalSettings>) {
+    egui_settings.auto_create_primary_context = false;
+    commands.insert_resource(BevyRendererState::default());
+    commands.spawn((GdsWorldCamera, Camera2d));
+    commands.spawn((
+        PrimaryEguiContext,
+        Camera2d,
+        RenderLayers::none(),
+        Camera {
+            order: 1,
+            output_mode: CameraOutputMode::Write {
+                blend_state: Some(BlendState::ALPHA_BLENDING),
+                clear_color: ClearColorConfig::None,
+            },
+            clear_color: ClearColorConfig::Custom(Color::NONE),
+            ..default()
         },
+    ));
+}
+
+pub fn sync_scene(
+    mut commands: Commands,
+    mut viewer: NonSendMut<ViewerApp>,
+    windows: Query<&Window, With<PrimaryWindow>>,
+    mut cameras: Query<(&mut Camera, &mut Transform, &mut Projection), With<GdsWorldCamera>>,
+    scene_entities: Query<Entity, With<GdsSceneEntity>>,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<ColorMaterial>>,
+    mut state: ResMut<BevyRendererState>,
+) {
+    let Some(window) = windows.iter().next() else {
+        return;
+    };
+    let rect = viewer.viewport_rect();
+    if !rect.is_positive() {
+        return;
+    }
+
+    let (center_x, center_y, zoom) = viewer.viewport_state();
+    let selected_cell = viewer.selected_cell_name().map(str::to_owned);
+
+    let Some(selected_cell_name) = selected_cell.as_deref() else {
+        clear_scene(
+            &mut commands,
+            &scene_entities,
+            &mut meshes,
+            &mut materials,
+            &mut state,
+        );
+        update_camera(window, rect, center_x, center_y, zoom, &state, &mut cameras);
+        state.selected_cell = None;
+        return;
+    };
+
+    let geometry_generation = viewer.geometry_generation();
+    if state.geometry_generation != Some(geometry_generation)
+        || state.prepared_cell.as_deref() != Some(selected_cell_name)
+    {
+        let prepared = viewer
+            .library()
+            .map(|library| PreparedLibrary::build(library, selected_cell_name));
+        match prepared {
+            Some(Ok(prepared)) => state.prepared = Some(prepared),
+            Some(Err(error)) => {
+                log::error!("failed to prepare Bevy scene: {error:?}");
+                state.prepared = None;
+            }
+            None => state.prepared = None,
+        }
+        state.geometry_generation = Some(geometry_generation);
+        state.prepared_cell = Some(selected_cell_name.to_string());
+    }
+
+    let render_generation = viewer.render_generation();
+    let render_depth = viewer.render_depth();
+    let mut hidden_layers: Vec<_> = viewer.hidden_layers().iter().copied().collect();
+    hidden_layers.sort_unstable();
+    let viewport_size = Vec2::new(rect.width(), rect.height());
+    let rebuild = should_rebuild_scene(
+        &state,
+        render_generation,
+        selected_cell_name,
+        render_depth,
+        &hidden_layers,
+        center_x,
+        center_y,
+        zoom,
+        viewport_size,
+    );
+
+    if rebuild {
+        let visible = expanded_visible_rect(center_x, center_y, zoom, viewport_size);
+        let plan = state.prepared.as_ref().map(|prepared| {
+            prepared.plan(
+                selected_cell_name,
+                &SceneOptions {
+                    visible: &visible,
+                    zoom,
+                    depth: render_depth,
+                    hidden_layers: viewer.hidden_layers(),
+                },
+            )
+        });
+
+        clear_scene(
+            &mut commands,
+            &scene_entities,
+            &mut meshes,
+            &mut materials,
+            &mut state,
+        );
+        if let Some(plan) = plan
+            && let Some(prepared) = state.prepared.take()
+        {
+            spawn_plan(
+                &mut commands,
+                &mut viewer,
+                &mut meshes,
+                &mut materials,
+                &mut state,
+                &prepared,
+                &plan,
+                DVec2::new(center_x, center_y),
+                zoom,
+            );
+            state.prepared = Some(prepared);
+        }
+
+        state.render_generation = Some(render_generation);
+        state.selected_cell = selected_cell;
+        state.render_depth = render_depth;
+        state.hidden_layers = hidden_layers;
+        state.render_origin = DVec2::new(center_x, center_y);
+        state.render_zoom = zoom;
+        state.viewport_size = viewport_size;
+    }
+
+    update_camera(window, rect, center_x, center_y, zoom, &state, &mut cameras);
+}
+
+fn should_rebuild_scene(
+    state: &BevyRendererState,
+    render_generation: u64,
+    selected_cell: &str,
+    render_depth: u32,
+    hidden_layers: &[(Layer, DataType)],
+    center_x: f64,
+    center_y: f64,
+    zoom: f64,
+    viewport_size: Vec2,
+) -> bool {
+    if state.prepared.is_none()
+        || state.render_generation != Some(render_generation)
+        || state.selected_cell.as_deref() != Some(selected_cell)
+        || state.render_depth != render_depth
+        || state.hidden_layers != hidden_layers
+        || viewport_size.x > state.viewport_size.x * 2.0
+        || viewport_size.y > state.viewport_size.y * 2.0
+        || !state.render_zoom.is_finite()
+        || state.render_zoom <= 0.0
+    {
+        return true;
+    }
+
+    let zoom_ratio = zoom / state.render_zoom;
+    if !(0.5..=2.0).contains(&zoom_ratio) {
+        return true;
+    }
+    let pan_x = (center_x - state.render_origin.x).abs() * zoom;
+    let pan_y = (center_y - state.render_origin.y).abs() * zoom;
+    let margin_x = (f64::from(state.viewport_size.x) * 1.5 * zoom_ratio
+        - f64::from(viewport_size.x) * 0.5)
+        .max(0.0)
+        * 0.8;
+    let margin_y = (f64::from(state.viewport_size.y) * 1.5 * zoom_ratio
+        - f64::from(viewport_size.y) * 0.5)
+        .max(0.0)
+        * 0.8;
+    pan_x > margin_x || pan_y > margin_y
+}
+
+fn expanded_visible_rect(
+    center_x: f64,
+    center_y: f64,
+    zoom: f64,
+    viewport_size: Vec2,
+) -> WorldBBox {
+    let half_width = f64::from(viewport_size.x) * 1.5 / zoom;
+    let half_height = f64::from(viewport_size.y) * 1.5 / zoom;
+    WorldBBox::new(
+        center_x - half_width,
+        center_y - half_height,
+        center_x + half_width,
+        center_y + half_height,
     )
 }
 
-pub fn build_visible_scene_with_options(
-    elements: &[Element],
-    visible_indices: &[u32],
-    hidden_layers: &BTreeSet<(Layer, DataType)>,
-    options: &BevySceneOptions<'_>,
-) -> Result<BevyRenderScene, BevyRenderError> {
-    let mut builder = SceneBuilder::new(hidden_layers, options);
-    for &idx in visible_indices {
-        let Some(element) = elements.get(idx as usize) else {
-            builder.skipped_element_count += 1;
-            continue;
-        };
-        builder.push_element(element, options.render_depth)?;
+fn clear_scene(
+    commands: &mut Commands,
+    scene_entities: &Query<Entity, With<GdsSceneEntity>>,
+    meshes: &mut Assets<Mesh>,
+    materials: &mut Assets<ColorMaterial>,
+    state: &mut BevyRendererState,
+) {
+    for entity in scene_entities {
+        commands.entity(entity).despawn();
     }
-    Ok(builder.into_scene())
+    for handle in state.mesh_handles.drain(..) {
+        meshes.remove(handle.id());
+    }
+    for handle in state.material_handles.drain(..) {
+        materials.remove(handle.id());
+    }
 }
 
-pub fn build_visible_scene_from_grid(
-    elements: &[Element],
-    grid: &SpatialGrid,
-    visible: &WorldBBox,
-    hidden_layers: &BTreeSet<(Layer, DataType)>,
-    query_buf: &mut Vec<u32>,
-) -> Result<BevyRenderScene, BevyRenderError> {
-    let visible_indices = grid.query_visible_indices(visible, query_buf);
-    build_visible_scene(elements, visible_indices, hidden_layers)
-}
-
-pub fn build_visible_scene_from_grid_with_options(
-    elements: &[Element],
-    grid: &SpatialGrid,
-    visible: &WorldBBox,
-    hidden_layers: &BTreeSet<(Layer, DataType)>,
-    query_buf: &mut Vec<u32>,
-    options: &BevySceneOptions<'_>,
-) -> Result<BevyRenderScene, BevyRenderError> {
-    let visible_indices = grid.query_visible_indices(visible, query_buf);
-    let mut builder = SceneBuilder::new(hidden_layers, options);
-    for &idx in visible_indices {
-        let Some(element) = elements.get(idx as usize) else {
-            builder.skipped_element_count += 1;
-            continue;
-        };
-        builder.push_element(element, options.render_depth)?;
+fn spawn_plan(
+    commands: &mut Commands,
+    viewer: &mut ViewerApp,
+    meshes: &mut Assets<Mesh>,
+    materials: &mut Assets<ColorMaterial>,
+    state: &mut BevyRendererState,
+    prepared: &PreparedLibrary,
+    plan: &ScenePlan,
+    render_origin: DVec2,
+    render_zoom: f64,
+) {
+    let mut layers = BTreeSet::new();
+    for instance in &plan.geometry_instances {
+        layers.insert(prepared.geometries[instance.geometry_id].layer);
     }
+    layers.extend(plan.texts.iter().map(|text| text.layer));
+    layers.extend(plan.node_points.keys().copied());
 
-    for element in elements {
-        if matches!(element, Element::Reference(_)) {
-            builder.push_element(element, options.render_depth)?;
-        }
-    }
-
-    Ok(builder.into_scene())
-}
-
-struct SceneBuilder<'a> {
-    hidden_layers: &'a BTreeSet<(Layer, DataType)>,
-    options: &'a BevySceneOptions<'a>,
-    builders: BTreeMap<(Layer, DataType), MeshBuilder>,
-    reference_lods: Vec<BevyReferenceLoad>,
-    skipped_element_count: usize,
-    cell_bbox_cache: HashMap<String, Option<WorldBBox>>,
-    cell_complexity_cache: HashMap<(String, u32), u64>,
-    reference_stack: HashSet<String>,
-}
-
-impl<'a> SceneBuilder<'a> {
-    fn new(
-        hidden_layers: &'a BTreeSet<(Layer, DataType)>,
-        options: &'a BevySceneOptions<'a>,
-    ) -> Self {
-        Self {
-            hidden_layers,
-            options,
-            builders: BTreeMap::new(),
-            reference_lods: Vec::new(),
-            skipped_element_count: 0,
-            cell_bbox_cache: HashMap::new(),
-            cell_complexity_cache: HashMap::new(),
-            reference_stack: HashSet::new(),
-        }
-    }
-
-    fn into_scene(self) -> BevyRenderScene {
-        let mut batched_element_count = 0;
-        let batches = self
-            .builders
-            .into_iter()
-            .filter_map(|(layer, builder)| {
-                let element_count = builder.element_count;
-                let mesh = builder.into_mesh()?;
-                batched_element_count += element_count;
-                Some(BevyLayerBatch {
-                    layer,
-                    mesh,
-                    element_count,
-                })
-            })
-            .collect();
-
-        BevyRenderScene {
-            batches,
-            reference_lods: self.reference_lods,
-            batched_element_count,
-            skipped_element_count: self.skipped_element_count,
-        }
-    }
-
-    fn push_element(&mut self, element: &Element, depth: u32) -> Result<(), BevyRenderError> {
-        if let Element::Reference(reference) = element {
-            self.push_reference(reference, depth)?;
-            return Ok(());
-        }
-
-        let Some(bbox) = element.world_bbox() else {
-            self.skipped_element_count += 1;
-            return Ok(());
-        };
-        if !bbox.overlaps(self.options.visible) {
-            return Ok(());
-        }
-
-        let Some((layer, points)) = element_polygon_points(element) else {
-            self.skipped_element_count += 1;
-            return Ok(());
-        };
-        if self.hidden_layers.contains(&layer) {
-            return Ok(());
-        }
-
-        let Some(points) = element_level_of_detail_points(&bbox, points, self.options.zoom) else {
-            return Ok(());
-        };
-
-        let builder = self.builders.entry(layer).or_default();
-        if builder.push_polygon(layer, &points)? {
-            builder.element_count += 1;
-        } else {
-            self.skipped_element_count += 1;
-        }
-        Ok(())
-    }
-
-    fn push_reference(
-        &mut self,
-        reference: &gdsr::Reference,
-        depth: u32,
-    ) -> Result<(), BevyRenderError> {
-        let Some(bbox) =
-            reference_instance_bbox(reference, self.options.library, &mut self.cell_bbox_cache)
-        else {
-            self.skipped_element_count += 1;
-            return Ok(());
-        };
-        if !bbox.overlaps(self.options.visible) {
-            return Ok(());
-        }
-
-        let width_px = ((bbox.max_x - bbox.min_x) * self.options.zoom) as f32;
-        let height_px = ((bbox.max_y - bbox.min_y) * self.options.zoom) as f32;
-        let draw_unit_count = reference_draw_units_for_depth(
-            reference,
-            self.options.library,
-            depth,
-            &mut self.cell_complexity_cache,
-            &mut self.reference_stack,
+    let mut layer_materials = HashMap::with_capacity(layers.len());
+    for layer in layers {
+        let color = viewer.layer_color(layer.0, layer.1);
+        let fill = materials.add(ColorMaterial::from_color(Color::srgba_u8(
+            color.r(),
+            color.g(),
+            color.b(),
+            80,
+        )));
+        let stroke = materials.add(ColorMaterial::from_color(Color::srgb_u8(
+            color.r(),
+            color.g(),
+            color.b(),
+        )));
+        state
+            .material_handles
+            .extend([fill.clone(), stroke.clone()]);
+        layer_materials.insert(
+            layer,
+            LayerAssets {
+                fill,
+                stroke,
+                color: Color::srgb_u8(color.r(), color.g(), color.b()),
+            },
         );
-        if should_collapse_reference(
-            width_px.abs(),
-            height_px.abs(),
-            reference_grid_count(reference),
-            draw_unit_count,
-            depth,
-            false,
-        ) {
-            self.reference_lods.push(BevyReferenceLoad {
-                bbox,
-                cell_name: reference.instance().as_cell().cloned(),
-            });
-            return Ok(());
-        }
-
-        let next_depth = depth.saturating_sub(1);
-        if let Some(element) = reference.instance().as_element() {
-            for element in reference.get_elements_in_grid(element.as_ref().as_ref()) {
-                self.push_element(&element, next_depth)?;
-            }
-        } else if let Some(cell_name) = reference.instance().as_cell() {
-            if !self.reference_stack.insert(cell_name.clone()) {
-                self.reference_lods.push(BevyReferenceLoad {
-                    bbox,
-                    cell_name: Some(cell_name.clone()),
-                });
-                return Ok(());
-            }
-            if let Some(cell) = self
-                .options
-                .library
-                .and_then(|library| library.get_cell(cell_name))
-            {
-                for element in cell.iter_elements() {
-                    for transformed in reference.get_elements_in_grid(element) {
-                        self.push_element(&transformed, next_depth)?;
-                    }
-                }
-            }
-            self.reference_stack.remove(cell_name);
-        }
-
-        Ok(())
-    }
-}
-
-fn element_level_of_detail_points(
-    bbox: &WorldBBox,
-    points: Vec<Point>,
-    zoom: f64,
-) -> Option<Vec<Point>> {
-    let Some((width_px, height_px)) = screen_size(bbox, zoom) else {
-        return Some(points);
-    };
-
-    if width_px < MIN_VISIBLE_PX && height_px < MIN_VISIBLE_PX {
-        return None;
     }
 
-    if width_px < BBOX_FALLBACK_PX || height_px < BBOX_FALLBACK_PX {
-        Some(bbox_points(bbox))
-    } else {
-        Some(points)
+    let used_geometry_ids: BTreeSet<_> = plan
+        .geometry_instances
+        .iter()
+        .map(|instance| instance.geometry_id)
+        .collect();
+    let mut geometry_handles = HashMap::with_capacity(used_geometry_ids.len());
+    for geometry_id in used_geometry_ids {
+        let geometry = &prepared.geometries[geometry_id];
+        let handles = upload_geometry(meshes, state, geometry, render_zoom);
+        geometry_handles.insert(geometry_id, handles);
     }
-}
 
-fn screen_size(bbox: &WorldBBox, zoom: f64) -> Option<(f32, f32)> {
-    if !zoom.is_finite() || zoom <= 1.0 {
-        return None;
-    }
-
-    let width = ((bbox.max_x - bbox.min_x) * zoom).abs() as f32;
-    let height = ((bbox.max_y - bbox.min_y) * zoom).abs() as f32;
-    if width.is_finite() && height.is_finite() {
-        Some((width, height))
-    } else {
-        None
-    }
-}
-
-fn bbox_points(bbox: &WorldBBox) -> Vec<Point> {
-    vec![
-        Point::float(bbox.min_x, bbox.min_y, 1.0),
-        Point::float(bbox.max_x, bbox.min_y, 1.0),
-        Point::float(bbox.max_x, bbox.max_y, 1.0),
-        Point::float(bbox.min_x, bbox.max_y, 1.0),
-        Point::float(bbox.min_x, bbox.min_y, 1.0),
-    ]
-}
-
-impl MeshBuilder {
-    fn push_polygon(
-        &mut self,
-        layer: (Layer, DataType),
-        points: &[Point],
-    ) -> Result<bool, BevyRenderError> {
-        let mut coords: Vec<(f64, f64)> = points
-            .iter()
-            .map(|p| (p.x().absolute_value(), p.y().absolute_value()))
-            .collect();
-        if coords.len() >= 2 && coords.first() == coords.last() {
-            coords.pop();
-        }
-        if coords.len() < 3 {
-            return Ok(false);
-        }
-
-        let mut flat = Vec::with_capacity(coords.len() * 2);
-        for &(x, y) in &coords {
-            flat.push(x);
-            flat.push(y);
-        }
-        let Ok(indices) = earcutr::earcut(&flat, &[], 2) else {
-            return Ok(false);
+    for instance in &plan.geometry_instances {
+        let geometry = &prepared.geometries[instance.geometry_id];
+        let Some((fill_mesh, line_mesh)) = geometry_handles.get(&instance.geometry_id) else {
+            continue;
         };
-        if indices.is_empty() {
-            return Ok(false);
+        let Some(layer_assets) = layer_materials.get(&geometry.layer) else {
+            continue;
+        };
+        let base_depth = layer_depth(geometry.layer);
+        let transform = instance_transform(
+            instance.transform,
+            geometry.origin,
+            render_origin,
+            render_zoom,
+            base_depth,
+        );
+        if let Some(fill_mesh) = fill_mesh {
+            commands.spawn((
+                GdsSceneEntity,
+                Mesh2d(fill_mesh.clone()),
+                MeshMaterial2d(layer_assets.fill.clone()),
+                transform,
+            ));
         }
-
-        let base = u32::try_from(self.positions.len())
-            .map_err(|_| BevyRenderError::TooManyVertices { layer })?;
-        for &(x, y) in &coords {
-            self.positions.push([x as f32, y as f32, 0.0]);
+        if let Some(line_mesh) = line_mesh {
+            let mut line_transform = transform;
+            line_transform.translation.z += 0.0001;
+            commands.spawn((
+                GdsSceneEntity,
+                Mesh2d(line_mesh.clone()),
+                MeshMaterial2d(layer_assets.stroke.clone()),
+                line_transform,
+            ));
         }
-        for idx in indices {
-            let idx = u32::try_from(idx).map_err(|_| BevyRenderError::TooManyVertices { layer })?;
-            self.indices.push(base + idx);
-        }
-
-        Ok(true)
     }
 
-    fn into_mesh(self) -> Option<Mesh> {
-        if self.positions.is_empty() || self.indices.is_empty() {
-            return None;
-        }
+    spawn_load_proxies(
+        commands,
+        meshes,
+        materials,
+        state,
+        plan,
+        render_origin,
+        render_zoom,
+    );
+    spawn_nodes(
+        commands,
+        meshes,
+        state,
+        plan,
+        &layer_materials,
+        render_origin,
+        render_zoom,
+    );
+    spawn_texts(commands, plan, &layer_materials, render_origin, render_zoom);
+}
 
-        Some(
-            Mesh::new(
-                PrimitiveTopology::TriangleList,
-                RenderAssetUsages::RENDER_WORLD,
-            )
-            .with_inserted_attribute(Mesh::ATTRIBUTE_POSITION, self.positions)
-            .with_inserted_indices(Indices::U32(self.indices)),
-        )
+fn upload_geometry(
+    meshes: &mut Assets<Mesh>,
+    state: &mut BevyRendererState,
+    geometry: &PreparedGeometry,
+    render_zoom: f64,
+) -> (Option<Handle<Mesh>>, Option<Handle<Mesh>>) {
+    let positions: Vec<[f32; 3]> = geometry
+        .positions
+        .iter()
+        .map(|position| {
+            let position = (*position - geometry.origin) * render_zoom;
+            [position.x as f32, position.y as f32, 0.0]
+        })
+        .collect();
+    let fill = make_mesh(
+        PrimitiveTopology::TriangleList,
+        positions.clone(),
+        geometry.triangle_indices.clone(),
+    )
+    .map(|mesh| meshes.add(mesh));
+    let lines = make_mesh(
+        PrimitiveTopology::LineList,
+        positions,
+        geometry.line_indices.clone(),
+    )
+    .map(|mesh| meshes.add(mesh));
+    state.mesh_handles.extend(fill.iter().cloned());
+    state.mesh_handles.extend(lines.iter().cloned());
+    (fill, lines)
+}
+
+fn make_mesh(
+    topology: PrimitiveTopology,
+    positions: Vec<[f32; 3]>,
+    indices: Vec<u32>,
+) -> Option<Mesh> {
+    if positions.is_empty() || indices.is_empty() {
+        return None;
+    }
+    Some(
+        Mesh::new(topology, RenderAssetUsages::RENDER_WORLD)
+            .with_inserted_attribute(Mesh::ATTRIBUTE_POSITION, positions)
+            .with_inserted_indices(Indices::U32(indices)),
+    )
+}
+
+fn instance_transform(
+    transform: DAffine2,
+    geometry_origin: DVec2,
+    render_origin: DVec2,
+    render_zoom: f64,
+    depth: f32,
+) -> Transform {
+    let world_origin = transform.transform_point2(geometry_origin);
+    let translation = (world_origin - render_origin) * render_zoom;
+    let (scale, angle, _) = transform.to_scale_angle_translation();
+    Transform {
+        translation: Vec3::new(translation.x as f32, translation.y as f32, depth),
+        rotation: Quat::from_rotation_z(angle as f32),
+        scale: Vec3::new(scale.x as f32, scale.y as f32, 1.0),
     }
 }
 
-fn element_polygon_points(element: &Element) -> Option<((Layer, DataType), Vec<Point>)> {
-    match element {
-        Element::Polygon(polygon) => Some((
-            (polygon.layer(), polygon.data_type()),
-            polygon.points().to_vec(),
-        )),
-        Element::Box(gds_box) => Some((
-            (gds_box.layer(), gds_box.box_type()),
-            gds_box.points().to_vec(),
-        )),
-        Element::Path(path) => path
-            .to_polygon_points(16)
-            .map(|points| ((path.layer(), path.data_type()), points)),
-        Element::Node(_) | Element::Text(_) | Element::Reference(_) => None,
+fn layer_depth(layer: (Layer, DataType)) -> f32 {
+    f32::from(layer.0.value()) * 0.001 + f32::from(layer.1.value()) * 0.000_001
+}
+
+fn scene_position(position: DVec2, render_origin: DVec2, render_zoom: f64) -> Vec2 {
+    let position = (position - render_origin) * render_zoom;
+    Vec2::new(position.x as f32, position.y as f32)
+}
+
+fn proxy_screen_bounds(bbox: WorldBBox, render_origin: DVec2, render_zoom: f64) -> (Vec2, Vec2) {
+    let mut min = scene_position(
+        DVec2::new(bbox.min_x, bbox.min_y),
+        render_origin,
+        render_zoom,
+    );
+    let mut max = scene_position(
+        DVec2::new(bbox.max_x, bbox.max_y),
+        render_origin,
+        render_zoom,
+    );
+    if max.x - min.x < 4.0 {
+        let center = f32::midpoint(min.x, max.x);
+        min.x = center - 2.0;
+        max.x = center + 2.0;
     }
+    if max.y - min.y < 4.0 {
+        let center = f32::midpoint(min.y, max.y);
+        min.y = center - 2.0;
+        max.y = center + 2.0;
+    }
+    (min, max)
+}
+
+fn spawn_load_proxies(
+    commands: &mut Commands,
+    meshes: &mut Assets<Mesh>,
+    materials: &mut Assets<ColorMaterial>,
+    state: &mut BevyRendererState,
+    plan: &ScenePlan,
+    render_origin: DVec2,
+    render_zoom: f64,
+) {
+    if plan.load_proxies.is_empty() {
+        return;
+    }
+    let mut positions = Vec::with_capacity(plan.load_proxies.len() * 4);
+    let mut triangles = Vec::with_capacity(plan.load_proxies.len() * 6);
+    let mut lines = Vec::with_capacity(plan.load_proxies.len() * 8);
+    for proxy in &plan.load_proxies {
+        let Ok(base) = u32::try_from(positions.len()) else {
+            break;
+        };
+        let (min, max) = proxy_screen_bounds(proxy.bbox, render_origin, render_zoom);
+        positions.extend([
+            [min.x, min.y, 0.0],
+            [max.x, min.y, 0.0],
+            [max.x, max.y, 0.0],
+            [min.x, max.y, 0.0],
+        ]);
+        triangles.extend([base, base + 1, base + 2, base, base + 2, base + 3]);
+        lines.extend([
+            base,
+            base + 1,
+            base + 1,
+            base + 2,
+            base + 2,
+            base + 3,
+            base + 3,
+            base,
+        ]);
+    }
+
+    let fill_material = materials.add(ColorMaterial::from_color(Color::srgba_u8(
+        180, 180, 180, 25,
+    )));
+    let stroke_material = materials.add(ColorMaterial::from_color(Color::srgb_u8(180, 180, 180)));
+    state
+        .material_handles
+        .extend([fill_material.clone(), stroke_material.clone()]);
+    if let Some(mesh) = make_mesh(
+        PrimitiveTopology::TriangleList,
+        positions.clone(),
+        triangles,
+    ) {
+        let handle = meshes.add(mesh);
+        state.mesh_handles.push(handle.clone());
+        commands.spawn((
+            GdsSceneEntity,
+            Mesh2d(handle),
+            MeshMaterial2d(fill_material),
+            Transform::from_xyz(0.0, 0.0, 100.0),
+        ));
+    }
+    if let Some(mesh) = make_mesh(PrimitiveTopology::LineList, positions, lines) {
+        let handle = meshes.add(mesh);
+        state.mesh_handles.push(handle.clone());
+        commands.spawn((
+            GdsSceneEntity,
+            Mesh2d(handle),
+            MeshMaterial2d(stroke_material),
+            Transform::from_xyz(0.0, 0.0, 100.001),
+        ));
+    }
+
+    for proxy in plan.load_proxies.iter().take(2_048) {
+        let width = (proxy.bbox.max_x - proxy.bbox.min_x).abs() * render_zoom;
+        let height = (proxy.bbox.max_y - proxy.bbox.min_y).abs() * render_zoom;
+        let Some(label) = proxy.label.as_deref() else {
+            continue;
+        };
+        if width < 40.0 || height < 20.0 {
+            continue;
+        }
+        let center = scene_position(
+            DVec2::new(
+                f64::midpoint(proxy.bbox.min_x, proxy.bbox.max_x),
+                f64::midpoint(proxy.bbox.min_y, proxy.bbox.max_y),
+            ),
+            render_origin,
+            render_zoom,
+        );
+        commands.spawn((
+            GdsSceneEntity,
+            Text2d::new(label),
+            TextFont::from_font_size(12.0),
+            TextColor(Color::srgb_u8(180, 180, 180)),
+            Anchor::CENTER,
+            Transform::from_xyz(center.x, center.y, 100.002),
+        ));
+    }
+}
+
+fn spawn_nodes(
+    commands: &mut Commands,
+    meshes: &mut Assets<Mesh>,
+    state: &mut BevyRendererState,
+    plan: &ScenePlan,
+    layer_materials: &HashMap<(Layer, DataType), LayerAssets>,
+    render_origin: DVec2,
+    render_zoom: f64,
+) {
+    for (layer, points) in &plan.node_points {
+        let mut positions = Vec::with_capacity(points.len() * 4);
+        let mut triangles = Vec::with_capacity(points.len() * 6);
+        for point in points {
+            let Ok(base) = u32::try_from(positions.len()) else {
+                break;
+            };
+            let point = scene_position(*point, render_origin, render_zoom);
+            let half_size = 3.0;
+            positions.extend([
+                [point.x - half_size, point.y - half_size, 0.0],
+                [point.x + half_size, point.y - half_size, 0.0],
+                [point.x + half_size, point.y + half_size, 0.0],
+                [point.x - half_size, point.y + half_size, 0.0],
+            ]);
+            triangles.extend([base, base + 1, base + 2, base, base + 2, base + 3]);
+        }
+        let Some(mesh) = make_mesh(PrimitiveTopology::TriangleList, positions, triangles) else {
+            continue;
+        };
+        let Some(layer_assets) = layer_materials.get(layer) else {
+            continue;
+        };
+        let handle = meshes.add(mesh);
+        state.mesh_handles.push(handle.clone());
+        commands.spawn((
+            GdsSceneEntity,
+            Mesh2d(handle),
+            MeshMaterial2d(layer_assets.stroke.clone()),
+            Transform::from_xyz(0.0, 0.0, layer_depth(*layer) + 0.0002),
+        ));
+    }
+}
+
+fn spawn_texts(
+    commands: &mut Commands,
+    plan: &ScenePlan,
+    layer_materials: &HashMap<(Layer, DataType), LayerAssets>,
+    render_origin: DVec2,
+    render_zoom: f64,
+) {
+    for text in plan.texts.iter().take(10_000) {
+        let Some(layer_assets) = layer_materials.get(&text.layer) else {
+            continue;
+        };
+        let position = scene_position(text.position, render_origin, render_zoom);
+        commands.spawn((
+            GdsSceneEntity,
+            Text2d::new(text.value.as_ref()),
+            TextFont::from_font_size(12.0),
+            TextColor(layer_assets.color),
+            Anchor::BOTTOM_LEFT,
+            Transform::from_xyz(position.x, position.y, layer_depth(text.layer) + 0.0002),
+        ));
+    }
+}
+
+fn update_camera(
+    window: &Window,
+    rect: egui::Rect,
+    center_x: f64,
+    center_y: f64,
+    zoom: f64,
+    state: &BevyRendererState,
+    cameras: &mut Query<(&mut Camera, &mut Transform, &mut Projection), With<GdsWorldCamera>>,
+) {
+    let scale_factor = window.scale_factor();
+    let position = UVec2::new(
+        (rect.min.x * scale_factor).max(0.0) as u32,
+        (rect.min.y * scale_factor).max(0.0) as u32,
+    );
+    let available = UVec2::new(
+        window.physical_width().saturating_sub(position.x).max(1),
+        window.physical_height().saturating_sub(position.y).max(1),
+    );
+    let size = UVec2::new(
+        (rect.width() * scale_factor).max(1.0) as u32,
+        (rect.height() * scale_factor).max(1.0) as u32,
+    )
+    .min(available);
+    let (camera_position, projection_scale) = camera_frame(state, center_x, center_y, zoom);
+
+    for (mut camera, mut transform, mut projection) in cameras.iter_mut() {
+        camera.viewport = Some(Viewport {
+            physical_position: position,
+            physical_size: size,
+            ..default()
+        });
+        transform.translation.x = camera_position.x as f32;
+        transform.translation.y = camera_position.y as f32;
+        if let Projection::Orthographic(projection) = projection.as_mut() {
+            projection.scale = projection_scale as f32;
+        }
+    }
+}
+
+fn camera_frame(
+    state: &BevyRendererState,
+    center_x: f64,
+    center_y: f64,
+    zoom: f64,
+) -> (DVec2, f64) {
+    let render_zoom = if state.render_zoom.is_finite() && state.render_zoom > 0.0 {
+        state.render_zoom
+    } else if zoom.is_finite() && zoom > 0.0 {
+        zoom
+    } else {
+        1.0
+    };
+    let camera_position = (DVec2::new(center_x, center_y) - state.render_origin) * render_zoom;
+    let projection_scale = if zoom.is_finite() && zoom > 0.0 {
+        render_zoom / zoom
+    } else {
+        1.0
+    };
+    (camera_position, projection_scale)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bevy_mesh::VertexAttributeValues;
+    use gdsr::{Cell, Library};
 
-    use crate::testutil::helpers::{path, polygon, text};
-    use crate::viewport::bounds::compute_bounds;
-
-    fn mesh_positions(mesh: &Mesh) -> &[[f32; 3]] {
-        match mesh.attribute(Mesh::ATTRIBUTE_POSITION) {
-            Some(VertexAttributeValues::Float32x3(positions)) => positions,
-            _ => panic!("mesh should have f32x3 positions"),
+    fn renderer_state() -> BevyRendererState {
+        let mut library = Library::new("test");
+        library.add_cell(Cell::new("top"));
+        BevyRendererState {
+            prepared: Some(PreparedLibrary::build(&library, "top").expect("scene should prepare")),
+            prepared_cell: Some("top".to_string()),
+            render_generation: Some(1),
+            selected_cell: Some("top".to_string()),
+            render_depth: 5,
+            render_origin: DVec2::ZERO,
+            render_zoom: 10.0,
+            viewport_size: Vec2::splat(100.0),
+            ..default()
         }
     }
 
-    fn mesh_index_count(mesh: &Mesh) -> usize {
-        match mesh.indices() {
-            Some(Indices::U32(indices)) => indices.len(),
-            _ => panic!("mesh should have u32 indices"),
-        }
-    }
-
-    fn visible() -> WorldBBox {
-        WorldBBox::new(-1.0, -1.0, 1.0, 1.0)
+    fn should_rebuild(state: &BevyRendererState, center_x: f64, zoom: f64, size: Vec2) -> bool {
+        should_rebuild_scene(state, 1, "top", 5, &[], center_x, 0.0, zoom, size)
     }
 
     #[test]
-    fn build_visible_scene_batches_polygon_meshes_by_layer() {
-        let elements = vec![
-            polygon(vec![(0, 0), (100, 0), (100, 100), (0, 100)], 1, 0),
-            polygon(vec![(200, 0), (300, 0), (300, 100), (200, 100)], 1, 0),
-        ];
-        let hidden_layers = BTreeSet::new();
+    fn camera_changes_inside_scene_margin_do_not_rebuild() {
+        let state = renderer_state();
 
-        let scene = build_visible_scene(&elements, &[0, 1], &hidden_layers)
-            .expect("test scene should build");
-
-        assert_eq!(scene.batches.len(), 1);
-        assert_eq!(scene.reference_lods.len(), 0);
-        assert_eq!(scene.batched_element_count, 2);
-        assert_eq!(scene.skipped_element_count, 0);
-        assert_eq!(scene.batches[0].element_count, 2);
-        assert_eq!(mesh_positions(&scene.batches[0].mesh).len(), 8);
-        assert_eq!(mesh_index_count(&scene.batches[0].mesh), 12);
+        assert!(!should_rebuild(&state, 3.9, 10.0, Vec2::splat(199.0)));
+        assert!(!should_rebuild(&state, 3.9, 5.0, Vec2::splat(100.0)));
+        assert!(!should_rebuild(&state, 0.0, 19.9, Vec2::splat(100.0)));
     }
 
     #[test]
-    fn build_visible_scene_uses_spatial_indices() {
-        let scale = 1e-9;
-        let elements = vec![
-            polygon(vec![(0, 0), (100, 0), (100, 100)], 1, 0),
-            polygon(vec![(9900, 9900), (10000, 9900), (10000, 10000)], 2, 0),
-        ];
-        let bounds = compute_bounds(&elements).expect("test elements should have bounds");
-        let grid = SpatialGrid::build(&elements, &bounds);
-        let visible = WorldBBox::new(0.0, 0.0, 1000.0 * scale, 1000.0 * scale);
-        let mut query_buf = Vec::new();
-        let scene = build_visible_scene_from_grid(
-            &elements,
-            &grid,
-            &visible,
-            &BTreeSet::new(),
-            &mut query_buf,
-        )
-        .expect("test scene should build");
+    fn camera_changes_outside_scene_margin_rebuild() {
+        let state = renderer_state();
 
-        assert_eq!(scene.batched_element_count, 1);
-        assert_eq!(scene.batches[0].layer, (Layer::new(1), DataType::new(0)));
-        assert_eq!(query_buf, &[0]);
+        assert!(should_rebuild(&state, 8.1, 10.0, Vec2::splat(100.0)));
+        assert!(should_rebuild(&state, 5.0, 5.0, Vec2::splat(100.0)));
+        assert!(should_rebuild(&state, 0.0, 20.1, Vec2::splat(100.0)));
+        assert!(should_rebuild(&state, 0.0, 10.0, Vec2::splat(201.0)));
     }
 
     #[test]
-    fn build_visible_scene_skips_hidden_layers_and_unsupported_elements() {
-        let elements = vec![
-            polygon(vec![(0, 0), (100, 0), (100, 100)], 1, 0),
-            polygon(vec![(200, 0), (300, 0), (300, 100)], 2, 0),
-            text("label", 0, 0, 3),
-        ];
-        let hidden_layers = BTreeSet::from([(Layer::new(2), DataType::new(0))]);
-
-        let scene = build_visible_scene(&elements, &[0, 1, 2], &hidden_layers)
-            .expect("test scene should build");
-
-        assert_eq!(scene.batches.len(), 1);
-        assert_eq!(scene.batches[0].layer, (Layer::new(1), DataType::new(0)));
-        assert_eq!(scene.batched_element_count, 1);
-        assert_eq!(scene.skipped_element_count, 1);
-    }
-
-    #[test]
-    fn build_visible_scene_expands_paths_to_meshes() {
-        let elements = vec![path(vec![(0, 0), (100, 0), (100, 100)], 7, 2, Some(10))];
-
-        let scene =
-            build_visible_scene(&elements, &[0], &BTreeSet::new()).expect("path should build");
-
-        assert_eq!(scene.batched_element_count, 1);
-        assert_eq!(scene.batches[0].layer, (Layer::new(7), DataType::new(2)));
-        assert!(!mesh_positions(&scene.batches[0].mesh).is_empty());
-        assert!(scene.batches[0].mesh.indices().is_some());
-    }
-
-    #[test]
-    fn bevy_scene_collapses_dense_referenced_cell_to_load() {
-        let mut leaf = gdsr::Cell::new("leaf");
-        for i in 0..200 {
-            let x = i * 20;
-            leaf.add(polygon(
-                vec![(x, 0), (x + 10, 0), (x + 10, 10), (x, 10)],
-                1,
-                0,
-            ));
-        }
-        let mut library = Library::new("lib");
-        library.add_cell(leaf);
-        let elements = vec![Element::Reference(gdsr::Reference::new("leaf"))];
-        let visible = visible();
-
-        let scene = build_visible_scene_with_options(
-            &elements,
-            &[0],
-            &BTreeSet::new(),
-            &BevySceneOptions {
-                visible: &visible,
-                zoom: 1.0e6,
-                library: Some(&library),
-                render_depth: 2,
-            },
-        )
-        .expect("scene should build");
-
-        assert_eq!(scene.batched_element_count, 0);
-        assert_eq!(scene.reference_lods.len(), 1);
-        assert_eq!(scene.reference_lods[0].cell_name.as_deref(), Some("leaf"));
-    }
-
-    #[test]
-    fn bevy_scene_expands_sparse_referenced_cell() {
-        let mut leaf = gdsr::Cell::new("leaf");
-        leaf.add(polygon(vec![(0, 0), (100, 0), (100, 100), (0, 100)], 1, 0));
-        leaf.add(polygon(
-            vec![(200, 0), (300, 0), (300, 100), (200, 100)],
-            1,
-            0,
+    fn instance_transform_preserves_reflection_and_rotation() {
+        let affine = DAffine2::from_scale_angle_translation(
+            DVec2::new(2.0, -3.0),
+            std::f64::consts::FRAC_PI_3,
+            DVec2::new(5.0, 7.0),
+        );
+        let geometry_origin = DVec2::new(11.0, 13.0);
+        let render_origin = DVec2::new(2.0, 3.0);
+        let render_zoom = 4.0;
+        let local_point = DVec2::new(1.5, -2.5);
+        let transform =
+            instance_transform(affine, geometry_origin, render_origin, render_zoom, 0.0);
+        let actual = transform.transform_point(Vec3::new(
+            (local_point.x * render_zoom) as f32,
+            (local_point.y * render_zoom) as f32,
+            0.0,
         ));
-        let mut library = Library::new("lib");
-        library.add_cell(leaf);
-        let elements = vec![Element::Reference(gdsr::Reference::new("leaf"))];
-        let visible = visible();
+        let expected =
+            (affine.transform_point2(geometry_origin + local_point) - render_origin) * render_zoom;
 
-        let scene = build_visible_scene_with_options(
-            &elements,
-            &[0],
-            &BTreeSet::new(),
-            &BevySceneOptions {
-                visible: &visible,
-                zoom: 1.0e12,
-                library: Some(&library),
-                render_depth: 2,
-            },
-        )
-        .expect("scene should build");
-
-        assert_eq!(scene.reference_lods.len(), 0);
-        assert_eq!(scene.batched_element_count, 2);
+        assert!((f64::from(actual.x) - expected.x).abs() < 1.0e-4);
+        assert!((f64::from(actual.y) - expected.y).abs() < 1.0e-4);
     }
 
     #[test]
-    fn bevy_scene_skips_subpixel_polygon() {
-        let elements = vec![polygon(vec![(0, 0), (100, 0), (100, 100), (0, 100)], 1, 0)];
-        let visible = visible();
+    fn point_proxy_has_visible_screen_area() {
+        let (min, max) = proxy_screen_bounds(WorldBBox::new(1.0, 2.0, 1.0, 2.0), DVec2::ZERO, 10.0);
 
-        let scene = build_visible_scene_with_options(
-            &elements,
-            &[0],
-            &BTreeSet::new(),
-            &BevySceneOptions {
-                visible: &visible,
-                zoom: 1.0e6,
-                library: None,
-                render_depth: 1,
-            },
-        )
-        .expect("scene should build");
-
-        assert!(scene.batches.is_empty());
-        assert_eq!(scene.batched_element_count, 0);
+        assert_eq!(max - min, Vec2::splat(4.0));
     }
 
     #[test]
-    fn bevy_scene_uses_bbox_proxy_for_skinny_polygon() {
-        let elements = vec![polygon(
-            vec![(0, 0), (4000, 0), (4000, 4), (3000, 4), (2000, 2), (0, 4)],
-            1,
-            0,
-        )];
-        let visible = visible();
+    fn empty_scene_uses_live_zoom_for_valid_camera_projection() {
+        let (position, scale) = camera_frame(&BevyRendererState::default(), 2.0, 3.0, 4.0);
 
-        let scene = build_visible_scene_with_options(
-            &elements,
-            &[0],
-            &BTreeSet::new(),
-            &BevySceneOptions {
-                visible: &visible,
-                zoom: 1.0e9,
-                library: None,
-                render_depth: 1,
-            },
-        )
-        .expect("scene should build");
-
-        assert_eq!(scene.batched_element_count, 1);
-        assert_eq!(scene.batches.len(), 1);
-        assert_eq!(mesh_positions(&scene.batches[0].mesh).len(), 4);
-        assert_eq!(mesh_index_count(&scene.batches[0].mesh), 6);
+        assert_eq!(position, DVec2::new(8.0, 12.0));
+        assert_eq!(scale, 1.0);
     }
 }

--- a/crates/gdsr-viewer/src/bevy_scene.rs
+++ b/crates/gdsr-viewer/src/bevy_scene.rs
@@ -1,0 +1,1225 @@
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::sync::Arc;
+
+use bevy::math::{DAffine2, DMat2, DVec2};
+use gdsr::{DataType, Element, Grid, Layer, Library, Point};
+
+use crate::drawable::{Drawable, WorldBBox, cell_world_bboxes, should_collapse_reference};
+
+const MAX_DETAIL_CELLS: usize = 20_000;
+const MAX_SCENE_OBJECTS: usize = 20_000;
+const MAX_TEXT_INSTANCES: usize = 10_000;
+const MAX_LOAD_PROXIES: usize = 100_000;
+const MAX_BATCH_ELEMENTS: u32 = 256;
+const DENSE_BATCH_MIN_ELEMENTS: u32 = 128;
+const MIN_AVERAGE_ELEMENT_AREA_PX: f32 = 16.0;
+const MIN_FIXED_CONTENT_PX: f32 = 24.0;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum SceneBuildError {
+    TooManyVertices { layer: (Layer, DataType) },
+}
+
+#[derive(Default)]
+struct GeometryBuilder {
+    positions: Vec<DVec2>,
+    triangle_indices: Vec<u32>,
+    line_indices: Vec<u32>,
+    element_count: u32,
+}
+
+pub struct PreparedGeometry {
+    pub layer: (Layer, DataType),
+    pub positions: Vec<DVec2>,
+    pub triangle_indices: Vec<u32>,
+    pub line_indices: Vec<u32>,
+    pub origin: DVec2,
+    bbox: WorldBBox,
+    element_count: u32,
+}
+
+#[derive(Clone)]
+struct PreparedText {
+    value: Arc<str>,
+    origin: DVec2,
+    layer: (Layer, DataType),
+}
+
+#[derive(Clone)]
+struct PreparedNode {
+    points: Vec<DVec2>,
+    layer: (Layer, DataType),
+}
+
+enum PreparedSource {
+    Cell(String),
+    Geometry(usize),
+    Text(PreparedText),
+    Node(PreparedNode),
+    Reference(Box<PreparedReference>),
+}
+
+struct PreparedReference {
+    grid: Grid,
+    source: PreparedSource,
+    source_bbox: Option<WorldBBox>,
+    label: Option<Arc<str>>,
+}
+
+struct PreparedCell {
+    geometry_ids: Vec<usize>,
+    direct_draw_units: u64,
+    texts: Vec<PreparedText>,
+    nodes: Vec<PreparedNode>,
+    references: Vec<PreparedReference>,
+    bbox: Option<WorldBBox>,
+}
+
+pub struct PreparedLibrary {
+    cells: HashMap<String, PreparedCell>,
+    pub geometries: Vec<PreparedGeometry>,
+}
+
+pub struct SceneOptions<'a> {
+    pub visible: &'a WorldBBox,
+    pub zoom: f64,
+    pub depth: u32,
+    pub hidden_layers: &'a HashSet<(Layer, DataType)>,
+}
+
+pub struct GeometryInstance {
+    pub geometry_id: usize,
+    pub transform: DAffine2,
+}
+
+pub struct LoadProxy {
+    pub bbox: WorldBBox,
+    pub label: Option<Arc<str>>,
+}
+
+pub struct TextInstance {
+    pub value: Arc<str>,
+    pub position: DVec2,
+    pub layer: (Layer, DataType),
+}
+
+#[derive(Default)]
+pub struct SceneStats {
+    pub detail_cells: usize,
+    pub detail_objects: usize,
+    pub culled_references: usize,
+    pub skipped_subpixel_references: usize,
+    pub culled_geometry_batches: usize,
+    pub skipped_subpixel_geometry_batches: usize,
+}
+
+#[derive(Default)]
+pub struct ScenePlan {
+    pub geometry_instances: Vec<GeometryInstance>,
+    pub load_proxies: Vec<LoadProxy>,
+    pub texts: Vec<TextInstance>,
+    pub node_points: BTreeMap<(Layer, DataType), Vec<DVec2>>,
+    pub stats: SceneStats,
+}
+
+impl GeometryBuilder {
+    fn push_polygon(
+        &mut self,
+        layer: (Layer, DataType),
+        points: &[Point],
+    ) -> Result<(), SceneBuildError> {
+        let mut coordinates: Vec<DVec2> = points.iter().map(point_position).collect();
+        if coordinates.len() >= 2 && coordinates.first() == coordinates.last() {
+            coordinates.pop();
+        }
+        if coordinates.len() < 3 {
+            return Ok(());
+        }
+
+        let mut flat = Vec::with_capacity(coordinates.len() * 2);
+        for point in &coordinates {
+            flat.extend([point.x, point.y]);
+        }
+        let Ok(triangles) = earcutr::earcut(&flat, &[], 2) else {
+            return Ok(());
+        };
+        if triangles.is_empty() {
+            return Ok(());
+        }
+
+        let base = u32::try_from(self.positions.len())
+            .map_err(|_| SceneBuildError::TooManyVertices { layer })?;
+        let vertex_count = u32::try_from(coordinates.len())
+            .map_err(|_| SceneBuildError::TooManyVertices { layer })?;
+        self.positions.extend(coordinates);
+        for triangle in triangles {
+            let index =
+                u32::try_from(triangle).map_err(|_| SceneBuildError::TooManyVertices { layer })?;
+            self.triangle_indices.push(base + index);
+        }
+        for index in 0..vertex_count {
+            self.line_indices.push(base + index);
+            self.line_indices.push(base + ((index + 1) % vertex_count));
+        }
+        self.element_count = self.element_count.saturating_add(1);
+        Ok(())
+    }
+
+    fn finish(self, layer: (Layer, DataType)) -> Option<PreparedGeometry> {
+        if self.positions.is_empty() || self.triangle_indices.is_empty() {
+            return None;
+        }
+        let mut min = DVec2::splat(f64::INFINITY);
+        let mut max = DVec2::splat(f64::NEG_INFINITY);
+        for position in &self.positions {
+            min = min.min(*position);
+            max = max.max(*position);
+        }
+
+        Some(PreparedGeometry {
+            layer,
+            positions: self.positions,
+            triangle_indices: self.triangle_indices,
+            line_indices: self.line_indices,
+            origin: (min + max) * 0.5,
+            bbox: WorldBBox::new(min.x, min.y, max.x, max.y),
+            element_count: self.element_count,
+        })
+    }
+}
+
+fn push_polygon_batch(
+    builders: &mut BTreeMap<(Layer, DataType), Vec<GeometryBuilder>>,
+    layer: (Layer, DataType),
+    points: &[Point],
+) -> Result<(), SceneBuildError> {
+    let layer_builders = builders.entry(layer).or_default();
+    if layer_builders
+        .last()
+        .is_none_or(|builder| builder.element_count >= MAX_BATCH_ELEMENTS)
+    {
+        layer_builders.push(GeometryBuilder::default());
+    }
+    if let Some(builder) = layer_builders.last_mut() {
+        builder.push_polygon(layer, points)?;
+    }
+    Ok(())
+}
+
+impl PreparedLibrary {
+    pub fn build(library: &Library, root_cell: &str) -> Result<Self, SceneBuildError> {
+        let cell_bboxes = cell_world_bboxes(library, root_cell);
+        let cell_names = reachable_cell_names(library, root_cell);
+        let mut prepared = Self {
+            cells: HashMap::with_capacity(cell_names.len()),
+            geometries: Vec::new(),
+        };
+
+        for cell_name in cell_names {
+            let Some(cell) = library.get_cell(&cell_name) else {
+                continue;
+            };
+            let mut builders = BTreeMap::<(Layer, DataType), Vec<GeometryBuilder>>::new();
+            let mut direct_draw_units = 0_u64;
+            let mut texts = Vec::new();
+            let mut nodes = Vec::new();
+            let mut references = Vec::new();
+
+            for element in cell.iter_elements() {
+                if !matches!(element, Element::Reference(_)) {
+                    direct_draw_units = direct_draw_units.saturating_add(1);
+                }
+                match element {
+                    Element::Polygon(polygon) => push_polygon_batch(
+                        &mut builders,
+                        (polygon.layer(), polygon.data_type()),
+                        polygon.points(),
+                    )?,
+                    Element::Box(gds_box) => push_polygon_batch(
+                        &mut builders,
+                        (gds_box.layer(), gds_box.box_type()),
+                        &gds_box.points(),
+                    )?,
+                    Element::Path(path) => {
+                        if let Some(points) = path.to_polygon_points(16) {
+                            push_polygon_batch(
+                                &mut builders,
+                                (path.layer(), path.data_type()),
+                                &points,
+                            )?;
+                        }
+                    }
+                    Element::Text(text) => texts.push(prepare_text(text)),
+                    Element::Node(node) => nodes.push(prepare_node(node)),
+                    Element::Reference(reference) => {
+                        references.push(prepared.prepare_reference(reference, &cell_bboxes)?);
+                    }
+                }
+            }
+
+            let mut geometry_ids = Vec::new();
+            for (layer, layer_builders) in builders {
+                for builder in layer_builders {
+                    if let Some(geometry) = builder.finish(layer) {
+                        geometry_ids.push(prepared.geometries.len());
+                        prepared.geometries.push(geometry);
+                    }
+                }
+            }
+
+            prepared.cells.insert(
+                cell_name.clone(),
+                PreparedCell {
+                    geometry_ids,
+                    direct_draw_units,
+                    texts,
+                    nodes,
+                    references,
+                    bbox: cell_bboxes.get(&cell_name).copied().flatten(),
+                },
+            );
+        }
+
+        Ok(prepared)
+    }
+
+    fn prepare_reference(
+        &mut self,
+        reference: &gdsr::Reference,
+        cell_bboxes: &HashMap<String, Option<WorldBBox>>,
+    ) -> Result<PreparedReference, SceneBuildError> {
+        let (source, source_bbox, label) = if let Some(cell_name) = reference.instance().as_cell() {
+            (
+                PreparedSource::Cell(cell_name.clone()),
+                cell_bboxes.get(cell_name).copied().flatten(),
+                Some(Arc::<str>::from(cell_name.as_str())),
+            )
+        } else if let Some(element) = reference.instance().as_element() {
+            let element = element.as_ref().as_ref();
+            match element {
+                Element::Reference(inner) => {
+                    let inner = self.prepare_reference(inner, cell_bboxes)?;
+                    let bbox = inner
+                        .source_bbox
+                        .and_then(|bbox| reference_bbox(&inner.grid, bbox));
+                    (PreparedSource::Reference(Box::new(inner)), bbox, None)
+                }
+                Element::Text(text) => (
+                    PreparedSource::Text(prepare_text(text)),
+                    element.world_bbox(),
+                    None,
+                ),
+                Element::Node(node) => (
+                    PreparedSource::Node(prepare_node(node)),
+                    element.world_bbox(),
+                    None,
+                ),
+                _ => {
+                    let layer = element_layer(element);
+                    let geometry_id = self.prepare_inline_geometry(element, layer)?;
+                    (
+                        PreparedSource::Geometry(geometry_id),
+                        element.world_bbox(),
+                        None,
+                    )
+                }
+            }
+        } else {
+            return Ok(PreparedReference {
+                grid: reference.grid().clone(),
+                source: PreparedSource::Cell(String::new()),
+                source_bbox: None,
+                label: None,
+            });
+        };
+
+        Ok(PreparedReference {
+            grid: reference.grid().clone(),
+            source,
+            source_bbox,
+            label,
+        })
+    }
+
+    fn prepare_inline_geometry(
+        &mut self,
+        element: &Element,
+        layer: (Layer, DataType),
+    ) -> Result<usize, SceneBuildError> {
+        let mut builder = GeometryBuilder::default();
+        match element {
+            Element::Polygon(polygon) => builder.push_polygon(layer, polygon.points())?,
+            Element::Box(gds_box) => builder.push_polygon(layer, &gds_box.points())?,
+            Element::Path(path) => {
+                if let Some(points) = path.to_polygon_points(16) {
+                    builder.push_polygon(layer, &points)?;
+                }
+            }
+            Element::Node(_) | Element::Reference(_) | Element::Text(_) => {}
+        }
+        let geometry_id = self.geometries.len();
+        if let Some(geometry) = builder.finish(layer) {
+            self.geometries.push(geometry);
+        } else {
+            self.geometries.push(PreparedGeometry {
+                layer,
+                positions: Vec::new(),
+                triangle_indices: Vec::new(),
+                line_indices: Vec::new(),
+                origin: DVec2::ZERO,
+                bbox: WorldBBox::new(0.0, 0.0, 0.0, 0.0),
+                element_count: 0,
+            });
+        }
+        Ok(geometry_id)
+    }
+
+    pub fn plan(&self, cell_name: &str, options: &SceneOptions<'_>) -> ScenePlan {
+        let mut planner = Planner {
+            library: self,
+            options,
+            plan: ScenePlan::default(),
+            complexity_cache: HashMap::new(),
+            complexity_stack: HashSet::new(),
+            cell_stack: HashSet::new(),
+        };
+
+        if options.depth == 0 {
+            if let Some(cell) = self.cells.get(cell_name)
+                && let Some(bbox) = cell.bbox
+                && bbox.overlaps(options.visible)
+            {
+                planner.add_load(bbox, Some(Arc::<str>::from(cell_name)));
+            }
+        } else {
+            planner.visit_cell(cell_name, DAffine2::IDENTITY, options.depth);
+        }
+        planner.plan
+    }
+}
+
+fn reachable_cell_names(library: &Library, root_cell: &str) -> BTreeSet<String> {
+    let mut reachable = BTreeSet::new();
+    let mut pending = vec![root_cell.to_string()];
+    while let Some(cell_name) = pending.pop() {
+        if !reachable.insert(cell_name.clone()) {
+            continue;
+        }
+        if let Some(cell) = library.get_cell(&cell_name) {
+            pending.extend(cell.referenced_cell_names().into_iter().map(str::to_string));
+        }
+    }
+    reachable
+}
+
+struct Planner<'a> {
+    library: &'a PreparedLibrary,
+    options: &'a SceneOptions<'a>,
+    plan: ScenePlan,
+    complexity_cache: HashMap<(String, u32), u64>,
+    complexity_stack: HashSet<String>,
+    cell_stack: HashSet<String>,
+}
+
+impl Planner<'_> {
+    fn visit_cell(&mut self, cell_name: &str, transform: DAffine2, depth: u32) {
+        let Some(cell) = self.library.cells.get(cell_name) else {
+            return;
+        };
+        let world_bbox = cell.bbox.map(|bbox| transform_bbox(transform, bbox));
+        if world_bbox.is_some_and(|bbox| !bbox.overlaps(self.options.visible)) {
+            return;
+        }
+        if self.plan.stats.detail_cells >= MAX_DETAIL_CELLS {
+            if let Some(bbox) = world_bbox {
+                self.add_load(bbox, Some(Arc::<str>::from(cell_name)));
+            }
+            return;
+        }
+        if self.detail_budget_exhausted() {
+            if let Some(bbox) = world_bbox {
+                self.add_load(bbox, Some(Arc::<str>::from(cell_name)));
+            }
+            return;
+        }
+        if !self.cell_stack.insert(cell_name.to_string()) {
+            if let Some(bbox) = world_bbox {
+                self.add_load(bbox, Some(Arc::<str>::from(cell_name)));
+            }
+            return;
+        }
+
+        self.plan.stats.detail_cells += 1;
+        for &geometry_id in &cell.geometry_ids {
+            if self.detail_budget_exhausted() {
+                if let Some(bbox) = world_bbox {
+                    self.add_load(bbox, Some(Arc::<str>::from(cell_name)));
+                }
+                self.cell_stack.remove(cell_name);
+                return;
+            }
+            self.push_geometry(geometry_id, transform);
+        }
+        for text in &cell.texts {
+            if self.detail_budget_exhausted() {
+                if let Some(bbox) = world_bbox {
+                    self.add_load(bbox, Some(Arc::<str>::from(cell_name)));
+                }
+                self.cell_stack.remove(cell_name);
+                return;
+            }
+            self.push_text(text, transform);
+        }
+        for node in &cell.nodes {
+            if self.detail_budget_exhausted() || !self.push_node(node, transform) {
+                if let Some(bbox) = world_bbox {
+                    self.add_load(bbox, Some(Arc::<str>::from(cell_name)));
+                }
+                self.cell_stack.remove(cell_name);
+                return;
+            }
+        }
+        for reference in &cell.references {
+            if self.detail_budget_exhausted() {
+                if let Some(bbox) = world_bbox {
+                    self.add_load(bbox, Some(Arc::<str>::from(cell_name)));
+                }
+                self.cell_stack.remove(cell_name);
+                return;
+            }
+            self.visit_reference(reference, transform, depth);
+        }
+
+        self.cell_stack.remove(cell_name);
+    }
+
+    fn visit_reference(
+        &mut self,
+        reference: &PreparedReference,
+        parent_transform: DAffine2,
+        depth: u32,
+    ) {
+        let Some(source_bbox) = reference.source_bbox else {
+            return;
+        };
+        let Some(local_bbox) = reference_bbox(&reference.grid, source_bbox) else {
+            return;
+        };
+        let world_bbox = transform_bbox(parent_transform, local_bbox);
+        if !world_bbox.overlaps(self.options.visible) {
+            self.plan.stats.culled_references += 1;
+            return;
+        }
+        if self.plan.stats.detail_cells >= MAX_DETAIL_CELLS {
+            self.add_load(world_bbox, reference.label.clone());
+            return;
+        }
+        if self.detail_budget_exhausted() {
+            self.add_load(world_bbox, reference.label.clone());
+            return;
+        }
+
+        let grid_count = grid_count(&reference.grid);
+        let draw_units = self.reference_draw_units(reference, depth);
+        let source_is_degenerate =
+            source_bbox.min_x == source_bbox.max_x || source_bbox.min_y == source_bbox.max_y;
+        let (width_px, height_px) =
+            reference_screen_size(world_bbox, self.options.zoom, source_is_degenerate);
+        if should_collapse_reference(width_px, height_px, grid_count, draw_units, depth, false) {
+            self.add_load(world_bbox, reference.label.clone());
+            return;
+        }
+
+        let source_units = draw_units.checked_div(grid_count).unwrap_or(1).max(1);
+        for column in 0..reference.grid.columns() {
+            for row in 0..reference.grid.rows() {
+                if self.detail_budget_exhausted() {
+                    self.add_load(world_bbox, reference.label.clone());
+                    return;
+                }
+                let member_transform =
+                    parent_transform * grid_member_transform(&reference.grid, column, row);
+                let member_bbox = transform_bbox(member_transform, source_bbox);
+                if !member_bbox.overlaps(self.options.visible) {
+                    self.plan.stats.culled_references += 1;
+                    continue;
+                }
+                let (member_width, member_height) =
+                    reference_screen_size(member_bbox, self.options.zoom, source_is_degenerate);
+                if !member_width.is_finite()
+                    || !member_height.is_finite()
+                    || (member_width < 1.0 && member_height < 1.0)
+                {
+                    self.plan.stats.skipped_subpixel_references += 1;
+                    continue;
+                }
+                if should_collapse_reference(
+                    member_width,
+                    member_height,
+                    1,
+                    source_units,
+                    depth,
+                    false,
+                ) {
+                    self.add_load(member_bbox, reference.label.clone());
+                } else {
+                    if !self.visit_source(
+                        &reference.source,
+                        member_transform,
+                        depth.saturating_sub(1),
+                    ) {
+                        self.add_load(member_bbox, reference.label.clone());
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+    fn visit_source(&mut self, source: &PreparedSource, transform: DAffine2, depth: u32) -> bool {
+        match source {
+            PreparedSource::Cell(cell_name) => {
+                self.visit_cell(cell_name, transform, depth);
+                true
+            }
+            PreparedSource::Geometry(geometry_id) => {
+                self.push_geometry(*geometry_id, transform);
+                true
+            }
+            PreparedSource::Text(text) => {
+                self.push_text(text, transform);
+                true
+            }
+            PreparedSource::Node(node) => self.push_node(node, transform),
+            PreparedSource::Reference(reference) => {
+                self.visit_reference(reference, transform, depth);
+                true
+            }
+        }
+    }
+
+    fn detail_budget_exhausted(&self) -> bool {
+        self.plan.stats.detail_objects >= MAX_SCENE_OBJECTS
+            || self.plan.texts.len() >= MAX_TEXT_INSTANCES
+            || self.plan.load_proxies.len() >= MAX_LOAD_PROXIES
+    }
+
+    fn push_geometry(&mut self, geometry_id: usize, transform: DAffine2) {
+        let geometry = &self.library.geometries[geometry_id];
+        if self.options.hidden_layers.contains(&geometry.layer) {
+            return;
+        }
+        let bbox = transform_bbox(transform, geometry.bbox);
+        if !bbox.overlaps(self.options.visible) {
+            self.plan.stats.culled_geometry_batches += 1;
+            return;
+        }
+        let (width_px, height_px) = screen_size(bbox, self.options.zoom);
+        if !width_px.is_finite() || !height_px.is_finite() || (width_px < 1.0 && height_px < 1.0) {
+            self.plan.stats.skipped_subpixel_geometry_batches += 1;
+            return;
+        }
+        let area_px = width_px * height_px;
+        if geometry.element_count >= DENSE_BATCH_MIN_ELEMENTS
+            && area_px.is_finite()
+            && area_px / geometry.element_count as f32 <= MIN_AVERAGE_ELEMENT_AREA_PX
+        {
+            self.add_load(bbox, None);
+            return;
+        }
+        if self.detail_budget_exhausted() {
+            self.add_load(bbox, None);
+            return;
+        }
+        self.plan.geometry_instances.push(GeometryInstance {
+            geometry_id,
+            transform,
+        });
+        self.plan.stats.detail_objects += 1;
+    }
+
+    fn push_text(&mut self, text: &PreparedText, transform: DAffine2) {
+        if self.options.hidden_layers.contains(&text.layer) {
+            return;
+        }
+        let position = transform.transform_point2(text.origin);
+        if point_in_bbox(position, self.options.visible) {
+            self.plan.texts.push(TextInstance {
+                value: Arc::clone(&text.value),
+                position,
+                layer: text.layer,
+            });
+            self.plan.stats.detail_objects += 1;
+        }
+    }
+
+    fn push_node(&mut self, node: &PreparedNode, transform: DAffine2) -> bool {
+        if self.options.hidden_layers.contains(&node.layer) {
+            return true;
+        }
+        let visible = self.options.visible;
+        for point in &node.points {
+            let point = transform.transform_point2(*point);
+            if !point_in_bbox(point, visible) {
+                continue;
+            }
+            if self.detail_budget_exhausted() {
+                return false;
+            }
+            self.plan
+                .node_points
+                .entry(node.layer)
+                .or_default()
+                .push(point);
+            self.plan.stats.detail_objects += 1;
+        }
+        true
+    }
+
+    fn add_load(&mut self, bbox: WorldBBox, label: Option<Arc<str>>) {
+        if self.plan.load_proxies.len() < MAX_LOAD_PROXIES {
+            self.plan.load_proxies.push(LoadProxy { bbox, label });
+        }
+    }
+
+    fn reference_draw_units(&mut self, reference: &PreparedReference, depth: u32) -> u64 {
+        let count = grid_count(&reference.grid);
+        if count == 0 {
+            return 0;
+        }
+        let source_count = if depth <= 1 {
+            1
+        } else {
+            self.source_draw_units(&reference.source, depth - 1)
+        };
+        count.saturating_mul(source_count.max(1))
+    }
+
+    fn source_draw_units(&mut self, source: &PreparedSource, depth: u32) -> u64 {
+        match source {
+            PreparedSource::Cell(cell_name) => self.cell_draw_units(cell_name, depth),
+            PreparedSource::Reference(reference) => self.reference_draw_units(reference, depth),
+            PreparedSource::Geometry(_) | PreparedSource::Text(_) | PreparedSource::Node(_) => 1,
+        }
+    }
+
+    fn cell_draw_units(&mut self, cell_name: &str, depth: u32) -> u64 {
+        let key = (cell_name.to_string(), depth);
+        if let Some(&count) = self.complexity_cache.get(&key) {
+            return count;
+        }
+        if depth == 0 || !self.complexity_stack.insert(cell_name.to_string()) {
+            return 1;
+        }
+        let count = self.library.cells.get(cell_name).map_or(1, |cell| {
+            let direct = cell.direct_draw_units;
+            cell.references.iter().fold(direct, |count, reference| {
+                count.saturating_add(self.reference_draw_units(reference, depth))
+            })
+        });
+        self.complexity_stack.remove(cell_name);
+        self.complexity_cache.insert(key, count);
+        count
+    }
+}
+
+fn prepare_text(text: &gdsr::Text) -> PreparedText {
+    PreparedText {
+        value: Arc::<str>::from(text.text().as_str()),
+        origin: point_position(text.origin()),
+        layer: (text.layer(), text.data_type()),
+    }
+}
+
+fn prepare_node(node: &gdsr::Node) -> PreparedNode {
+    PreparedNode {
+        points: node.points().iter().map(point_position).collect(),
+        layer: (node.layer(), node.node_type()),
+    }
+}
+
+fn element_layer(element: &Element) -> (Layer, DataType) {
+    match element {
+        Element::Polygon(polygon) => (polygon.layer(), polygon.data_type()),
+        Element::Box(gds_box) => (gds_box.layer(), gds_box.box_type()),
+        Element::Path(path) => (path.layer(), path.data_type()),
+        Element::Node(node) => (node.layer(), node.node_type()),
+        Element::Text(text) => (text.layer(), text.data_type()),
+        Element::Reference(_) => (Layer::default(), DataType::default()),
+    }
+}
+
+fn point_position(point: &Point) -> DVec2 {
+    DVec2::new(point.x().absolute_value(), point.y().absolute_value())
+}
+
+fn grid_count(grid: &Grid) -> u64 {
+    u64::from(grid.columns()) * u64::from(grid.rows())
+}
+
+fn grid_member_transform(grid: &Grid, column: u32, row: u32) -> DAffine2 {
+    let angle = grid.angle().value();
+    let (sin, cos) = angle.sin_cos();
+    let magnification = grid.magnification();
+    let spacing_x = grid
+        .spacing_x()
+        .map_or(DVec2::ZERO, |point| point_position(&point));
+    let spacing_y = grid
+        .spacing_y()
+        .map_or(DVec2::ZERO, |point| point_position(&point));
+    let offset = spacing_x * f64::from(column) + spacing_y * f64::from(row);
+    let rotated_offset = DVec2::new(
+        offset.x.mul_add(cos, -(offset.y * sin)),
+        offset.x.mul_add(sin, offset.y * cos),
+    );
+    let origin = point_position(&grid.origin()) + rotated_offset;
+    let x_axis = DVec2::new(cos, sin) * magnification;
+    let y_axis = if grid.x_reflection() {
+        DVec2::new(sin, -cos) * magnification
+    } else {
+        DVec2::new(-sin, cos) * magnification
+    };
+    DAffine2::from_mat2_translation(DMat2::from_cols(x_axis, y_axis), origin)
+}
+
+fn reference_bbox(grid: &Grid, source_bbox: WorldBBox) -> Option<WorldBBox> {
+    if grid.columns() == 0 || grid.rows() == 0 {
+        return None;
+    }
+    let mut bbox = None;
+    for column in [0, grid.columns() - 1] {
+        for row in [0, grid.rows() - 1] {
+            let member_bbox = transform_bbox(grid_member_transform(grid, column, row), source_bbox);
+            bbox = Some(bbox.map_or(member_bbox, |bbox: WorldBBox| bbox.merge(&member_bbox)));
+        }
+    }
+    bbox
+}
+
+fn transform_bbox(transform: DAffine2, bbox: WorldBBox) -> WorldBBox {
+    let corners = [
+        DVec2::new(bbox.min_x, bbox.min_y),
+        DVec2::new(bbox.max_x, bbox.min_y),
+        DVec2::new(bbox.max_x, bbox.max_y),
+        DVec2::new(bbox.min_x, bbox.max_y),
+    ];
+    let mut min = DVec2::splat(f64::INFINITY);
+    let mut max = DVec2::splat(f64::NEG_INFINITY);
+    for corner in corners {
+        let corner = transform.transform_point2(corner);
+        min = min.min(corner);
+        max = max.max(corner);
+    }
+    WorldBBox::new(min.x, min.y, max.x, max.y)
+}
+
+fn screen_size(bbox: WorldBBox, zoom: f64) -> (f32, f32) {
+    (
+        ((bbox.max_x - bbox.min_x).abs() * zoom) as f32,
+        ((bbox.max_y - bbox.min_y).abs() * zoom) as f32,
+    )
+}
+
+fn reference_screen_size(bbox: WorldBBox, zoom: f64, source_is_degenerate: bool) -> (f32, f32) {
+    let (width, height) = screen_size(bbox, zoom);
+    if source_is_degenerate {
+        (
+            width.max(MIN_FIXED_CONTENT_PX),
+            height.max(MIN_FIXED_CONTENT_PX),
+        )
+    } else {
+        (width, height)
+    }
+}
+
+fn point_in_bbox(point: DVec2, bbox: &WorldBBox) -> bool {
+    point.x >= bbox.min_x && point.x <= bbox.max_x && point.y >= bbox.min_y && point.y <= bbox.max_y
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gdsr::{
+        Cell, DataType, HorizontalPresentation, Layer, Polygon, Radians, Reference, Text,
+        VerticalPresentation,
+    };
+
+    fn point(x: i32, y: i32) -> Point {
+        Point::integer(x, y, 1e-9)
+    }
+
+    fn square(size: i32, layer: u16) -> Polygon {
+        square_at(0, 0, size, layer)
+    }
+
+    fn square_at(x: i32, y: i32, size: i32, layer: u16) -> Polygon {
+        Polygon::new(
+            [
+                point(x, y),
+                point(x + size, y),
+                point(x + size, y + size),
+                point(x, y + size),
+            ],
+            Layer::new(layer),
+            DataType::new(0),
+        )
+    }
+
+    fn visible() -> WorldBBox {
+        WorldBBox::new(-1.0, -1.0, 1.0, 1.0)
+    }
+
+    fn label() -> Text {
+        Text::new(
+            "label",
+            point(0, 0),
+            Layer::new(1),
+            DataType::new(0),
+            1.0,
+            Radians::default(),
+            false,
+            VerticalPresentation::default(),
+            HorizontalPresentation::default(),
+        )
+    }
+
+    #[test]
+    fn member_transform_matches_reference_geometry() {
+        let reference = Reference::new("leaf").with_grid(
+            Grid::default()
+                .with_origin(point(100, 200))
+                .with_columns(2)
+                .with_spacing_x(Some(point(40, 0)))
+                .with_magnification(2.0)
+                .with_angle(Radians::FRAC_PI_2)
+                .with_x_reflection(true),
+        );
+        let element = Element::Polygon(square(10, 1));
+        let transformed = reference.get_elements_in_grid(&element);
+        let Element::Polygon(second) = &transformed[1] else {
+            panic!("reference should preserve polygon type");
+        };
+        let affine = grid_member_transform(reference.grid(), 1, 0);
+
+        for (actual, source) in second.points().iter().zip(square(10, 1).points()) {
+            let expected = affine.transform_point2(point_position(source));
+            assert!((actual.x().absolute_value() - expected.x).abs() < 1e-12);
+            assert!((actual.y().absolute_value() - expected.y).abs() < 1e-12);
+        }
+    }
+
+    #[test]
+    fn repeated_cells_share_one_prepared_geometry() {
+        let mut leaf = Cell::new("leaf");
+        leaf.add(square(100, 1));
+        let mut top = Cell::new("top");
+        top.add(
+            Reference::new("leaf").with_grid(
+                Grid::default()
+                    .with_columns(10)
+                    .with_rows(10)
+                    .with_spacing_x(Some(point(200, 0)))
+                    .with_spacing_y(Some(point(0, 200))),
+            ),
+        );
+        let mut library = Library::new("test");
+        library.add_cell(leaf);
+        library.add_cell(top);
+
+        let prepared = PreparedLibrary::build(&library, "top").expect("scene should prepare");
+        let plan = prepared.plan(
+            "top",
+            &SceneOptions {
+                visible: &visible(),
+                zoom: 1.0e9,
+                depth: 2,
+                hidden_layers: &HashSet::new(),
+            },
+        );
+
+        assert_eq!(prepared.geometries.len(), 1);
+        assert_eq!(plan.geometry_instances.len(), 100);
+        assert!(
+            plan.geometry_instances
+                .iter()
+                .all(|instance| instance.geometry_id == 0)
+        );
+    }
+
+    #[test]
+    fn preparation_skips_cells_outside_selected_hierarchy() {
+        let mut top = Cell::new("top");
+        top.add(square(100, 1));
+        let mut unused = Cell::new("unused");
+        unused.add(square(100, 2));
+        let mut library = Library::new("test");
+        library.add_cell(top);
+        library.add_cell(unused);
+
+        let prepared = PreparedLibrary::build(&library, "top").expect("scene should prepare");
+
+        assert_eq!(prepared.cells.len(), 1);
+        assert!(prepared.cells.contains_key("top"));
+        assert_eq!(prepared.geometries.len(), 1);
+        assert_eq!(
+            prepared.geometries[0].layer,
+            (Layer::new(1), DataType::new(0))
+        );
+    }
+
+    #[test]
+    fn subpixel_grid_members_are_not_expanded() {
+        let mut leaf = Cell::new("leaf");
+        leaf.add(square(1, 1));
+        let mut top = Cell::new("top");
+        top.add(
+            Reference::new("leaf").with_grid(
+                Grid::default()
+                    .with_columns(10)
+                    .with_rows(10)
+                    .with_spacing_x(Some(point(10_000, 0)))
+                    .with_spacing_y(Some(point(0, 10_000))),
+            ),
+        );
+        let mut library = Library::new("test");
+        library.add_cell(leaf);
+        library.add_cell(top);
+
+        let prepared = PreparedLibrary::build(&library, "top").expect("scene should prepare");
+        let plan = prepared.plan(
+            "top",
+            &SceneOptions {
+                visible: &visible(),
+                zoom: 1.0e6,
+                depth: 2,
+                hidden_layers: &HashSet::new(),
+            },
+        );
+
+        assert!(plan.geometry_instances.is_empty());
+        assert_eq!(plan.stats.skipped_subpixel_references, 100);
+    }
+
+    #[test]
+    fn depth_zero_uses_one_cell_proxy() {
+        let mut cell = Cell::new("top");
+        cell.add(square(100, 1));
+        let mut library = Library::new("test");
+        library.add_cell(cell);
+        let prepared = PreparedLibrary::build(&library, "top").expect("scene should prepare");
+
+        let plan = prepared.plan(
+            "top",
+            &SceneOptions {
+                visible: &visible(),
+                zoom: 1.0e9,
+                depth: 0,
+                hidden_layers: &HashSet::new(),
+            },
+        );
+
+        assert_eq!(plan.load_proxies.len(), 1);
+        assert_eq!(plan.load_proxies[0].label.as_deref(), Some("top"));
+        assert!(plan.geometry_instances.is_empty());
+    }
+
+    #[test]
+    fn hidden_layers_do_not_emit_geometry() {
+        let mut cell = Cell::new("top");
+        cell.add(square(100, 7));
+        let mut library = Library::new("test");
+        library.add_cell(cell);
+        let prepared = PreparedLibrary::build(&library, "top").expect("scene should prepare");
+        let hidden = HashSet::from([(Layer::new(7), DataType::new(0))]);
+
+        let plan = prepared.plan(
+            "top",
+            &SceneOptions {
+                visible: &visible(),
+                zoom: 1.0e9,
+                depth: 1,
+                hidden_layers: &hidden,
+            },
+        );
+
+        assert!(plan.geometry_instances.is_empty());
+    }
+
+    #[test]
+    fn large_direct_cells_are_split_into_bounded_batches() {
+        let mut cell = Cell::new("top");
+        for x in 0..257 {
+            cell.add(square_at(x * 20, 0, 10, 1));
+        }
+        let mut library = Library::new("test");
+        library.add_cell(cell);
+
+        let prepared = PreparedLibrary::build(&library, "top").expect("scene should prepare");
+
+        assert_eq!(prepared.geometries.len(), 2);
+        assert_eq!(prepared.geometries[0].element_count, MAX_BATCH_ELEMENTS);
+        assert_eq!(prepared.geometries[1].element_count, 1);
+    }
+
+    #[test]
+    fn offscreen_geometry_batches_are_culled() {
+        let mut cell = Cell::new("top");
+        for x in 0..256 {
+            cell.add(square_at(x * 20, 0, 10, 1));
+        }
+        cell.add(square_at(1_000_000, 0, 10, 1));
+        let mut library = Library::new("test");
+        library.add_cell(cell);
+        let prepared = PreparedLibrary::build(&library, "top").expect("scene should prepare");
+        let visible = WorldBBox::new(0.000_999, -0.001, 0.001_001, 0.001);
+
+        let plan = prepared.plan(
+            "top",
+            &SceneOptions {
+                visible: &visible,
+                zoom: 1.0e12,
+                depth: 1,
+                hidden_layers: &HashSet::new(),
+            },
+        );
+
+        assert_eq!(plan.geometry_instances.len(), 1);
+        assert_eq!(plan.stats.culled_geometry_batches, 1);
+    }
+
+    #[test]
+    fn dense_subpixel_geometry_uses_one_proxy() {
+        let mut cell = Cell::new("top");
+        for _ in 0..DENSE_BATCH_MIN_ELEMENTS {
+            cell.add(square(100, 1));
+        }
+        let mut library = Library::new("test");
+        library.add_cell(cell);
+        let prepared = PreparedLibrary::build(&library, "top").expect("scene should prepare");
+
+        let plan = prepared.plan(
+            "top",
+            &SceneOptions {
+                visible: &visible(),
+                zoom: 1.0e8,
+                depth: 1,
+                hidden_layers: &HashSet::new(),
+            },
+        );
+
+        assert!(plan.geometry_instances.is_empty());
+        assert_eq!(plan.load_proxies.len(), 1);
+    }
+
+    #[test]
+    fn subpixel_direct_geometry_is_skipped() {
+        let mut cell = Cell::new("top");
+        cell.add(square(1, 1));
+        let mut library = Library::new("test");
+        library.add_cell(cell);
+        let prepared = PreparedLibrary::build(&library, "top").expect("scene should prepare");
+
+        let plan = prepared.plan(
+            "top",
+            &SceneOptions {
+                visible: &visible(),
+                zoom: 1.0e6,
+                depth: 1,
+                hidden_layers: &HashSet::new(),
+            },
+        );
+
+        assert!(plan.geometry_instances.is_empty());
+        assert_eq!(plan.stats.skipped_subpixel_geometry_batches, 1);
+    }
+
+    #[test]
+    fn nested_inline_arrays_stop_at_geometry_budget() {
+        let inner = Reference::new(Element::Polygon(square(100, 1))).with_grid(
+            Grid::default()
+                .with_columns(100)
+                .with_rows(50)
+                .with_spacing_x(Some(point(200, 0)))
+                .with_spacing_y(Some(point(0, 200))),
+        );
+        let outer = Reference::new(Element::Reference(inner)).with_grid(
+            Grid::default()
+                .with_columns(5)
+                .with_spacing_x(Some(point(100_000, 0))),
+        );
+        let mut top = Cell::new("top");
+        top.add(outer);
+        let mut library = Library::new("test");
+        library.add_cell(top);
+        let prepared = PreparedLibrary::build(&library, "top").expect("scene should prepare");
+
+        let plan = prepared.plan(
+            "top",
+            &SceneOptions {
+                visible: &visible(),
+                zoom: 1.0e12,
+                depth: 3,
+                hidden_layers: &HashSet::new(),
+            },
+        );
+
+        assert_eq!(plan.geometry_instances.len(), MAX_SCENE_OBJECTS);
+        assert_eq!(plan.load_proxies.len(), 1);
+    }
+
+    #[test]
+    fn referenced_text_is_not_discarded_as_subpixel_geometry() {
+        let mut top = Cell::new("top");
+        top.add(Reference::new(Element::Text(label())));
+        let mut library = Library::new("test");
+        library.add_cell(top);
+        let prepared = PreparedLibrary::build(&library, "top").expect("scene should prepare");
+
+        let plan = prepared.plan(
+            "top",
+            &SceneOptions {
+                visible: &visible(),
+                zoom: 1.0e9,
+                depth: 2,
+                hidden_layers: &HashSet::new(),
+            },
+        );
+
+        assert_eq!(plan.texts.len(), 1);
+        assert!(plan.load_proxies.is_empty());
+    }
+
+    #[test]
+    fn nested_inline_text_arrays_stop_at_text_budget() {
+        let inner = Reference::new(Element::Text(label())).with_grid(
+            Grid::default()
+                .with_columns(100)
+                .with_rows(50)
+                .with_spacing_x(Some(point(200, 0)))
+                .with_spacing_y(Some(point(0, 200))),
+        );
+        let outer = Reference::new(Element::Reference(inner)).with_grid(
+            Grid::default()
+                .with_columns(5)
+                .with_spacing_x(Some(point(100_000, 0))),
+        );
+        let mut top = Cell::new("top");
+        top.add(outer);
+        let mut library = Library::new("test");
+        library.add_cell(top);
+        let prepared = PreparedLibrary::build(&library, "top").expect("scene should prepare");
+
+        let plan = prepared.plan(
+            "top",
+            &SceneOptions {
+                visible: &visible(),
+                zoom: 1.0e12,
+                depth: 3,
+                hidden_layers: &HashSet::new(),
+            },
+        );
+
+        assert_eq!(plan.texts.len(), MAX_TEXT_INSTANCES);
+        assert_eq!(plan.load_proxies.len(), 1);
+    }
+}

--- a/crates/gdsr-viewer/src/drawable.rs
+++ b/crates/gdsr-viewer/src/drawable.rs
@@ -49,6 +49,13 @@ pub fn cell_world_bbox(cell_name: &str, library: &Library) -> Option<WorldBBox> 
     named_cell_world_bbox(cell_name, library, &mut visiting, &mut cache)
 }
 
+pub fn cell_world_bboxes(library: &Library, root_cell: &str) -> HashMap<String, Option<WorldBBox>> {
+    let mut visiting = HashSet::new();
+    let mut cache = HashMap::new();
+    named_cell_world_bbox(root_cell, library, &mut visiting, &mut cache);
+    cache
+}
+
 fn named_cell_world_bbox(
     cell_name: &str,
     library: &Library,
@@ -757,7 +764,7 @@ impl Drawable for gdsr::Path {
 
 impl Drawable for gdsr::Text {
     fn layer_keys(&self) -> Vec<(Layer, DataType)> {
-        vec![(self.layer(), DataType::new(0))]
+        vec![(self.layer(), self.data_type())]
     }
 
     fn world_bbox(&self) -> Option<WorldBBox> {
@@ -778,7 +785,7 @@ impl Drawable for gdsr::Text {
     }
 
     fn draw(&self, ctx: &mut DrawContext) {
-        let key = (self.layer(), DataType::new(0));
+        let key = (self.layer(), self.data_type());
         if ctx.layer_state.hidden_layers.contains(&key) {
             return;
         }

--- a/crates/gdsr-viewer/src/main.rs
+++ b/crates/gdsr-viewer/src/main.rs
@@ -1,7 +1,12 @@
+use bevy::prelude::*;
+use bevy::window::{Window, WindowPlugin, WindowResolution};
+use bevy::winit::WinitSettings;
+use bevy_egui::{EguiPlugin, EguiPrimaryContextPass};
 use clap::Parser;
 
 mod app;
-pub mod bevy_renderer;
+mod bevy_renderer;
+mod bevy_scene;
 mod colors;
 mod drawable;
 mod grid;
@@ -25,20 +30,52 @@ struct Args {
     file: Option<std::path::PathBuf>,
 }
 
-fn main() -> eframe::Result<()> {
-    env_logger::init();
+fn winit_settings() -> WinitSettings {
+    WinitSettings::desktop_app()
+}
 
+fn main() {
     let args = Args::parse();
 
-    let app = match args.file {
+    let viewer = match args.file {
         Some(file) => app::ViewerApp::with_path(&file),
         None => app::ViewerApp::default(),
     };
 
-    let options = eframe::NativeOptions {
-        viewport: egui::ViewportBuilder::default().with_inner_size([1280.0, 800.0]),
-        ..Default::default()
-    };
+    App::new()
+        .insert_non_send_resource(viewer)
+        .insert_resource(ClearColor(Color::srgb_u8(30, 30, 30)))
+        .insert_resource(winit_settings())
+        .add_plugins(DefaultPlugins.set(WindowPlugin {
+            primary_window: Some(Window {
+                title: "GDS Viewer".to_string(),
+                resolution: WindowResolution::new(1280, 800),
+                ..default()
+            }),
+            ..default()
+        }))
+        .add_plugins(EguiPlugin::default())
+        .add_systems(Startup, bevy_renderer::setup)
+        .add_systems(
+            EguiPrimaryContextPass,
+            (app::update_system, bevy_renderer::sync_scene).chain(),
+        )
+        .run();
+}
 
-    eframe::run_native("GDS Viewer", options, Box::new(|_cc| Ok(Box::new(app))))
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy::winit::UpdateMode;
+
+    #[test]
+    fn viewer_uses_reactive_window_updates() {
+        let settings = winit_settings();
+
+        assert!(matches!(settings.focused_mode, UpdateMode::Reactive { .. }));
+        assert!(matches!(
+            settings.unfocused_mode,
+            UpdateMode::Reactive { .. }
+        ));
+    }
 }

--- a/crates/gdsr-viewer/src/spatial.rs
+++ b/crates/gdsr-viewer/src/spatial.rs
@@ -120,6 +120,7 @@ impl SpatialGrid {
     }
 
     /// Returns an iterator over grid cells that overlap the given visible world-space rectangle.
+    #[cfg(test)]
     pub fn query_visible(&self, visible: &WorldBBox) -> impl Iterator<Item = &GridCell> {
         let col_min = ((visible.min_x - self.world_min_x) / self.cell_width).floor() as isize;
         let col_max = ((visible.max_x - self.world_min_x) / self.cell_width).ceil() as isize;
@@ -143,6 +144,7 @@ impl SpatialGrid {
         })
     }
 
+    #[cfg(test)]
     pub fn query_visible_indices<'a>(
         &self,
         visible: &WorldBBox,
@@ -380,8 +382,18 @@ mod tests {
 
     #[test]
     fn layer_keys_text() {
-        let elem = text("t", 0, 0, 4);
-        assert_eq!(elem.layer_keys(), vec![(Layer::new(4), DataType::new(0))]);
+        let elem = Element::Text(gdsr::Text::new(
+            "t",
+            gdsr::Point::default_integer(0, 0),
+            Layer::new(4),
+            DataType::new(6),
+            1.0,
+            gdsr::Radians::default(),
+            false,
+            gdsr::VerticalPresentation::default(),
+            gdsr::HorizontalPresentation::default(),
+        ));
+        assert_eq!(elem.layer_keys(), vec![(Layer::new(4), DataType::new(6))]);
     }
 
     #[test]

--- a/crates/gdsr-viewer/src/state.rs
+++ b/crates/gdsr-viewer/src/state.rs
@@ -2,8 +2,6 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::mpsc;
 
-use egui::{Mesh, Pos2, Shape};
-use emath::{TSTransform, Vec2};
 use gdsr::{Cell, CellStats, DataType, Element, Layer, Library, Movable, Point};
 
 use crate::colors::LayerColorMap;
@@ -90,16 +88,30 @@ impl CellState {
         self.elements = cell.elements().to_vec();
         self.rebuild_render_indexes();
 
+        self.refresh_layers_for(name);
+        true
+    }
+
+    pub fn refresh_layers(&mut self) {
+        let Some(name) = self.selected_cell.clone() else {
+            self.layers.clear();
+            return;
+        };
+        self.refresh_layers_for(&name);
+    }
+
+    fn refresh_layers_for(&mut self, name: &str) {
         self.layers.clear();
         let mut visiting = HashSet::new();
+        let mut visited_depths = HashMap::new();
         collect_layers_from_cell(
             name,
             &self.library,
             self.render_depth,
             &mut self.layers,
             &mut visiting,
+            &mut visited_depths,
         );
-        true
     }
 
     pub fn insert_element(&mut self, index: usize, element: Element) -> bool {
@@ -180,14 +192,21 @@ fn collect_layers_from_cell(
     depth: u32,
     layers: &mut BTreeSet<(Layer, DataType)>,
     visiting: &mut HashSet<String>,
+    visited_depths: &mut HashMap<String, u32>,
 ) {
-    if depth == 0 || !visiting.insert(cell_name.to_owned()) {
+    if depth == 0
+        || visited_depths
+            .get(cell_name)
+            .is_some_and(|visited_depth| *visited_depth >= depth)
+        || !visiting.insert(cell_name.to_owned())
+    {
         return;
     }
+    visited_depths.insert(cell_name.to_owned(), depth);
 
     if let Some(cell) = library.get_cell(cell_name) {
         for element in cell.iter_elements() {
-            collect_layers_from_element(element, library, depth, layers, visiting);
+            collect_layers_from_element(element, library, depth, layers, visiting, visited_depths);
         }
     }
 
@@ -200,6 +219,7 @@ fn collect_layers_from_element(
     depth: u32,
     layers: &mut BTreeSet<(Layer, DataType)>,
     visiting: &mut HashSet<String>,
+    visited_depths: &mut HashMap<String, u32>,
 ) {
     let Element::Reference(reference) = element else {
         layers.extend(element.layer_keys());
@@ -211,7 +231,14 @@ fn collect_layers_from_element(
     }
 
     if let Some(cell_name) = reference.instance().as_cell() {
-        collect_layers_from_cell(cell_name, library, depth - 1, layers, visiting);
+        collect_layers_from_cell(
+            cell_name,
+            library,
+            depth - 1,
+            layers,
+            visiting,
+            visited_depths,
+        );
     } else if let Some(inner) = reference.instance().as_element() {
         collect_layers_from_element(
             inner.as_ref().as_ref(),
@@ -219,171 +246,17 @@ fn collect_layers_from_element(
             depth - 1,
             layers,
             visiting,
+            visited_depths,
         );
-    }
-}
-
-/// Caches rendered geometry and supports delta-transforms on pan/zoom instead of
-/// full re-renders. A full render queries a 3× viewport so there is margin for
-/// panning before the cache must be rebuilt.
-///
-/// Geometry is split into batched layer meshes (few large meshes, cheap to clone)
-/// and extra shapes (text, rect fallbacks).
-pub struct RenderCache {
-    layer_meshes: Vec<((Layer, DataType), Mesh)>,
-    extra_shapes: Vec<Shape>,
-    /// Viewport state at the time shapes were rendered.
-    render_center_x: f64,
-    render_center_y: f64,
-    render_zoom: f64,
-    render_rect_center: Pos2,
-    /// Invalidation metadata — if any of these change, full re-render.
-    hidden_layers: Vec<(Layer, DataType)>,
-    element_count: usize,
-    render_depth: u32,
-    populated: bool,
-}
-
-impl Default for RenderCache {
-    fn default() -> Self {
-        Self {
-            layer_meshes: Vec::new(),
-            extra_shapes: Vec::new(),
-            render_center_x: 0.0,
-            render_center_y: 0.0,
-            render_zoom: 1.0,
-            render_rect_center: Pos2::ZERO,
-            hidden_layers: Vec::new(),
-            element_count: 0,
-            render_depth: 1,
-            populated: false,
-        }
-    }
-}
-
-impl RenderCache {
-    /// Returns `true` when a full re-render is needed (cannot use delta transform).
-    pub fn needs_full_render(
-        &self,
-        hidden_layers: &[(Layer, DataType)],
-        element_count: usize,
-        render_depth: u32,
-        current_center_x: f64,
-        current_center_y: f64,
-        current_zoom: f64,
-        rect: egui::Rect,
-    ) -> bool {
-        if !self.populated {
-            return true;
-        }
-        if self.hidden_layers != hidden_layers
-            || self.element_count != element_count
-            || self.render_depth != render_depth
-        {
-            return true;
-        }
-
-        // Zoom ratio outside [0.5, 2.0] means LOAD thresholds may have crossed.
-        let zoom_ratio = current_zoom / self.render_zoom;
-        if !(0.5..=2.0).contains(&zoom_ratio) {
-            return true;
-        }
-
-        // Pan distance in screen pixels. The margin budget is one full viewport
-        // width/height (from the 3× query region). Trigger re-render at 80%.
-        let dx_screen = (self.render_center_x - current_center_x) * current_zoom;
-        let dy_screen = (self.render_center_y - current_center_y) * current_zoom;
-        let margin_x = f64::from(rect.width()) * 0.8;
-        let margin_y = f64::from(rect.height()) * 0.8;
-        if dx_screen.abs() > margin_x || dy_screen.abs() > margin_y {
-            return true;
-        }
-
-        false
-    }
-
-    /// Computes the `TSTransform` that maps render-time screen coordinates to
-    /// current screen coordinates.
-    pub fn delta_transform(
-        &self,
-        current_center_x: f64,
-        current_center_y: f64,
-        current_zoom: f64,
-        rect_center: Pos2,
-    ) -> TSTransform {
-        let scale = (current_zoom / self.render_zoom) as f32;
-        let tx = f64::from(rect_center.x) * f64::from(1.0 - scale)
-            + (self.render_center_x - current_center_x) * current_zoom;
-        let ty = f64::from(rect_center.y) * f64::from(1.0 - scale)
-            - (self.render_center_y - current_center_y) * current_zoom;
-        TSTransform::new(Vec2::new(tx as f32, ty as f32), scale)
-    }
-
-    /// Stores batched layer meshes, extra shapes, and the viewport state.
-    pub fn update(
-        &mut self,
-        layer_meshes: Vec<((Layer, DataType), Mesh)>,
-        extra_shapes: Vec<Shape>,
-        center_x: f64,
-        center_y: f64,
-        zoom: f64,
-        rect_center: Pos2,
-        hidden_layers: Vec<(Layer, DataType)>,
-        element_count: usize,
-        render_depth: u32,
-    ) {
-        self.layer_meshes = layer_meshes;
-        self.extra_shapes = extra_shapes;
-        self.render_center_x = center_x;
-        self.render_center_y = center_y;
-        self.render_zoom = zoom;
-        self.render_rect_center = rect_center;
-        self.hidden_layers = hidden_layers;
-        self.element_count = element_count;
-        self.render_depth = render_depth;
-        self.populated = true;
-    }
-
-    pub fn clear(&mut self) {
-        self.populated = false;
-    }
-
-    pub fn layer_meshes(&self) -> &[((Layer, DataType), Mesh)] {
-        &self.layer_meshes
-    }
-
-    pub fn extra_shapes(&self) -> &[Shape] {
-        &self.extra_shapes
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use egui::Rect;
     use gdsr::{Cell, Element, Library, Reference};
 
     use crate::testutil::helpers::polygon;
-
-    fn test_rect() -> Rect {
-        Rect::from_min_size(Pos2::ZERO, egui::Vec2::new(800.0, 600.0))
-    }
-
-    fn populated_cache() -> RenderCache {
-        let mut cache = RenderCache::default();
-        cache.update(
-            vec![],
-            vec![],
-            0.0,
-            0.0,
-            1.0,
-            test_rect().center(),
-            vec![],
-            42,
-            1,
-        );
-        cache
-    }
 
     fn cell_state_with_elements(elements: Vec<Element>) -> CellState {
         let mut source_cell = Cell::new("top");
@@ -439,6 +312,39 @@ mod tests {
         assert_eq!(cell.selected_cell.as_deref(), Some("new_cell"));
         assert!(cell.elements.is_empty());
         assert!(cell.spatial_grid.is_none());
+    }
+
+    #[test]
+    fn refreshing_depth_layers_preserves_direct_render_indexes() {
+        let mut leaf = Cell::new("leaf");
+        leaf.add(polygon(vec![(0, 0), (100, 0), (100, 100)], 2, 0));
+        let mut top = Cell::new("top");
+        top.add(polygon(vec![(0, 0), (100, 0), (100, 100)], 1, 0));
+        top.add(Reference::new("leaf"));
+        let mut library = Library::new("test");
+        library.add_cell(leaf);
+        library.add_cell(top);
+        let mut cell = CellState::new(library);
+        cell.selected_cell = Some("top".to_string());
+        assert!(cell.load_direct_cell_elements("top"));
+        cell.tessellation_cache.insert(0, vec![0, 1, 2]);
+
+        cell.render_depth = 2;
+        cell.refresh_layers();
+
+        assert_eq!(
+            cell.layers,
+            BTreeSet::from([
+                (Layer::new(1), DataType::new(0)),
+                (Layer::new(2), DataType::new(0)),
+            ])
+        );
+        assert_eq!(cell.elements.len(), 2);
+        assert!(cell.spatial_grid.is_some());
+        assert_eq!(
+            cell.tessellation_cache.get(&0).map(Vec::as_slice),
+            Some(&[0, 1, 2][..])
+        );
     }
 
     #[test]
@@ -562,222 +468,6 @@ mod tests {
             .expect("unchanged element has bbox");
         assert!((bbox.min_x - 0.0).abs() < 1e-15);
         assert!(cell.spatial_grid.is_some());
-    }
-
-    #[test]
-    fn no_rerender_on_same_state() {
-        let cache = populated_cache();
-        let rect = test_rect();
-        assert!(!cache.needs_full_render(&[], 42, 1, 0.0, 0.0, 1.0, rect));
-    }
-
-    #[test]
-    fn rerender_when_empty() {
-        let cache = RenderCache::default();
-        assert!(cache.needs_full_render(&[], 42, 1, 0.0, 0.0, 1.0, test_rect()));
-    }
-
-    #[test]
-    fn no_rerender_on_small_pan() {
-        let cache = populated_cache();
-        let rect = test_rect();
-        assert!(!cache.needs_full_render(&[], 42, 1, 100.0, 0.0, 1.0, rect));
-    }
-
-    #[test]
-    fn rerender_on_large_pan() {
-        let cache = populated_cache();
-        let rect = test_rect();
-        // 800px viewport width, margin budget = 800, 80% = 640px.
-        // dx_screen = (0.0 - 700.0) * 1.0 = -700, |700| > 640 → re-render
-        assert!(cache.needs_full_render(&[], 42, 1, 700.0, 0.0, 1.0, rect));
-    }
-
-    #[test]
-    fn no_rerender_on_small_zoom() {
-        let cache = populated_cache();
-        let rect = test_rect();
-        assert!(!cache.needs_full_render(&[], 42, 1, 0.0, 0.0, 1.5, rect));
-    }
-
-    #[test]
-    fn rerender_on_large_zoom() {
-        let cache = populated_cache();
-        let rect = test_rect();
-        // zoom ratio 3.0 / 1.0 = 3.0, outside [0.5, 2.0]
-        assert!(cache.needs_full_render(&[], 42, 1, 0.0, 0.0, 3.0, rect));
-    }
-
-    #[test]
-    fn rerender_on_hidden_layer_change() {
-        let cache = populated_cache();
-        assert!(cache.needs_full_render(
-            &[(Layer::new(1), DataType::new(0))],
-            42,
-            1,
-            0.0,
-            0.0,
-            1.0,
-            test_rect()
-        ));
-    }
-
-    #[test]
-    fn rerender_on_element_count_change() {
-        let cache = populated_cache();
-        assert!(cache.needs_full_render(&[], 43, 1, 0.0, 0.0, 1.0, test_rect()));
-    }
-
-    #[test]
-    fn rerender_on_render_depth_change() {
-        let cache = populated_cache();
-        assert!(cache.needs_full_render(&[], 42, 2, 0.0, 0.0, 1.0, test_rect()));
-    }
-
-    #[test]
-    fn delta_transform_identity_on_same_state() {
-        let cache = populated_cache();
-        let rect = test_rect();
-        let tsf = cache.delta_transform(0.0, 0.0, 1.0, rect.center());
-        assert!((tsf.scaling - 1.0).abs() < 1e-6);
-        assert!(tsf.translation.x.abs() < 1e-3);
-        assert!(tsf.translation.y.abs() < 1e-3);
-    }
-
-    #[test]
-    fn delta_transform_pure_pan() {
-        let cache = populated_cache();
-        let rect = test_rect();
-        let zoom = 1.0;
-        let pan_x = 50.0;
-        let tsf = cache.delta_transform(pan_x, 0.0, zoom, rect.center());
-
-        // Pure pan: scale=1, tx = (0 - 50) * 1 = -50, ty = 0
-        assert!((tsf.scaling - 1.0).abs() < 1e-6);
-        assert!((tsf.translation.x - (-50.0)).abs() < 1e-3);
-        assert!(tsf.translation.y.abs() < 1e-3);
-    }
-
-    /// Verifies the delta transform maps an old screen point to where it should be
-    /// after a viewport change, matching a fresh `world_to_screen` call.
-    #[test]
-    fn delta_transform_matches_fresh_render() {
-        use crate::viewport::Viewport;
-
-        let rect = test_rect();
-        let old_vp = Viewport {
-            center_x: 10.0,
-            center_y: 20.0,
-            zoom: 100.0,
-        };
-
-        let mut cache = RenderCache::default();
-        cache.update(
-            vec![],
-            vec![],
-            old_vp.center_x,
-            old_vp.center_y,
-            old_vp.zoom,
-            rect.center(),
-            vec![],
-            1,
-            1,
-        );
-
-        let new_vp = Viewport {
-            center_x: 15.0,
-            center_y: 25.0,
-            zoom: 120.0,
-        };
-
-        let tsf =
-            cache.delta_transform(new_vp.center_x, new_vp.center_y, new_vp.zoom, rect.center());
-
-        // Pick a world point, render with old viewport, apply delta, compare to new viewport.
-        let (wx, wy) = (12.0, 22.0);
-        let old_screen = old_vp.world_to_screen(wx, wy, rect);
-        let transformed = tsf * old_screen;
-        let fresh = new_vp.world_to_screen(wx, wy, rect);
-
-        assert!(
-            (transformed.x - fresh.x).abs() < 0.5,
-            "x: {transformed} vs {fresh}"
-        );
-        assert!(
-            (transformed.y - fresh.y).abs() < 0.5,
-            "y: {transformed} vs {fresh}"
-        );
-    }
-
-    #[test]
-    fn no_rerender_at_zoom_ratio_boundary_low() {
-        let cache = populated_cache();
-        let rect = test_rect();
-        assert!(!cache.needs_full_render(&[], 42, 1, 0.0, 0.0, 0.5, rect));
-    }
-
-    #[test]
-    fn rerender_just_below_zoom_ratio_boundary() {
-        let cache = populated_cache();
-        let rect = test_rect();
-        assert!(cache.needs_full_render(&[], 42, 1, 0.0, 0.0, 0.49, rect));
-    }
-
-    #[test]
-    fn no_rerender_at_zoom_ratio_boundary_high() {
-        let cache = populated_cache();
-        let rect = test_rect();
-        assert!(!cache.needs_full_render(&[], 42, 1, 0.0, 0.0, 2.0, rect));
-    }
-
-    #[test]
-    fn rerender_just_above_zoom_ratio_boundary() {
-        let cache = populated_cache();
-        let rect = test_rect();
-        assert!(cache.needs_full_render(&[], 42, 1, 0.0, 0.0, 2.01, rect));
-    }
-
-    #[test]
-    fn no_rerender_at_exact_margin() {
-        let cache = populated_cache();
-        let rect = test_rect();
-        // margin_x = 800 * 0.8 = 640, dx_screen = |0 - 640| = 640, NOT > 640
-        assert!(!cache.needs_full_render(&[], 42, 1, 640.0, 0.0, 1.0, rect));
-    }
-
-    #[test]
-    fn rerender_just_beyond_margin() {
-        let cache = populated_cache();
-        let rect = test_rect();
-        assert!(cache.needs_full_render(&[], 42, 1, 641.0, 0.0, 1.0, rect));
-    }
-
-    #[test]
-    fn delta_transform_extreme_zoom_ratio() {
-        let cache = populated_cache();
-        let rect = test_rect();
-        let tsf = cache.delta_transform(0.0, 0.0, 2.0, rect.center());
-        assert!(tsf.scaling.is_finite());
-        assert!(tsf.translation.x.is_finite());
-        assert!(tsf.translation.y.is_finite());
-    }
-
-    #[test]
-    fn delta_transform_large_pan() {
-        let cache = populated_cache();
-        let rect = test_rect();
-        let tsf = cache.delta_transform(1e6, 1e6, 1.0, rect.center());
-        assert!(tsf.translation.x.is_finite());
-        assert!(tsf.translation.y.is_finite());
-    }
-
-    #[test]
-    fn clear_forces_rerender() {
-        let mut cache = populated_cache();
-        let rect = test_rect();
-        assert!(!cache.needs_full_render(&[], 42, 1, 0.0, 0.0, 1.0, rect));
-        cache.clear();
-        assert!(cache.needs_full_render(&[], 42, 1, 0.0, 0.0, 1.0, rect));
     }
 
     #[test]

--- a/crates/gdsr-viewer/src/viewport/mod.rs
+++ b/crates/gdsr-viewer/src/viewport/mod.rs
@@ -5,13 +5,12 @@ pub use bounds::compute_bounds;
 use std::collections::HashMap;
 
 use egui::{Color32, Pos2, Rect, Sense};
-use gdsr::{DataType, Element, Layer, Library, Point};
+use gdsr::{Element, Library, Point};
 
-use crate::drawable::{DrawContext, Drawable, WorldBBox, cell_world_bbox, draw_highlight};
+use crate::drawable::{WorldBBox, draw_highlight};
 use crate::grid;
 use crate::ruler::RulerState;
-use crate::spatial::SpatialGrid;
-use crate::state::{GridSpacing, LayerState, RenderCache};
+use crate::state::{GridSpacing, LayerState};
 
 /// Camera state for the 2D viewport: center position in world coordinates and zoom level.
 pub struct Viewport {
@@ -22,6 +21,7 @@ pub struct Viewport {
 }
 
 pub struct ViewportInteraction {
+    pub rect: Rect,
     pub mouse_world: Option<(f64, f64)>,
     pub clicked: bool,
     pub double_clicked: bool,
@@ -92,71 +92,44 @@ impl Viewport {
     }
 }
 
-/// Screen-pixel threshold below which a grid cell draws as a single LOAD rectangle
-/// instead of rendering individual elements.
-const CELL_LOAD_THRESHOLD_PX: f32 = 24.0;
-const CELL_LOAD_DENSITY_MIN_ELEMENTS: usize = 128;
-const CELL_LOAD_MIN_AVG_ELEMENT_AREA_PX: f32 = 16.0;
-
-fn should_draw_cell_load(width_px: f32, height_px: f32, element_count: usize) -> bool {
-    if width_px < CELL_LOAD_THRESHOLD_PX || height_px < CELL_LOAD_THRESHOLD_PX {
-        return true;
-    }
-    if element_count < CELL_LOAD_DENSITY_MIN_ELEMENTS {
-        return false;
-    }
-
-    let area_px = width_px * height_px;
-    area_px.is_finite() && area_px / element_count as f32 <= CELL_LOAD_MIN_AVG_ELEMENT_AREA_PX
-}
-
 impl Viewport {
-    /// Draws the viewport and handles pan/zoom interaction.
-    ///
-    /// Returns the mouse position in world coordinates if the pointer is inside the viewport.
+    /// Draws viewport interaction and egui overlays over the Bevy scene.
     pub fn draw(
         &mut self,
         ui: &mut egui::Ui,
         elements: &[Element],
         layer_state: &mut LayerState,
-        spatial_grid: Option<&SpatialGrid>,
-        query_buf: &mut Vec<u32>,
-        drawn_element_marks: &mut Vec<bool>,
         library: Option<&Library>,
-        render_cache: &mut RenderCache,
         tessellation_cache: &mut HashMap<u32, Vec<usize>>,
         ruler: &mut RulerState,
         show_grid: bool,
         grid_spacing: GridSpacing,
         hovered_element: Option<usize>,
         selected_element: Option<usize>,
-        render_depth: u32,
-        selected_cell: Option<&str>,
         drawing_preview_points: Option<&[Point]>,
     ) -> ViewportInteraction {
         let (response, painter) = ui.allocate_painter(ui.available_size(), Sense::click_and_drag());
         let rect = response.rect;
-
-        painter.rect_filled(rect, 0.0, Color32::from_rgb(30, 30, 30));
 
         if show_grid {
             grid::draw_grid(&painter, self, rect, grid_spacing);
             grid::draw_origin_axes(&painter, self, rect);
         }
 
-        // Handle ruler clicks before drag so ruler gets priority when active.
         let ruler_was_active = ruler.active;
-        if ruler_was_active && response.clicked() {
-            if let Some(pos) = response.interact_pointer_pos() {
-                let (wx, wy) = self.screen_to_world(pos.x, pos.y, rect);
-                ruler.handle_click(wx, wy);
-            }
+        if ruler_was_active
+            && response.clicked()
+            && let Some(pos) = response.interact_pointer_pos()
+        {
+            let (wx, wy) = self.screen_to_world(pos.x, pos.y, rect);
+            ruler.handle_click(wx, wy);
         }
         let clicked = response.clicked() && !ruler_was_active;
         let double_clicked = response.double_clicked() && !ruler_was_active;
 
-        let move_selected_element =
-            selected_element.is_some() && ui.input(|i| i.modifiers.shift) && response.dragged();
+        let move_selected_element = selected_element.is_some()
+            && ui.input(|input| input.modifiers.shift)
+            && response.dragged();
         let selected_element_drag_delta = if move_selected_element {
             let delta = response.drag_delta();
             Some((
@@ -174,290 +147,40 @@ impl Viewport {
         }
 
         if let Some(hover_pos) = response.hover_pos() {
-            let scroll = ui.input(|i| i.smooth_scroll_delta.y);
+            let scroll = ui.input(|input| input.smooth_scroll_delta.y);
             if scroll != 0.0 {
                 let (wx, wy) = self.screen_to_world(hover_pos.x, hover_pos.y, rect);
                 let factor = 1.0 + f64::from(scroll) * 0.002;
                 let new_zoom = (self.zoom * factor).clamp(1e-3, 1e15);
-                let cx = f64::from(rect.center().x);
-                let cy = f64::from(rect.center().y);
-                let sx = f64::from(hover_pos.x);
-                let sy = f64::from(hover_pos.y);
-                self.center_x = wx - (sx - cx) / new_zoom;
-                self.center_y = wy + (sy - cy) / new_zoom;
+                let center = rect.center();
+                self.center_x = wx - f64::from(hover_pos.x - center.x) / new_zoom;
+                self.center_y = wy + f64::from(hover_pos.y - center.y) / new_zoom;
                 self.zoom = new_zoom;
             }
         }
 
-        // Keyboard pan: arrow keys move by 10% of the visible viewport.
         let pan_step_x = f64::from(rect.width()) * 0.1 / self.zoom;
         let pan_step_y = f64::from(rect.height()) * 0.1 / self.zoom;
-        ui.input(|i| {
-            if i.key_pressed(egui::Key::ArrowLeft) {
+        ui.input(|input| {
+            if input.key_pressed(egui::Key::ArrowLeft) {
                 self.pan(-pan_step_x, 0.0);
             }
-            if i.key_pressed(egui::Key::ArrowRight) {
+            if input.key_pressed(egui::Key::ArrowRight) {
                 self.pan(pan_step_x, 0.0);
             }
-            if i.key_pressed(egui::Key::ArrowUp) {
+            if input.key_pressed(egui::Key::ArrowUp) {
                 self.pan(0.0, pan_step_y);
             }
-            if i.key_pressed(egui::Key::ArrowDown) {
+            if input.key_pressed(egui::Key::ArrowDown) {
                 self.pan(0.0, -pan_step_y);
             }
-            if i.key_pressed(egui::Key::Plus) || i.key_pressed(egui::Key::Equals) {
+            if input.key_pressed(egui::Key::Plus) || input.key_pressed(egui::Key::Equals) {
                 self.zoom_at_center(1.2);
             }
-            if i.key_pressed(egui::Key::Minus) {
+            if input.key_pressed(egui::Key::Minus) {
                 self.zoom_at_center(1.0 / 1.2);
             }
         });
-
-        let mut hidden_layers: Vec<(Layer, DataType)> =
-            layer_state.hidden_layers.iter().copied().collect();
-        hidden_layers.sort_unstable();
-
-        if !render_cache.needs_full_render(
-            &hidden_layers,
-            elements.len(),
-            render_depth,
-            self.center_x,
-            self.center_y,
-            self.zoom,
-            rect,
-        ) {
-            let tsf = render_cache.delta_transform(
-                self.center_x,
-                self.center_y,
-                self.zoom,
-                rect.center(),
-            );
-            for (_, mesh) in render_cache.layer_meshes() {
-                let mut m = mesh.clone();
-                for v in &mut m.vertices {
-                    v.pos = tsf * v.pos;
-                }
-                painter.add(egui::Shape::mesh(m));
-            }
-            for s in render_cache.extra_shapes() {
-                let mut s = s.clone();
-                s.transform(tsf);
-                painter.add(s);
-            }
-            draw_element_highlight(
-                selected_element,
-                elements,
-                self,
-                &painter,
-                rect,
-                layer_state,
-                library,
-                tessellation_cache,
-            );
-            if hovered_element != selected_element {
-                draw_element_highlight(
-                    hovered_element,
-                    elements,
-                    self,
-                    &painter,
-                    rect,
-                    layer_state,
-                    library,
-                    tessellation_cache,
-                );
-            }
-            let mouse_world = response
-                .hover_pos()
-                .map(|pos| self.screen_to_world(pos.x, pos.y, rect));
-            draw_drawing_preview(drawing_preview_points, self, &painter, rect);
-            ruler.draw(&painter, self, rect, mouse_world);
-            return ViewportInteraction {
-                mouse_world,
-                clicked,
-                double_clicked,
-                selected_element_drag_delta,
-            };
-        }
-
-        // Depth-0: draw just the selected cell's bounding box with its name.
-        if render_depth == 0 {
-            if let Some(cell_name) = selected_cell {
-                if let Some(lib) = library {
-                    if let Some(bbox) = cell_world_bbox(cell_name, lib) {
-                        let min_x = bbox.min_x;
-                        let min_y = bbox.min_y;
-                        let max_x = bbox.max_x;
-                        let max_y = bbox.max_y;
-                        let s_min = self.world_to_screen(min_x, min_y, rect);
-                        let s_max = self.world_to_screen(max_x, max_y, rect);
-                        let screen_rect = Rect::from_two_pos(s_min, s_max);
-                        let stroke_color = Color32::from_rgb(180, 180, 180);
-                        painter.rect_stroke(
-                            screen_rect,
-                            0.0,
-                            egui::Stroke::new(1.0_f32, stroke_color),
-                            egui::StrokeKind::Outside,
-                        );
-                        let sw = (s_max.x - s_min.x).abs();
-                        let sh = (s_min.y - s_max.y).abs();
-                        if sw >= 40.0 && sh >= 20.0 {
-                            let char_count = cell_name.len().max(1) as f32;
-                            let fit_w = sw * 0.9 / (char_count * 0.6);
-                            let fit_h = sh * 0.4;
-                            let font_size = fit_w.min(fit_h).min(48.0);
-                            if font_size >= 8.0 {
-                                painter.text(
-                                    screen_rect.center(),
-                                    egui::Align2::CENTER_CENTER,
-                                    cell_name,
-                                    egui::FontId::monospace(font_size),
-                                    stroke_color,
-                                );
-                            }
-                        }
-                    }
-                }
-            }
-            let mouse_world = response
-                .hover_pos()
-                .map(|pos| self.screen_to_world(pos.x, pos.y, rect));
-            draw_drawing_preview(drawing_preview_points, self, &painter, rect);
-            ruler.draw(&painter, self, rect, mouse_world);
-            return ViewportInteraction {
-                mouse_world,
-                clicked,
-                double_clicked,
-                selected_element_drag_delta,
-            };
-        }
-
-        // Full render: query a 3× expanded region so the cache has margin for panning.
-        let visible = self.visible_world_rect(rect);
-        let w = visible.max_x - visible.min_x;
-        let h = visible.max_y - visible.min_y;
-        let render_visible = WorldBBox::new(
-            visible.min_x - w,
-            visible.min_y - h,
-            visible.max_x + w,
-            visible.max_y + h,
-        );
-
-        let mut layer_meshes = HashMap::new();
-        let mut extra_shapes = Vec::new();
-        let mut screen_pts_buf = Vec::new();
-        let mut cell_bbox_cache = HashMap::new();
-        let mut cell_complexity_cache = HashMap::new();
-        let mut ctx = DrawContext {
-            painter: &painter,
-            layer_meshes: &mut layer_meshes,
-            extra_shapes: &mut extra_shapes,
-            viewport: self,
-            rect,
-            visible: &render_visible,
-            layer_state,
-            library,
-            current_element_idx: None,
-            tessellation_cache,
-            screen_pts_buf: &mut screen_pts_buf,
-            highlight: false,
-            show_ref_bbox: false,
-            reference_depth: render_depth,
-            reference_stack: selected_cell.map_or_else(Vec::new, |name| vec![name.to_string()]),
-            cell_bbox_cache: &mut cell_bbox_cache,
-            cell_complexity_cache: &mut cell_complexity_cache,
-        };
-
-        if let Some(grid) = spatial_grid {
-            if drawn_element_marks.len() < elements.len() {
-                drawn_element_marks.resize(elements.len(), false);
-            }
-            query_buf.clear();
-
-            for cell in grid.query_visible(&render_visible) {
-                let s_min = ctx
-                    .viewport
-                    .world_to_screen(cell.bbox.min_x, cell.bbox.min_y, rect);
-                let s_max = ctx
-                    .viewport
-                    .world_to_screen(cell.bbox.max_x, cell.bbox.max_y, rect);
-                let sw = (s_max.x - s_min.x).abs();
-                let sh = (s_min.y - s_max.y).abs();
-
-                let has_area =
-                    cell.bbox.min_x < cell.bbox.max_x || cell.bbox.min_y < cell.bbox.max_y;
-
-                if has_area && sw < 1.0 && sh < 1.0 {
-                    continue;
-                }
-
-                if has_area && should_draw_cell_load(sw, sh, cell.indices.len()) {
-                    if !ctx.layer_state.hidden_layers.contains(&cell.dominant_layer) {
-                        let color = ctx
-                            .layer_state
-                            .layer_colors
-                            .get(cell.dominant_layer.0, cell.dominant_layer.1);
-                        let fill =
-                            Color32::from_rgba_unmultiplied(color.r(), color.g(), color.b(), 80);
-                        let cell_rect = Rect::from_two_pos(s_min, s_max);
-                        ctx.rect_filled(cell_rect, 0.0, fill);
-                    }
-                    continue;
-                }
-
-                for &idx in &cell.indices {
-                    let i = idx as usize;
-                    if drawn_element_marks[i] {
-                        continue;
-                    }
-                    drawn_element_marks[i] = true;
-                    query_buf.push(idx);
-                    if let Some(element) = elements.get(i) {
-                        ctx.current_element_idx = Some(idx);
-                        element.draw(&mut ctx);
-                    }
-                }
-            }
-
-            // Cell references have no direct world bbox, so the spatial grid never
-            // contains them. Draw any unseen references in a second pass.
-            for (i, element) in elements.iter().enumerate() {
-                if matches!(element, Element::Reference(_))
-                    && !drawn_element_marks.get(i).copied().unwrap_or_default()
-                {
-                    ctx.current_element_idx = Some(i as u32);
-                    element.draw(&mut ctx);
-                }
-            }
-
-            for &idx in query_buf.iter() {
-                if let Some(mark) = drawn_element_marks.get_mut(idx as usize) {
-                    *mark = false;
-                }
-            }
-        } else {
-            for (i, element) in elements.iter().enumerate() {
-                ctx.current_element_idx = Some(i as u32);
-                element.draw(&mut ctx);
-            }
-        }
-
-        let batched: Vec<((Layer, DataType), egui::epaint::Mesh)> =
-            layer_meshes.into_iter().collect();
-        for (_, mesh) in &batched {
-            painter.add(egui::Shape::mesh(mesh.clone()));
-        }
-        painter.extend(extra_shapes.iter().cloned());
-        render_cache.update(
-            batched,
-            extra_shapes,
-            self.center_x,
-            self.center_y,
-            self.zoom,
-            rect.center(),
-            hidden_layers,
-            elements.len(),
-            render_depth,
-        );
 
         draw_element_highlight(
             selected_element,
@@ -487,7 +210,9 @@ impl Viewport {
             .map(|pos| self.screen_to_world(pos.x, pos.y, rect));
         draw_drawing_preview(drawing_preview_points, self, &painter, rect);
         ruler.draw(&painter, self, rect, mouse_world);
+
         ViewportInteraction {
+            rect,
             mouse_world,
             clicked,
             double_clicked,
@@ -689,26 +414,6 @@ mod tests {
         vp.pan(10.0, -5.0);
         assert!((vp.center_x - 10.0).abs() < EPSILON);
         assert!((vp.center_y - (-5.0)).abs() < EPSILON);
-    }
-
-    #[test]
-    fn load_cell_for_small_screen_area() {
-        assert!(should_draw_cell_load(12.0, 20.0, 1));
-    }
-
-    #[test]
-    fn load_cell_for_skinny_screen_area() {
-        assert!(should_draw_cell_load(4000.0, 4.0, 1));
-    }
-
-    #[test]
-    fn load_cell_for_dense_screen_area() {
-        assert!(should_draw_cell_load(400.0, 200.0, 10_000));
-    }
-
-    #[test]
-    fn draw_sparse_large_cell_elements() {
-        assert!(!should_draw_cell_load(400.0, 200.0, 100));
     }
 
     #[test]

--- a/crates/gdsr/src/io/write/mod.rs
+++ b/crates/gdsr/src/io/write/mod.rs
@@ -234,7 +234,7 @@ fn write_string_with_record_to_file(
     write_u16_array(buffer, &string_start)?;
 
     buffer.write_all(string.as_bytes())?;
-    if byte_len % 2 != 0 {
+    if !byte_len.is_multiple_of(2) {
         buffer.write_all(&[0])?;
     }
 


### PR DESCRIPTION
## Summary

Replace the eframe CPU renderer with a Bevy scene that shares cell geometry, culls before hierarchy expansion, substitutes pixel-scale LOAD proxies, and caps visible detail. The reported sample prepares in about 49 ms, plans depths 5 through 10 in at most 1.4 ms under the stress probe, and idles at 0.0% CPU in release mode; the Bevy 0.18 integration raises the workspace MSRV to Rust 1.89.

## Test Plan

Ran `cargo nextest run`, strict workspace Clippy, `uvx prek run -a`, and release-mode profiling with `Golden_Output_no_raith_data.gds`.