### PR TITLE
Add GDS element properties

### DIFF
--- a/crates/gdsr/src/boolean.rs
+++ b/crates/gdsr/src/boolean.rs
@@ -24,14 +24,20 @@ fn apply(left: &Polygon, right: &Polygon, operation: OpType) -> Vec<Polygon> {
 fn element_polygon(element: &Element) -> Option<Polygon> {
     match element {
         Element::Polygon(polygon) => Some(polygon.clone()),
-        Element::Box(gds_box) => Some(Polygon::new(
-            gds_box.points(),
-            gds_box.layer(),
-            gds_box.box_type(),
-        )),
-        Element::Path(path) => path
-            .to_polygon_points(PATH_ARC_SEGMENTS)
-            .map(|points| Polygon::new(points, path.layer(), path.data_type())),
+        Element::Box(gds_box) => {
+            let mut polygon = Polygon::new(gds_box.points(), gds_box.layer(), gds_box.box_type());
+            polygon
+                .properties_mut()
+                .extend_from_slice(gds_box.properties());
+            Some(polygon)
+        }
+        Element::Path(path) => path.to_polygon_points(PATH_ARC_SEGMENTS).map(|points| {
+            let mut polygon = Polygon::new(points, path.layer(), path.data_type());
+            polygon
+                .properties_mut()
+                .extend_from_slice(path.properties());
+            polygon
+        }),
         Element::Node(_) | Element::Text(_) | Element::Reference(_) => None,
     }
 }
@@ -45,7 +51,7 @@ fn apply_elements(left: &Element, right: &Element, operation: OpType) -> Option<
 impl Polygon {
     /// Returns the filled union of this polygon and `other`.
     ///
-    /// Results use this polygon's layer, data type, and coordinate units.
+    /// Results preserve this polygon's layer, data type, coordinate units, and properties.
     #[must_use]
     pub fn union(&self, other: &Self) -> Vec<Self> {
         apply(self, other, OpType::Union)
@@ -53,7 +59,7 @@ impl Polygon {
 
     /// Returns the regions shared by this polygon and `other`.
     ///
-    /// Results use this polygon's layer, data type, and coordinate units.
+    /// Results preserve this polygon's layer, data type, coordinate units, and properties.
     #[must_use]
     pub fn intersection(&self, other: &Self) -> Vec<Self> {
         apply(self, other, OpType::Intersection)
@@ -61,7 +67,7 @@ impl Polygon {
 
     /// Returns the regions in this polygon that are not in `other`.
     ///
-    /// Results use this polygon's layer, data type, and coordinate units.
+    /// Results preserve this polygon's layer, data type, coordinate units, and properties.
     #[must_use]
     pub fn difference(&self, other: &Self) -> Vec<Self> {
         apply(self, other, OpType::Difference)
@@ -69,7 +75,7 @@ impl Polygon {
 
     /// Returns the regions in either polygon, but not both.
     ///
-    /// Results use this polygon's layer, data type, and coordinate units.
+    /// Results preserve this polygon's layer, data type, coordinate units, and properties.
     #[must_use]
     pub fn xor(&self, other: &Self) -> Vec<Self> {
         apply(self, other, OpType::Xor)
@@ -80,7 +86,8 @@ impl Element {
     /// Returns the filled union of this element and `other`.
     ///
     /// Polygons, boxes, and paths with positive width are supported. Returns `None` when either
-    /// element has no filled-area representation. Results use this element's layer and data type.
+    /// element has no filled-area representation. Results preserve this element's layer, data
+    /// type, coordinate units, and properties.
     #[must_use]
     pub fn union(&self, other: &Self) -> Option<Vec<Polygon>> {
         apply_elements(self, other, OpType::Union)
@@ -89,7 +96,8 @@ impl Element {
     /// Returns the regions shared by this element and `other`.
     ///
     /// Polygons, boxes, and paths with positive width are supported. Returns `None` when either
-    /// element has no filled-area representation. Results use this element's layer and data type.
+    /// element has no filled-area representation. Results preserve this element's layer, data
+    /// type, coordinate units, and properties.
     #[must_use]
     pub fn intersection(&self, other: &Self) -> Option<Vec<Polygon>> {
         apply_elements(self, other, OpType::Intersection)
@@ -98,7 +106,8 @@ impl Element {
     /// Returns the regions in this element that are not in `other`.
     ///
     /// Polygons, boxes, and paths with positive width are supported. Returns `None` when either
-    /// element has no filled-area representation. Results use this element's layer and data type.
+    /// element has no filled-area representation. Results preserve this element's layer, data
+    /// type, coordinate units, and properties.
     #[must_use]
     pub fn difference(&self, other: &Self) -> Option<Vec<Polygon>> {
         apply_elements(self, other, OpType::Difference)
@@ -107,7 +116,8 @@ impl Element {
     /// Returns the regions in either element, but not both.
     ///
     /// Polygons, boxes, and paths with positive width are supported. Returns `None` when either
-    /// element has no filled-area representation. Results use this element's layer and data type.
+    /// element has no filled-area representation. Results preserve this element's layer, data
+    /// type, coordinate units, and properties.
     #[must_use]
     pub fn xor(&self, other: &Self) -> Option<Vec<Polygon>> {
         apply_elements(self, other, OpType::Xor)
@@ -117,7 +127,7 @@ impl Element {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{DataType, GdsBox, Layer, Path, Point, Text, Unit};
+    use crate::{DataType, GdsBox, Layer, Path, Point, Property, Text, Unit};
 
     const NANOMETERS: f64 = 1e-9;
 
@@ -156,7 +166,8 @@ mod tests {
     fn polygon_boolean_operations_return_all_regions() {
         let layer = Layer::new(7);
         let data_type = DataType::new(11);
-        let left = rectangle(0.0, 0.0, 10.0, 10.0, layer, data_type);
+        let mut left = rectangle(0.0, 0.0, 10.0, 10.0, layer, data_type);
+        left.properties_mut().push(Property::new(3, "left"));
         let right = rectangle(5.0, 0.0, 15.0, 10.0, Layer::new(2), DataType::new(3));
 
         assert_area(&left.union(&right), 150.0);
@@ -165,10 +176,9 @@ mod tests {
         let xor = left.xor(&right);
         assert_eq!(xor.len(), 2);
         assert_area(&xor, 100.0);
-        assert!(
-            xor.iter()
-                .all(|polygon| polygon.layer() == layer && polygon.data_type() == data_type)
-        );
+        assert!(xor.iter().all(|polygon| polygon.layer() == layer
+            && polygon.data_type() == data_type
+            && polygon.properties() == left.properties()));
     }
 
     #[test]

--- a/crates/gdsr/src/clip.rs
+++ b/crates/gdsr/src/clip.rs
@@ -153,8 +153,13 @@ fn polygon_from_coordinates(
     {
         points.push(first);
     }
-    (points.len() >= MIN_POLYGON_POINTS)
-        .then(|| Polygon::new(points, source.layer(), source.data_type()))
+    (points.len() >= MIN_POLYGON_POINTS).then(|| {
+        let mut polygon = Polygon::new(points, source.layer(), source.data_type());
+        polygon
+            .properties_mut()
+            .extend_from_slice(source.properties());
+        polygon
+    })
 }
 
 pub fn polygons_from_geo(polygon: &GeoPolygon<f64>, source: &Polygon) -> Vec<Polygon> {
@@ -235,7 +240,7 @@ fn clip_path(path: &Path, region: &ClipRegion) -> Vec<Path> {
                 .collect();
             points.dedup();
             (points.len() >= 2).then(|| {
-                Path::new(
+                let mut clipped_path = Path::new(
                     points,
                     path.layer(),
                     path.data_type(),
@@ -243,7 +248,11 @@ fn clip_path(path: &Path, region: &ClipRegion) -> Vec<Path> {
                     path.width(),
                     None,
                     None,
-                )
+                );
+                clipped_path
+                    .properties_mut()
+                    .extend_from_slice(path.properties());
+                clipped_path
             })
         })
         .collect()
@@ -263,12 +272,16 @@ fn clip_box(gds_box: &GdsBox, region: &ClipRegion) -> Option<GdsBox> {
     }
 
     let units = PointUnits::from_point(&gds_box.bottom_left());
-    Some(GdsBox::new(
+    let mut clipped_box = GdsBox::new(
         units.point(Coord { x: min_x, y: min_y }),
         units.point(Coord { x: max_x, y: max_y }),
         gds_box.layer(),
         gds_box.box_type(),
-    ))
+    );
+    clipped_box
+        .properties_mut()
+        .extend_from_slice(gds_box.properties());
+    Some(clipped_box)
 }
 
 fn clip_node(node: &Node, region: &ClipRegion) -> Option<Node> {
@@ -284,7 +297,11 @@ fn clip_node(node: &Node, region: &ClipRegion) -> Option<Node> {
     if points.len() == node.points().len() {
         return Some(node.clone());
     }
-    Some(Node::new(points, node.layer(), node.node_type()))
+    let mut clipped_node = Node::new(points, node.layer(), node.node_type());
+    clipped_node
+        .properties_mut()
+        .extend_from_slice(node.properties());
+    Some(clipped_node)
 }
 
 fn clip_element(element: &Element, region: &ClipRegion) -> Vec<Element> {
@@ -325,7 +342,8 @@ impl Polygon {
     /// Clips this polygon to an axis-aligned bounding box.
     ///
     /// Multiple polygons are returned when clipping splits a concave polygon into disconnected
-    /// regions. Bounding-box corners may be supplied in either order or in different units.
+    /// regions. Element properties are preserved. Bounding-box corners may be supplied in either
+    /// order or in different units.
     #[must_use]
     pub fn clip_to_bounding_box(&self, bounds: (Point, Point)) -> Vec<Self> {
         clip_polygon(self, &ClipRegion::new(bounds))
@@ -336,7 +354,8 @@ impl Path {
     /// Clips this path's centerline to an axis-aligned bounding box.
     ///
     /// A path can split into multiple paths. Partially clipped paths retain their width and path
-    /// type, but their end extensions are removed because the new endpoints lie on the boundary.
+    /// type and properties, but their end extensions are removed because the new endpoints lie on
+    /// the boundary.
     #[must_use]
     pub fn clip_to_bounding_box(&self, bounds: (Point, Point)) -> Vec<Self> {
         clip_path(self, &ClipRegion::new(bounds))
@@ -346,8 +365,8 @@ impl Path {
 impl Element {
     /// Clips this element to an axis-aligned bounding box.
     ///
-    /// References are preserved because resolving them requires a library and a chosen hierarchy
-    /// coordinate system.
+    /// Element properties are preserved. References are preserved because resolving them requires
+    /// a library and a chosen hierarchy coordinate system.
     #[must_use]
     pub fn clip_to_bounding_box(&self, bounds: (Point, Point)) -> Vec<Self> {
         clip_element(self, &ClipRegion::new(bounds))
@@ -385,7 +404,7 @@ mod tests {
     use approx::assert_relative_eq;
 
     use super::*;
-    use crate::{DataType, Dimensions, Layer, PathType, Reference, Text};
+    use crate::{DataType, Dimensions, Layer, PathType, Property, Reference, Text};
 
     const UNITS: f64 = 1e-9;
 
@@ -410,14 +429,16 @@ mod tests {
 
     #[test]
     fn polygon_clipping_preserves_metadata_and_removes_outside_geometry() {
-        let polygon =
+        let mut polygon =
             Polygon::rectangle(point(-5, -5), point(5, 5), Layer::new(3), DataType::new(4));
+        polygon.properties_mut().push(Property::new(7, "source"));
 
         let clipped = polygon.clip_to_bounding_box(bounds());
 
         assert_eq!(clipped.len(), 1);
         assert_eq!(clipped[0].layer(), Layer::new(3));
         assert_eq!(clipped[0].data_type(), DataType::new(4));
+        assert_eq!(clipped[0].properties(), polygon.properties());
         assert_relative_eq!(clipped[0].area().float_value(), 25.0, epsilon = 1e-6);
         assert_points_in_bounds(clipped[0].points(), &ClipRegion::new(bounds()));
 

--- a/crates/gdsr/src/diff.rs
+++ b/crates/gdsr/src/diff.rs
@@ -52,8 +52,8 @@ pub enum ElementDiff {
     /// The element at this index changed.
     Modified {
         index: usize,
-        before: Element,
-        after: Element,
+        before: Box<Element>,
+        after: Box<Element>,
     },
 }
 
@@ -117,8 +117,8 @@ fn diff_elements(before: &[Element], after: &[Element], tolerance: f64) -> Vec<E
         .filter(|(_, (before, after))| !elements_equal(before, after, tolerance))
         .map(|(index, (before, after))| ElementDiff::Modified {
             index,
-            before: before.clone(),
-            after: after.clone(),
+            before: Box::new(before.clone()),
+            after: Box::new(after.clone()),
         })
         .collect();
 
@@ -167,12 +167,14 @@ fn paths_equal(left: &Path, right: &Path, tolerance: f64) -> bool {
         && optional_units_equal(left.width(), right.width(), tolerance)
         && optional_units_equal(left.begin_extension(), right.begin_extension(), tolerance)
         && optional_units_equal(left.end_extension(), right.end_extension(), tolerance)
+        && left.properties() == right.properties()
 }
 
 fn polygons_equal(left: &Polygon, right: &Polygon, tolerance: f64) -> bool {
     left.layer() == right.layer()
         && left.data_type() == right.data_type()
         && points_equal(left.points(), right.points(), tolerance)
+        && left.properties() == right.properties()
 }
 
 fn boxes_equal(left: &GdsBox, right: &GdsBox, tolerance: f64) -> bool {
@@ -183,12 +185,14 @@ fn boxes_equal(left: &GdsBox, right: &GdsBox, tolerance: f64) -> bool {
             &[right.bottom_left(), right.top_right()],
             tolerance,
         )
+        && left.properties() == right.properties()
 }
 
 fn nodes_equal(left: &Node, right: &Node, tolerance: f64) -> bool {
     left.layer() == right.layer()
         && left.node_type() == right.node_type()
         && points_equal(left.points(), right.points(), tolerance)
+        && left.properties() == right.properties()
 }
 
 fn texts_equal(left: &Text, right: &Text, tolerance: f64) -> bool {
@@ -201,11 +205,13 @@ fn texts_equal(left: &Text, right: &Text, tolerance: f64) -> bool {
         && left.vertical_presentation() == right.vertical_presentation()
         && left.horizontal_presentation() == right.horizontal_presentation()
         && points_equal(&[*left.origin()], &[*right.origin()], tolerance)
+        && left.properties() == right.properties()
 }
 
 fn references_equal(left: &Reference, right: &Reference, tolerance: f64) -> bool {
     instances_equal(left.instance(), right.instance(), tolerance)
         && grids_equal(left.grid(), right.grid(), tolerance)
+        && left.properties() == right.properties()
 }
 
 fn instances_equal(left: &Instance, right: &Instance, tolerance: f64) -> bool {
@@ -263,7 +269,7 @@ fn units_equal(left: Unit, right: Unit, tolerance: f64) -> bool {
 mod tests {
     use crate::{
         Cell, DataType, GdsBox, Grid, HorizontalPresentation, Layer, Node, Path, Point, Polygon,
-        Radians, Reference, Text, Unit, VerticalPresentation,
+        Property, Radians, Reference, Text, Unit, VerticalPresentation,
     };
 
     use super::*;
@@ -295,6 +301,28 @@ mod tests {
                 .diff(&library, LibraryDiffOptions::default())
                 .is_empty()
         );
+    }
+
+    #[test]
+    fn property_changes_are_reported() {
+        let mut before_cell = Cell::new("top");
+        before_cell.add(polygon(0.0));
+        let before = library_with_cell(before_cell);
+
+        let mut changed = polygon(0.0);
+        changed.properties_mut().push(Property::new(7, "net-a"));
+        let mut after_cell = Cell::new("top");
+        after_cell.add(changed);
+        let after = library_with_cell(after_cell);
+
+        assert!(matches!(
+            before
+                .diff(&after, LibraryDiffOptions::default())
+                .modified_cells[0]
+                .elements
+                .as_slice(),
+            [ElementDiff::Modified { index: 0, .. }]
+        ));
     }
 
     #[test]

--- a/crates/gdsr/src/elements/gds_box.rs
+++ b/crates/gdsr/src/elements/gds_box.rs
@@ -1,3 +1,4 @@
+use crate::elements::property::PropertyStore;
 use crate::{DataType, Dimensions, Layer, LayerMapping, Movable, Point, Transformable};
 
 /// A GDS II Box element defined by two diagonal corners on a specific layer.
@@ -10,6 +11,7 @@ pub struct GdsBox {
     pub(crate) top_right: Point,
     pub(crate) layer: Layer,
     pub(crate) box_type: DataType,
+    pub(crate) properties: PropertyStore,
 }
 
 impl GdsBox {
@@ -23,6 +25,7 @@ impl GdsBox {
             top_right,
             layer,
             box_type,
+            properties: PropertyStore::default(),
         }
     }
 

--- a/crates/gdsr/src/elements/mod.rs
+++ b/crates/gdsr/src/elements/mod.rs
@@ -3,6 +3,7 @@ pub mod gds_box;
 pub mod node;
 pub mod path;
 pub mod polygon;
+mod property;
 pub mod reference;
 pub mod text;
 
@@ -11,5 +12,6 @@ pub use gds_box::GdsBox;
 pub use node::Node;
 pub use path::{Path, PathType};
 pub use polygon::Polygon;
+pub use property::Property;
 pub use reference::{Instance, Reference};
 pub use text::Text;

--- a/crates/gdsr/src/elements/node.rs
+++ b/crates/gdsr/src/elements/node.rs
@@ -1,3 +1,4 @@
+use crate::elements::property::PropertyStore;
 use crate::{DataType, Dimensions, Layer, LayerMapping, Movable, Point, Transformable};
 
 /// Maximum number of points allowed in a GDS II Node element.
@@ -12,6 +13,7 @@ pub struct Node {
     pub(crate) points: Vec<Point>,
     pub(crate) layer: Layer,
     pub(crate) node_type: DataType,
+    pub(crate) properties: PropertyStore,
 }
 
 impl Node {
@@ -24,6 +26,7 @@ impl Node {
             points,
             layer,
             node_type,
+            properties: PropertyStore::default(),
         }
     }
 

--- a/crates/gdsr/src/elements/path.rs
+++ b/crates/gdsr/src/elements/path.rs
@@ -1,3 +1,4 @@
+use crate::elements::property::PropertyStore;
 use crate::{
     DataType, Dimensions, Layer, LayerMapping, Movable, Point, Radians, Transformable, Unit,
 };
@@ -38,6 +39,7 @@ pub struct Path {
     pub(crate) width: Option<Unit>,
     pub(crate) begin_extension: Option<Unit>,
     pub(crate) end_extension: Option<Unit>,
+    pub(crate) properties: PropertyStore,
 }
 
 impl Path {
@@ -59,6 +61,7 @@ impl Path {
             width,
             begin_extension,
             end_extension,
+            properties: PropertyStore::default(),
         }
     }
 

--- a/crates/gdsr/src/elements/polygon.rs
+++ b/crates/gdsr/src/elements/polygon.rs
@@ -1,3 +1,4 @@
+use crate::elements::property::PropertyStore;
 use crate::{
     DataType, Dimensions, Layer, LayerMapping, Movable, Point, Radians, Transformable, Unit,
 };
@@ -30,6 +31,7 @@ pub struct Polygon {
     pub(crate) points: Vec<Point>,
     pub(crate) layer: Layer,
     pub(crate) data_type: DataType,
+    pub(crate) properties: PropertyStore,
 }
 
 impl Polygon {
@@ -40,6 +42,7 @@ impl Polygon {
             points: get_correct_polygon_points_format(points),
             layer,
             data_type,
+            properties: PropertyStore::default(),
         }
     }
 

--- a/crates/gdsr/src/elements/property.rs
+++ b/crates/gdsr/src/elements/property.rs
@@ -1,0 +1,148 @@
+use std::fmt;
+
+use crate::{Element, GdsBox, Node, Path, Polygon, Reference, Text};
+
+/// A GDS II element property represented by a `PROPATTR`/`PROPVALUE` record pair.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Property {
+    attribute: u16,
+    value: String,
+}
+
+#[derive(Clone, Default)]
+pub struct PropertyStore(Option<Box<PropertyList>>);
+
+#[derive(Clone)]
+struct PropertyList(Vec<Property>);
+
+impl PropertyStore {
+    fn as_slice(&self) -> &[Property] {
+        self.0.as_deref().map_or(&[], |list| list.0.as_slice())
+    }
+
+    fn as_mut_vec(&mut self) -> &mut Vec<Property> {
+        &mut self
+            .0
+            .get_or_insert_with(|| Box::new(PropertyList(Vec::new())))
+            .as_mut()
+            .0
+    }
+}
+
+impl fmt::Debug for PropertyStore {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.as_slice().fmt(formatter)
+    }
+}
+
+impl PartialEq for PropertyStore {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_slice() == other.as_slice()
+    }
+}
+
+impl Eq for PropertyStore {}
+
+impl Property {
+    /// Creates a property with the given numeric attribute and string value.
+    pub fn new(attribute: u16, value: impl Into<String>) -> Self {
+        Self {
+            attribute,
+            value: value.into(),
+        }
+    }
+
+    /// Returns the numeric property attribute.
+    pub const fn attribute(&self) -> u16 {
+        self.attribute
+    }
+
+    /// Returns the property value.
+    pub fn value(&self) -> &str {
+        &self.value
+    }
+}
+
+macro_rules! impl_properties {
+    ($($element:ty),+ $(,)?) => {
+        $(
+            impl $element {
+                /// Returns this element's ordered properties.
+                pub fn properties(&self) -> &[Property] {
+                    self.properties.as_slice()
+                }
+
+                /// Returns this element's ordered properties mutably.
+                pub fn properties_mut(&mut self) -> &mut Vec<Property> {
+                    self.properties.as_mut_vec()
+                }
+            }
+        )+
+    };
+}
+
+impl_properties!(Polygon, Path, Text, Reference, GdsBox, Node);
+
+impl Element {
+    /// Returns the inner element's ordered properties.
+    pub fn properties(&self) -> &[Property] {
+        match self {
+            Self::Path(path) => path.properties(),
+            Self::Polygon(polygon) => polygon.properties(),
+            Self::Box(gds_box) => gds_box.properties(),
+            Self::Node(node) => node.properties(),
+            Self::Text(text) => text.properties(),
+            Self::Reference(reference) => reference.properties(),
+        }
+    }
+
+    /// Returns the inner element's ordered properties mutably.
+    pub fn properties_mut(&mut self) -> &mut Vec<Property> {
+        match self {
+            Self::Path(path) => path.properties_mut(),
+            Self::Polygon(polygon) => polygon.properties_mut(),
+            Self::Box(gds_box) => gds_box.properties_mut(),
+            Self::Node(node) => node.properties_mut(),
+            Self::Text(text) => text.properties_mut(),
+            Self::Reference(reference) => reference.properties_mut(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::mem::size_of;
+
+    use super::*;
+    use crate::{DataType, Layer, Point};
+
+    #[test]
+    fn property_accessors_preserve_order_and_duplicate_attributes() {
+        let mut element = Element::Polygon(Polygon::new(
+            [
+                Point::integer(0, 0, 1e-9),
+                Point::integer(10, 0, 1e-9),
+                Point::integer(0, 10, 1e-9),
+            ],
+            Layer::default(),
+            DataType::default(),
+        ));
+
+        element
+            .properties_mut()
+            .extend([Property::new(7, "net-a"), Property::new(7, "net-b")]);
+
+        assert_eq!(element.properties()[0].attribute(), 7);
+        assert_eq!(element.properties()[0].value(), "net-a");
+        assert_eq!(element.properties()[1].value(), "net-b");
+    }
+
+    #[test]
+    fn empty_property_storage_is_pointer_sized() {
+        let mut allocated_empty = PropertyStore::default();
+        allocated_empty.as_mut_vec();
+
+        assert_eq!(size_of::<PropertyStore>(), size_of::<usize>());
+        assert_eq!(allocated_empty, PropertyStore::default());
+    }
+}

--- a/crates/gdsr/src/elements/reference.rs
+++ b/crates/gdsr/src/elements/reference.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use std::sync::mpsc;
 
 use crate::elements::Element;
+use crate::elements::property::PropertyStore;
 use crate::traits::{Movable, Transformable};
 use crate::{Cell, FlattenOptions, Grid, Library, Point, Radians, Transformation};
 
@@ -73,6 +74,7 @@ impl From<&str> for Instance {
 pub struct Reference {
     pub(crate) instance: Instance,
     pub(crate) grid: Grid,
+    pub(crate) properties: PropertyStore,
 }
 
 impl Reference {
@@ -81,6 +83,7 @@ impl Reference {
         Self {
             instance: instance.into(),
             grid: Grid::default(),
+            properties: PropertyStore::default(),
         }
     }
 

--- a/crates/gdsr/src/elements/snapshots/gdsr__elements__reference__tests__cell_ref_grid_expansion_with_origin_and_rotation.snap
+++ b/crates/gdsr/src/elements/snapshots/gdsr__elements__reference__tests__cell_ref_grid_expansion_with_origin_and_rotation.snap
@@ -69,6 +69,7 @@ expression: flattened
             data_type: DataType(
                 0,
             ),
+            properties: [],
         },
     ),
 ]

--- a/crates/gdsr/src/elements/snapshots/gdsr__elements__reference__tests__grid_expansion_with_rotation_verifies_positions.snap
+++ b/crates/gdsr/src/elements/snapshots/gdsr__elements__reference__tests__grid_expansion_with_rotation_verifies_positions.snap
@@ -69,6 +69,7 @@ expression: elements
             data_type: DataType(
                 0,
             ),
+            properties: [],
         },
     ),
     Polygon(
@@ -137,6 +138,7 @@ expression: elements
             data_type: DataType(
                 0,
             ),
+            properties: [],
         },
     ),
 ]

--- a/crates/gdsr/src/elements/snapshots/gdsr__elements__reference__tests__reference_flatten.snap
+++ b/crates/gdsr/src/elements/snapshots/gdsr__elements__reference__tests__reference_flatten.snap
@@ -69,6 +69,7 @@ expression: flattened
             data_type: DataType(
                 0,
             ),
+            properties: [],
         },
     ),
     Polygon(
@@ -137,6 +138,7 @@ expression: flattened
             data_type: DataType(
                 0,
             ),
+            properties: [],
         },
     ),
     Polygon(
@@ -205,6 +207,7 @@ expression: flattened
             data_type: DataType(
                 0,
             ),
+            properties: [],
         },
     ),
     Polygon(
@@ -273,6 +276,7 @@ expression: flattened
             data_type: DataType(
                 0,
             ),
+            properties: [],
         },
     ),
 ]

--- a/crates/gdsr/src/elements/text.rs
+++ b/crates/gdsr/src/elements/text.rs
@@ -1,3 +1,4 @@
+use crate::elements::property::PropertyStore;
 use crate::{DataType, Dimensions, Layer, Movable, Point, Radians, Transformable};
 
 // --- Presentation types ---
@@ -162,6 +163,7 @@ pub struct Text {
     pub(crate) x_reflection: bool,
     pub(crate) vertical_presentation: VerticalPresentation,
     pub(crate) horizontal_presentation: HorizontalPresentation,
+    pub(crate) properties: PropertyStore,
 }
 
 impl Default for Text {
@@ -176,6 +178,7 @@ impl Default for Text {
             x_reflection: false,
             vertical_presentation: VerticalPresentation::default(),
             horizontal_presentation: HorizontalPresentation::default(),
+            properties: PropertyStore::default(),
         }
     }
 }
@@ -203,6 +206,7 @@ impl Text {
             x_reflection,
             vertical_presentation,
             horizontal_presentation,
+            properties: PropertyStore::default(),
         }
     }
 
@@ -842,6 +846,7 @@ mod tests {
             x_reflection: false,
             vertical_presentation: Middle,
             horizontal_presentation: Centre,
+            properties: [],
         }
         "#);
     }
@@ -939,6 +944,7 @@ mod tests {
             x_reflection: true,
             vertical_presentation: Middle,
             horizontal_presentation: Centre,
+            properties: [],
         }
         "#);
     }

--- a/crates/gdsr/src/io/read/mod.rs
+++ b/crates/gdsr/src/io/read/mod.rs
@@ -4,7 +4,7 @@ use std::io::{self, BufReader, Read};
 use crate::cell::Cell;
 use crate::config::gds_file_types::{GDSDataType, GDSRecord, GDSRecordData, STRANS_X_REFLECTION};
 use crate::elements::text::get_presentations_from_value;
-use crate::elements::{GdsBox, Node, Path, PathType, Polygon, Reference, Text};
+use crate::elements::{GdsBox, Node, Path, PathType, Polygon, Property, Reference, Text};
 use crate::error::GdsError;
 use crate::geometry::round_to_decimals;
 use crate::library::Library;
@@ -40,6 +40,7 @@ where
     let mut node: Option<Node> = None;
     let mut text: Option<Text> = None;
     let mut reference: Option<Reference> = None;
+    let mut property_attribute: Option<u16> = None;
 
     let mut scale = 1.0;
     let mut db_units = units.unwrap_or(DEFAULT_INTEGER_UNITS);
@@ -78,21 +79,27 @@ where
                     }
                 }
                 GDSRecord::Boundary => {
+                    property_attribute = None;
                     polygon = Some(Polygon::default());
                 }
                 GDSRecord::Box => {
+                    property_attribute = None;
                     gds_box = Some(GdsBox::default());
                 }
                 GDSRecord::Node => {
+                    property_attribute = None;
                     node = Some(Node::default());
                 }
                 GDSRecord::Path => {
+                    property_attribute = None;
                     path = Some(Path::default());
                 }
                 GDSRecord::ARef | GDSRecord::SRef => {
+                    property_attribute = None;
                     reference = Some(Reference::default());
                 }
                 GDSRecord::Text => {
+                    property_attribute = None;
                     text = Some(Text::default());
                 }
                 GDSRecord::Layer => {
@@ -261,6 +268,7 @@ where
                     path = None;
                     text = None;
                     reference = None;
+                    property_attribute = None;
                 }
                 GDSRecord::SName => {
                     if let GDSRecordData::Str(cell_name) = data {
@@ -348,6 +356,33 @@ where
                         if let Some(path) = &mut path {
                             let value = round_to_decimals(f64::from(extn[0]) * scale, 10);
                             path.end_extension = Some(Unit::float(value, db_units));
+                        }
+                    }
+                }
+                GDSRecord::PropAttr => {
+                    if let GDSRecordData::I16(attributes) = data
+                        && let Some(attribute) = attributes.first()
+                    {
+                        property_attribute = Some(*attribute as u16);
+                    }
+                }
+                GDSRecord::PropValue => {
+                    if let GDSRecordData::Str(value) = data
+                        && let Some(attribute) = property_attribute
+                    {
+                        let property = Property::new(attribute, value);
+                        if let Some(polygon) = &mut polygon {
+                            polygon.properties_mut().push(property);
+                        } else if let Some(gds_box) = &mut gds_box {
+                            gds_box.properties_mut().push(property);
+                        } else if let Some(node) = &mut node {
+                            node.properties_mut().push(property);
+                        } else if let Some(path) = &mut path {
+                            path.properties_mut().push(property);
+                        } else if let Some(reference) = &mut reference {
+                            reference.properties_mut().push(property);
+                        } else if let Some(text) = &mut text {
+                            text.properties_mut().push(property);
                         }
                     }
                 }

--- a/crates/gdsr/src/io/write/mod.rs
+++ b/crates/gdsr/src/io/write/mod.rs
@@ -13,8 +13,8 @@ use crate::config::gds_file_types::{
 use crate::elements::text::get_presentation_value;
 use crate::error::GdsError;
 use crate::{
-    Cell, Element, GdsBox, Instance, Library, Movable, Node, Path, Point, Polygon, Reference, Text,
-    Transformable,
+    Cell, Element, GdsBox, Instance, Library, Movable, Node, Path, Point, Polygon, Property,
+    Reference, Text, Transformable,
 };
 use gds_format::{eight_byte_real, write_u16_array_as_big_endian};
 use validation::{
@@ -268,7 +268,16 @@ fn write_points_to_file(
     Ok(())
 }
 
-fn write_element_tail_to_file(buffer: &mut impl Write) -> Result<(), GdsError> {
+fn write_element_tail_to_file(
+    buffer: &mut impl Write,
+    properties: &[Property],
+) -> Result<(), GdsError> {
+    for property in properties {
+        let [size, head] = record_header(GDSRecord::PropAttr, GDSDataType::TwoByteSignedInteger, 1);
+        write_u16_array(buffer, &[size, head, property.attribute()])?;
+        write_string_with_record_to_file(buffer, GDSRecord::PropValue, property.value())?;
+    }
+
     let tail = [
         GDSDataType::NoData.record_size(1),
         record_head(GDSRecord::EndEl, GDSDataType::NoData),
@@ -282,12 +291,21 @@ fn write_string_with_record_to_file(
     string: &str,
 ) -> Result<(), GdsError> {
     let byte_len = string.len();
-    let padded_len = byte_len + (byte_len % 2);
+    let Some(padded_len) = byte_len.checked_add(byte_len % 2) else {
+        return Err(GdsError::ValidationError {
+            message: "String record length overflow".to_string(),
+        });
+    };
+    let Some(record_size) = 4usize
+        .checked_add(padded_len)
+        .and_then(|size| u16::try_from(size).ok())
+    else {
+        return Err(GdsError::ValidationError {
+            message: format!("String record of {byte_len} bytes exceeds the GDS record limit"),
+        });
+    };
 
-    let string_start = [
-        (4 + padded_len) as u16,
-        record_head(record, GDSDataType::AsciiString),
-    ];
+    let string_start = [record_size, record_head(record, GDSDataType::AsciiString)];
 
     write_u16_array(buffer, &string_start)?;
 
@@ -420,7 +438,7 @@ pub fn write_polygon(polygon: &Polygon, db_units: f64) -> Result<Vec<u8>, GdsErr
     );
     write_u16_array(&mut buffer, &head)?;
     write_points_to_file(&mut buffer, polygon.points(), db_units)?;
-    write_element_tail_to_file(&mut buffer)?;
+    write_element_tail_to_file(&mut buffer, polygon.properties())?;
 
     Ok(buffer)
 }
@@ -465,7 +483,7 @@ pub fn write_path(path: &Path, db_units: f64) -> Result<Vec<u8>, GdsError> {
     }
 
     write_points_to_file(&mut buffer, path.points(), db_units)?;
-    write_element_tail_to_file(&mut buffer)?;
+    write_element_tail_to_file(&mut buffer, path.properties())?;
 
     Ok(buffer)
 }
@@ -510,12 +528,14 @@ pub fn write_text(text: &Text, db_units: f64) -> Result<Vec<u8>, GdsError> {
     )?;
     write_points_to_file(&mut buffer, &[*text.origin()], db_units)?;
     write_string_with_record_to_file(&mut buffer, GDSRecord::String, text.text())?;
-    write_element_tail_to_file(&mut buffer)?;
+    write_element_tail_to_file(&mut buffer, text.properties())?;
 
     Ok(buffer)
 }
 
 /// Serializes a reference to GDS bytes.
+///
+/// Properties on inline references are appended to each expanded element.
 pub fn write_reference(reference: &Reference, db_units: f64) -> Result<Vec<u8>, GdsError> {
     match reference.instance() {
         Instance::Cell(cell_name) => write_reference_cell(reference, db_units, cell_name),
@@ -531,6 +551,7 @@ fn write_reference_element(
     element: &Element,
 ) -> Result<Vec<u8>, GdsError> {
     let grid = reference.grid();
+    let properties = reference.properties();
     let spacing_x = grid.spacing_x().unwrap_or_default();
     let spacing_y = grid.spacing_y().unwrap_or_default();
 
@@ -548,6 +569,9 @@ fn write_reference_element(
             new_element = new_element.rotate(grid.angle(), Point::default());
             new_element = new_element.scale(grid.magnification(), Point::default());
             new_element = new_element.move_by(final_position);
+            if !properties.is_empty() {
+                new_element.properties_mut().extend_from_slice(properties);
+            }
 
             buf.extend_from_slice(&GdsFileWriter.write_element(&new_element, db_units)?);
         }
@@ -611,7 +635,7 @@ fn write_reference_cell(
         }
     }
 
-    write_element_tail_to_file(&mut buffer)?;
+    write_element_tail_to_file(&mut buffer, reference.properties())?;
 
     Ok(buffer)
 }
@@ -632,7 +656,7 @@ pub fn write_box(gds_box: &GdsBox, db_units: f64) -> Result<Vec<u8>, GdsError> {
     write_u16_array(&mut buffer, &head)?;
     let points = gds_box.points();
     write_points_to_file(&mut buffer, &points, db_units)?;
-    write_element_tail_to_file(&mut buffer)?;
+    write_element_tail_to_file(&mut buffer, gds_box.properties())?;
 
     Ok(buffer)
 }
@@ -652,7 +676,7 @@ pub fn write_node(node: &Node, db_units: f64) -> Result<Vec<u8>, GdsError> {
     );
     write_u16_array(&mut buffer, &head)?;
     write_points_to_file(&mut buffer, node.points(), db_units)?;
-    write_element_tail_to_file(&mut buffer)?;
+    write_element_tail_to_file(&mut buffer, node.properties())?;
 
     Ok(buffer)
 }
@@ -660,9 +684,11 @@ pub fn write_node(node: &Node, db_units: f64) -> Result<Vec<u8>, GdsError> {
 #[cfg(test)]
 mod tests {
     use std::fs;
-    use std::io::{self, Write};
+    use std::io::{self, BufReader, Write};
 
-    use crate::{DEFAULT_INTEGER_UNITS, Library};
+    use crate::config::gds_file_types::GDSRecordData;
+    use crate::io::read::RecordReader;
+    use crate::{DEFAULT_INTEGER_UNITS, DataType, Layer, Library, Property};
 
     use super::*;
 
@@ -682,6 +708,83 @@ mod tests {
             self.flushes += 1;
             Ok(())
         }
+    }
+
+    fn polygon_with_property(value: impl Into<String>) -> Polygon {
+        let mut polygon = Polygon::new(
+            [
+                Point::integer(0, 0, DEFAULT_INTEGER_UNITS),
+                Point::integer(10, 0, DEFAULT_INTEGER_UNITS),
+                Point::integer(0, 10, DEFAULT_INTEGER_UNITS),
+            ],
+            Layer::new(1),
+            DataType::new(2),
+        );
+        polygon.properties_mut().push(Property::new(65_535, value));
+        polygon
+    }
+
+    #[test]
+    fn properties_are_written_before_end_element() {
+        let bytes = write_polygon(&polygon_with_property("net-a"), DEFAULT_INTEGER_UNITS)
+            .expect("polygon should be writable");
+        let records: Vec<_> = RecordReader::new(BufReader::new(bytes.as_slice()))
+            .collect::<Result<_, _>>()
+            .expect("element records should be readable");
+        let record_types: Vec<_> = records.iter().map(|(record, _)| *record).collect();
+
+        assert_eq!(
+            record_types,
+            [
+                GDSRecord::Boundary,
+                GDSRecord::Layer,
+                GDSRecord::DataType,
+                GDSRecord::XY,
+                GDSRecord::PropAttr,
+                GDSRecord::PropValue,
+                GDSRecord::EndEl,
+            ]
+        );
+        assert!(matches!(
+            &records[4].1,
+            GDSRecordData::I16(attributes) if attributes == &[-1]
+        ));
+        assert!(matches!(
+            &records[5].1,
+            GDSRecordData::Str(value) if value == "net-a"
+        ));
+    }
+
+    #[test]
+    fn oversized_property_value_is_rejected() {
+        let property_value = "x".repeat(usize::from(u16::MAX));
+
+        let error = write_polygon(
+            &polygon_with_property(property_value),
+            DEFAULT_INTEGER_UNITS,
+        )
+        .expect_err("oversized property value should be rejected");
+
+        assert!(matches!(error, GdsError::ValidationError { .. }));
+    }
+
+    #[test]
+    fn inline_reference_properties_are_written_on_expanded_elements() {
+        let mut reference = Reference::new(polygon_with_property("inner"));
+        reference.properties_mut().push(Property::new(7, "outer"));
+
+        let bytes = write_reference(&reference, DEFAULT_INTEGER_UNITS)
+            .expect("inline reference should be writable");
+        let property_values: Vec<_> = RecordReader::new(BufReader::new(bytes.as_slice()))
+            .filter_map(
+                |record| match record.expect("element records should be readable") {
+                    (GDSRecord::PropValue, GDSRecordData::Str(value)) => Some(value),
+                    _ => None,
+                },
+            )
+            .collect();
+
+        assert_eq!(property_values, ["inner", "outer"]);
     }
 
     #[test]

--- a/crates/gdsr/src/lib.rs
+++ b/crates/gdsr/src/lib.rs
@@ -26,7 +26,9 @@ pub use design_rules::{
 };
 pub use diff::{CellDiff, ElementDiff, LibraryDiff, LibraryDiffOptions};
 pub use elements::text::{HorizontalPresentation, VerticalPresentation};
-pub use elements::{Element, GdsBox, Instance, Node, Path, PathType, Polygon, Reference, Text};
+pub use elements::{
+    Element, GdsBox, Instance, Node, Path, PathType, Polygon, Property, Reference, Text,
+};
 pub use error::GdsError;
 pub use flatten::FlattenOptions;
 pub use grid::Grid;

--- a/crates/gdsr/src/property_tests/roundtrip.rs
+++ b/crates/gdsr/src/property_tests/roundtrip.rs
@@ -26,6 +26,50 @@ fn make_library(cell_name: &str, elements: Vec<Element>) -> Library {
     library
 }
 
+#[test]
+fn element_properties_roundtrip_for_every_variant() {
+    let point = |x, y| Point::integer(x, y, DEFAULT_INTEGER_UNITS);
+    let mut elements: Vec<Element> = vec![
+        Polygon::new(
+            [point(0, 0), point(20, 0), point(0, 20)],
+            Layer::new(1),
+            DataType::new(2),
+        )
+        .into(),
+        Path::new(
+            [point(0, 0), point(20, 20)],
+            Layer::new(3),
+            DataType::new(4),
+            None,
+            Some(Unit::integer(2, DEFAULT_INTEGER_UNITS)),
+            None,
+            None,
+        )
+        .into(),
+        GdsBox::new(point(0, 0), point(20, 20), Layer::new(5), DataType::new(6)).into(),
+        Node::new(
+            vec![point(0, 0), point(20, 20)],
+            Layer::new(7),
+            DataType::new(8),
+        )
+        .into(),
+        Text::default().set_text("label".to_string()).into(),
+        Reference::new("target").into(),
+    ];
+    for element in &mut elements {
+        element.properties_mut().extend([
+            Property::new(17, "net-a"),
+            Property::new(17, "net-b"),
+            Property::new(u16::MAX, "tool-metadata"),
+        ]);
+    }
+
+    let mut library = make_library("top", elements);
+    library.add_cell(Cell::new("target"));
+
+    assert_roundtrip(&library);
+}
+
 #[quickcheck]
 fn polygon_roundtrip(_seed: u8) -> bool {
     let mut g = Gen::new(30);

--- a/crates/gdsr/src/snapshots/gdsr__cell__tests__cell_get_elements-2.snap
+++ b/crates/gdsr/src/snapshots/gdsr__cell__tests__cell_get_elements-2.snap
@@ -12,6 +12,7 @@ expression: moved_elements
             data_type: DataType(
                 0,
             ),
+            properties: [],
         },
     ),
     Polygon(
@@ -23,6 +24,7 @@ expression: moved_elements
             data_type: DataType(
                 0,
             ),
+            properties: [],
         },
     ),
     Path(
@@ -38,6 +40,7 @@ expression: moved_elements
             width: None,
             begin_extension: None,
             end_extension: None,
+            properties: [],
         },
     ),
     Text(
@@ -70,6 +73,7 @@ expression: moved_elements
             x_reflection: false,
             vertical_presentation: Middle,
             horizontal_presentation: Centre,
+            properties: [],
         },
     ),
 ]

--- a/crates/gdsr/src/snapshots/gdsr__cell__tests__cell_get_elements-3.snap
+++ b/crates/gdsr/src/snapshots/gdsr__cell__tests__cell_get_elements-3.snap
@@ -12,6 +12,7 @@ expression: rotated_elements
             data_type: DataType(
                 0,
             ),
+            properties: [],
         },
     ),
     Polygon(
@@ -23,6 +24,7 @@ expression: rotated_elements
             data_type: DataType(
                 0,
             ),
+            properties: [],
         },
     ),
     Path(
@@ -38,6 +40,7 @@ expression: rotated_elements
             width: None,
             begin_extension: None,
             end_extension: None,
+            properties: [],
         },
     ),
     Text(
@@ -70,6 +73,7 @@ expression: rotated_elements
             x_reflection: false,
             vertical_presentation: Middle,
             horizontal_presentation: Centre,
+            properties: [],
         },
     ),
 ]

--- a/crates/gdsr/src/snapshots/gdsr__cell__tests__cell_get_elements.snap
+++ b/crates/gdsr/src/snapshots/gdsr__cell__tests__cell_get_elements.snap
@@ -12,6 +12,7 @@ expression: elements
             data_type: DataType(
                 0,
             ),
+            properties: [],
         },
     ),
     Polygon(
@@ -23,6 +24,7 @@ expression: elements
             data_type: DataType(
                 0,
             ),
+            properties: [],
         },
     ),
     Path(
@@ -38,6 +40,7 @@ expression: elements
             width: None,
             begin_extension: None,
             end_extension: None,
+            properties: [],
         },
     ),
     Text(
@@ -70,6 +73,7 @@ expression: elements
             x_reflection: false,
             vertical_presentation: Middle,
             horizontal_presentation: Centre,
+            properties: [],
         },
     ),
 ]


### PR DESCRIPTION
## Summary

Adds ordered element properties and preserves PROPATTR/PROPVALUE records during GDS reads and writes. Empty elements use lazy pointer-sized storage, derived geometry retains source properties, inline reference expansion retains wrapper properties, and library diffs detect property changes. Closes #116.

## Test Plan

Verified with cargo nextest run, strict workspace Clippy, cargo doc, and uvx prek run -a.