### PR TITLE
Add explicit GDS timestamp policies

### DIFF
--- a/crates/gdsr/src/cell.rs
+++ b/crates/gdsr/src/cell.rs
@@ -1,15 +1,24 @@
 use std::sync::mpsc;
 
+use crate::timestamp::GdsTimestamps;
 use crate::{
     Dimensions, Element, FlattenOptions, GdsBox, LayerMapping, Library, Movable, Node, Path, Point,
     Polygon, Reference, Text, Transformable, Transformation,
 };
 
 /// A named cell containing polygons, paths, boxes, nodes, texts, and references to other cells or elements.
-#[derive(Clone, Debug, PartialEq, Default)]
+/// Timestamp metadata is excluded from equality comparisons.
+#[derive(Clone, Debug, Default)]
 pub struct Cell {
     name: String,
     elements: Vec<Element>,
+    timestamps: Option<GdsTimestamps>,
+}
+
+impl PartialEq for Cell {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name && self.elements == other.elements
+    }
 }
 
 impl Cell {
@@ -18,12 +27,23 @@ impl Cell {
         Self {
             name: name.to_string(),
             elements: Vec::new(),
+            timestamps: None,
         }
     }
 
     /// Returns the cell name.
     pub fn name(&self) -> &str {
         &self.name
+    }
+
+    /// Returns the parsed or explicitly assigned `BGNSTR` timestamps.
+    pub const fn timestamps(&self) -> Option<GdsTimestamps> {
+        self.timestamps
+    }
+
+    /// Assigns the creation and last modification times used by Preserve writes.
+    pub fn set_timestamps(&mut self, timestamps: GdsTimestamps) {
+        self.timestamps = Some(timestamps);
     }
 
     pub(crate) fn set_name(&mut self, name: &str) {
@@ -117,6 +137,7 @@ impl Cell {
     pub fn to_integer_unit(self) -> Self {
         Self {
             name: self.name,
+            timestamps: self.timestamps,
             elements: self
                 .elements
                 .into_iter()
@@ -130,6 +151,7 @@ impl Cell {
     pub fn to_float_unit(self) -> Self {
         Self {
             name: self.name,
+            timestamps: self.timestamps,
             elements: self
                 .elements
                 .into_iter()
@@ -233,6 +255,7 @@ impl Transformable for Cell {
     fn transform_impl(self, transformation: &Transformation) -> Self {
         Self {
             name: self.name,
+            timestamps: self.timestamps,
             elements: self
                 .elements
                 .into_iter()
@@ -262,6 +285,7 @@ impl Movable for Cell {
     fn move_to(self, target: crate::Point) -> Self {
         Self {
             name: self.name,
+            timestamps: self.timestamps,
             elements: self
                 .elements
                 .into_iter()

--- a/crates/gdsr/src/io/read/mod.rs
+++ b/crates/gdsr/src/io/read/mod.rs
@@ -8,7 +8,9 @@ use crate::elements::{GdsBox, Node, Path, PathType, Polygon, Property, Reference
 use crate::error::GdsError;
 use crate::geometry::round_to_decimals;
 use crate::library::Library;
-use crate::{DEFAULT_INTEGER_UNITS, DataType, Degrees, Instance, Layer, Point, Unit};
+use crate::{
+    DEFAULT_INTEGER_UNITS, DataType, Degrees, GdsTimestamps, Instance, Layer, Point, Unit,
+};
 
 #[allow(clippy::too_many_lines)]
 pub fn from_gds<P: AsRef<std::path::Path>>(
@@ -48,6 +50,12 @@ where
     for record in reader {
         match record {
             Ok((record_type, data)) => match record_type {
+                GDSRecord::BgnLib => {
+                    let GDSRecordData::I16(values) = data else {
+                        return Err(invalid_timestamp_record("BGNLIB"));
+                    };
+                    library.timestamps = Some(GdsTimestamps::from_record(&values, "BGNLIB")?);
+                }
                 GDSRecord::LibName => {
                     if let GDSRecordData::Str(name) = data {
                         library.name = name;
@@ -64,7 +72,12 @@ where
                     }
                 }
                 GDSRecord::BgnStr => {
-                    cell = Some(Cell::default());
+                    let GDSRecordData::I16(values) = data else {
+                        return Err(invalid_timestamp_record("BGNSTR"));
+                    };
+                    let mut new_cell = Cell::default();
+                    new_cell.set_timestamps(GdsTimestamps::from_record(&values, "BGNSTR")?);
+                    cell = Some(new_cell);
                 }
                 GDSRecord::StrName => {
                     if let GDSRecordData::Str(cell_name) = data {
@@ -393,6 +406,12 @@ where
     }
 
     Ok(library)
+}
+
+fn invalid_timestamp_record(record: &str) -> GdsError {
+    GdsError::InvalidData {
+        message: format!("Invalid {record} timestamp record"),
+    }
 }
 
 fn should_parse_xy<F>(

--- a/crates/gdsr/src/io/write/mod.rs
+++ b/crates/gdsr/src/io/write/mod.rs
@@ -4,7 +4,6 @@ pub mod validation;
 
 use std::io::Write;
 
-use chrono::{Datelike, Local, Timelike};
 use rayon::prelude::*;
 
 use crate::config::gds_file_types::{
@@ -13,8 +12,8 @@ use crate::config::gds_file_types::{
 use crate::elements::text::get_presentation_value;
 use crate::error::GdsError;
 use crate::{
-    Cell, Element, GdsBox, Instance, Library, Movable, Node, Path, Point, Polygon, Property,
-    Reference, Text, Transformable,
+    Cell, Element, GdsBox, GdsTimestampPolicy, GdsTimestamps, Instance, Library, Movable, Node,
+    Path, Point, Polygon, Property, Reference, Text, Transformable,
 };
 use gds_format::{eight_byte_real, write_u16_array_as_big_endian};
 use validation::{
@@ -40,9 +39,40 @@ pub trait GdsWriter: Sync {
         write_library(self, library, user_units, db_units)
     }
 
+    /// Serializes a library using an explicit timestamp policy.
+    fn write_library_with_timestamp_policy(
+        &self,
+        library: &Library,
+        user_units: f64,
+        db_units: f64,
+        timestamp_policy: GdsTimestampPolicy,
+    ) -> Result<Vec<u8>, GdsError> {
+        write_library_with_timestamp_policy(self, library, user_units, db_units, timestamp_policy)
+    }
+
     /// Serializes a single cell to GDS bytes.
     fn write_cell(&self, cell: &Cell, db_units: f64) -> Result<Vec<u8>, GdsError> {
         write_cell(self, cell, db_units)
+    }
+
+    /// Serializes a single cell using an explicit timestamp policy.
+    fn write_cell_with_timestamp_policy(
+        &self,
+        cell: &Cell,
+        db_units: f64,
+        timestamp_policy: GdsTimestampPolicy,
+    ) -> Result<Vec<u8>, GdsError> {
+        write_cell_with_timestamp_policy(self, cell, db_units, timestamp_policy)
+    }
+
+    /// Serializes a single cell with an already resolved `BGNSTR` timestamp pair.
+    fn write_cell_with_timestamps(
+        &self,
+        cell: &Cell,
+        db_units: f64,
+        timestamps: GdsTimestamps,
+    ) -> Result<Vec<u8>, GdsError> {
+        write_cell_with_timestamps(self, cell, db_units, timestamps)
     }
 
     /// Serializes a single element to GDS bytes.
@@ -117,27 +147,93 @@ impl GdsWriter for GdsFileWriter {}
 pub struct GdsStreamWriter<W> {
     output: W,
     database_units: f64,
+    timestamp_policy: GdsTimestampPolicy,
+    current_timestamps: GdsTimestamps,
 }
 
 impl<W: Write> GdsStreamWriter<W> {
     /// Writes a library header to `output` and starts a streaming GDS library.
     pub fn new(
-        mut output: W,
+        output: W,
         library_name: &str,
         user_units: f64,
         database_units: f64,
     ) -> Result<Self, GdsError> {
-        write_gds_head_to_file(library_name, user_units, database_units, &mut output)?;
+        Self::start(
+            output,
+            library_name,
+            None,
+            user_units,
+            database_units,
+            GdsTimestampPolicy::Current,
+        )
+    }
+
+    /// Starts a streaming write from a library using an explicit timestamp policy.
+    ///
+    /// Taking the library provides the `BGNLIB` metadata required by
+    /// [`GdsTimestampPolicy::Preserve`]. Cells passed to [`Self::write_cell`]
+    /// must also contain timestamps when that policy is selected.
+    pub fn from_library_with_timestamp_policy(
+        output: W,
+        library: &Library,
+        user_units: f64,
+        database_units: f64,
+        timestamp_policy: GdsTimestampPolicy,
+    ) -> Result<Self, GdsError> {
+        Self::start(
+            output,
+            library.name(),
+            library.timestamps(),
+            user_units,
+            database_units,
+            timestamp_policy,
+        )
+    }
+
+    fn start(
+        mut output: W,
+        library_name: &str,
+        library_timestamps: Option<GdsTimestamps>,
+        user_units: f64,
+        database_units: f64,
+        timestamp_policy: GdsTimestampPolicy,
+    ) -> Result<Self, GdsError> {
+        let current_timestamps = GdsTimestamps::current();
+        let timestamps = resolve_timestamps(
+            timestamp_policy,
+            library_timestamps,
+            current_timestamps,
+            "library",
+            library_name,
+        )?;
+        write_gds_head_to_file(
+            library_name,
+            user_units,
+            database_units,
+            timestamps,
+            &mut output,
+        )?;
         output.flush()?;
         Ok(Self {
             output,
             database_units,
+            timestamp_policy,
+            current_timestamps,
         })
     }
 
     /// Serializes and flushes one cell to the library.
     pub fn write_cell(&mut self, cell: &Cell) -> Result<(), GdsError> {
-        let bytes = GdsFileWriter.write_cell(cell, self.database_units)?;
+        let timestamps = resolve_timestamps(
+            self.timestamp_policy,
+            cell.timestamps(),
+            self.current_timestamps,
+            "cell",
+            cell.name(),
+        )?;
+        let bytes =
+            GdsFileWriter.write_cell_with_timestamps(cell, self.database_units, timestamps)?;
         self.output.write_all(&bytes)?;
         self.output.flush()?;
         Ok(())
@@ -163,30 +259,9 @@ fn write_float_to_eight_byte_real_to_file(
     Ok(buffer.write_all(&value)?)
 }
 
-/// Returns the current timestamp as 12 u16 values (creation + modification) for GDS records.
-fn gds_timestamp() -> [u16; 12] {
-    let now = Local::now();
-    let ts = now.naive_utc();
-    [
-        ts.year() as u16,
-        ts.month() as u16,
-        ts.day() as u16,
-        ts.hour() as u16,
-        ts.minute() as u16,
-        ts.second() as u16,
-        ts.year() as u16,
-        ts.month() as u16,
-        ts.day() as u16,
-        ts.hour() as u16,
-        ts.minute() as u16,
-        ts.second() as u16,
-    ]
-}
-
-/// Returns the `BgnStr` record header with the current timestamp.
-fn cell_head_record() -> [u16; 14] {
+fn cell_head_record(timestamps: GdsTimestamps) -> [u16; 14] {
     let [size, head] = record_header(GDSRecord::BgnStr, GDSDataType::TwoByteSignedInteger, 12);
-    let ts = gds_timestamp();
+    let ts = timestamps.to_record();
     [
         size, head, ts[0], ts[1], ts[2], ts[3], ts[4], ts[5], ts[6], ts[7], ts[8], ts[9], ts[10],
         ts[11],
@@ -211,11 +286,12 @@ fn write_gds_head_to_file(
     library_name: &str,
     user_units: f64,
     db_units: f64,
+    timestamps: GdsTimestamps,
     buffer: &mut impl Write,
 ) -> Result<(), GdsError> {
     let [s1, h1] = record_header(GDSRecord::Header, GDSDataType::TwoByteSignedInteger, 1);
     let [s2, h2] = record_header(GDSRecord::BgnLib, GDSDataType::TwoByteSignedInteger, 12);
-    let ts = gds_timestamp();
+    let ts = timestamps.to_record();
     let head_start = [
         s1, h1, 0x0258, s2, h2, ts[0], ts[1], ts[2], ts[3], ts[4], ts[5], ts[6], ts[7], ts[8],
         ts[9], ts[10], ts[11],
@@ -375,14 +451,54 @@ pub fn write_library(
     user_units: f64,
     db_units: f64,
 ) -> Result<Vec<u8>, GdsError> {
+    write_library_with_timestamp_policy(
+        writer,
+        library,
+        user_units,
+        db_units,
+        GdsTimestampPolicy::Current,
+    )
+}
+
+/// Serializes an entire library using an explicit timestamp policy.
+pub fn write_library_with_timestamp_policy(
+    writer: &(impl GdsWriter + ?Sized),
+    library: &Library,
+    user_units: f64,
+    db_units: f64,
+    timestamp_policy: GdsTimestampPolicy,
+) -> Result<Vec<u8>, GdsError> {
+    let current_timestamps = GdsTimestamps::current();
+    let library_timestamps = resolve_timestamps(
+        timestamp_policy,
+        library.timestamps(),
+        current_timestamps,
+        "library",
+        library.name(),
+    )?;
     let mut buffer = Vec::new();
-    write_gds_head_to_file(library.name(), user_units, db_units, &mut buffer)?;
+    write_gds_head_to_file(
+        library.name(),
+        user_units,
+        db_units,
+        library_timestamps,
+        &mut buffer,
+    )?;
 
     let cells: Vec<&Cell> = library.cells().values().collect();
 
     for buf in cells
         .par_iter()
-        .map(|cell| writer.write_cell(cell, db_units))
+        .map(|cell| {
+            let timestamps = resolve_timestamps(
+                timestamp_policy,
+                cell.timestamps(),
+                current_timestamps,
+                "cell",
+                cell.name(),
+            )?;
+            writer.write_cell_with_timestamps(cell, db_units, timestamps)
+        })
         .collect::<Result<Vec<_>, GdsError>>()?
     {
         buffer.extend_from_slice(&buf);
@@ -399,10 +515,38 @@ pub fn write_cell(
     cell: &Cell,
     db_units: f64,
 ) -> Result<Vec<u8>, GdsError> {
+    write_cell_with_timestamp_policy(writer, cell, db_units, GdsTimestampPolicy::Current)
+}
+
+/// Serializes a single cell using an explicit timestamp policy.
+pub fn write_cell_with_timestamp_policy(
+    writer: &(impl GdsWriter + ?Sized),
+    cell: &Cell,
+    db_units: f64,
+    timestamp_policy: GdsTimestampPolicy,
+) -> Result<Vec<u8>, GdsError> {
+    let current_timestamps = GdsTimestamps::current();
+    let timestamps = resolve_timestamps(
+        timestamp_policy,
+        cell.timestamps(),
+        current_timestamps,
+        "cell",
+        cell.name(),
+    )?;
+    write_cell_with_timestamps(writer, cell, db_units, timestamps)
+}
+
+/// Serializes a single cell with an already resolved timestamp pair.
+pub fn write_cell_with_timestamps(
+    writer: &(impl GdsWriter + ?Sized),
+    cell: &Cell,
+    db_units: f64,
+    timestamps: GdsTimestamps,
+) -> Result<Vec<u8>, GdsError> {
     validate_structure_name(cell.name())?;
 
     let mut buffer = Vec::new();
-    write_u16_array(&mut buffer, &cell_head_record())?;
+    write_u16_array(&mut buffer, &cell_head_record(timestamps))?;
     write_string_with_record_to_file(&mut buffer, GDSRecord::StrName, cell.name())?;
 
     for buf in cell
@@ -420,6 +564,24 @@ pub fn write_cell(
     )?;
 
     Ok(buffer)
+}
+
+fn resolve_timestamps(
+    policy: GdsTimestampPolicy,
+    preserved: Option<GdsTimestamps>,
+    current: GdsTimestamps,
+    target_kind: &str,
+    target_name: &str,
+) -> Result<GdsTimestamps, GdsError> {
+    match policy {
+        GdsTimestampPolicy::Current => Ok(current),
+        GdsTimestampPolicy::Preserve => preserved.ok_or_else(|| GdsError::ValidationError {
+            message: format!(
+                "Cannot preserve timestamps for {target_kind} '{target_name}': no timestamps are stored"
+            ),
+        }),
+        GdsTimestampPolicy::Zero => Ok(GdsTimestamps::ZERO),
+    }
 }
 
 /// Serializes a polygon to GDS bytes.
@@ -686,9 +848,14 @@ mod tests {
     use std::fs;
     use std::io::{self, BufReader, Write};
 
+    use chrono::{NaiveDate, NaiveDateTime};
+
     use crate::config::gds_file_types::GDSRecordData;
     use crate::io::read::RecordReader;
-    use crate::{DEFAULT_INTEGER_UNITS, DataType, Layer, Library, Property};
+    use crate::{
+        DEFAULT_INTEGER_UNITS, DataType, GdsTimestampPolicy, GdsTimestamps, Layer, Library,
+        Property,
+    };
 
     use super::*;
 
@@ -722,6 +889,35 @@ mod tests {
         );
         polygon.properties_mut().push(Property::new(65_535, value));
         polygon
+    }
+
+    fn datetime(
+        year: i32,
+        month: u32,
+        day: u32,
+        hour: u32,
+        minute: u32,
+        second: u32,
+    ) -> NaiveDateTime {
+        NaiveDate::from_ymd_opt(year, month, day)
+            .expect("test date should be valid")
+            .and_hms_opt(hour, minute, second)
+            .expect("test time should be valid")
+    }
+
+    fn timestamps(first_year: i32, second_year: i32) -> GdsTimestamps {
+        GdsTimestamps::try_new(
+            datetime(first_year, 2, 3, 4, 5, 6),
+            datetime(second_year, 7, 8, 9, 10, 11),
+        )
+        .expect("test timestamps should be valid")
+    }
+
+    fn read_library_bytes(bytes: &[u8]) -> Result<Library, GdsError> {
+        let directory = tempfile::tempdir().expect("temporary directory should be created");
+        let path = directory.path().join("timestamps.gds");
+        fs::write(&path, bytes).expect("test GDS should be writable");
+        Library::read_file(path, Some(DEFAULT_INTEGER_UNITS))
     }
 
     #[test]
@@ -817,5 +1013,173 @@ mod tests {
         assert_eq!(library.name(), "streamed");
         assert!(library.get_cell("first").is_some());
         assert!(library.get_cell("second").is_some());
+    }
+
+    #[test]
+    fn preserve_round_trips_library_and_structure_timestamps() {
+        let library_timestamps = timestamps(2020, 2021);
+        let cell_timestamps = timestamps(2022, 2023);
+        let mut library = Library::new("preserved");
+        library.set_timestamps(library_timestamps);
+        let mut cell = Cell::new("top");
+        cell.set_timestamps(cell_timestamps);
+        library.add_cell(cell);
+
+        let bytes = library
+            .write_with_timestamp_policy(
+                &GdsFileWriter,
+                DEFAULT_INTEGER_UNITS,
+                DEFAULT_INTEGER_UNITS,
+                GdsTimestampPolicy::Preserve,
+            )
+            .expect("preserved timestamps should be writable");
+        let parsed = read_library_bytes(&bytes).expect("written library should be readable");
+
+        assert_eq!(parsed.timestamps(), Some(library_timestamps));
+        assert_eq!(
+            parsed
+                .get_cell("top")
+                .expect("parsed cell should exist")
+                .timestamps(),
+            Some(cell_timestamps)
+        );
+    }
+
+    #[test]
+    fn zero_policy_is_stable_and_readable() {
+        let mut library = Library::new("stable");
+        library.add_cell(Cell::new("top"));
+
+        let write = || {
+            library.write_with_timestamp_policy(
+                &GdsFileWriter,
+                DEFAULT_INTEGER_UNITS,
+                DEFAULT_INTEGER_UNITS,
+                GdsTimestampPolicy::Zero,
+            )
+        };
+        let first = write().expect("zero timestamps should be writable");
+        let second = write().expect("zero timestamps should be writable again");
+        let parsed = read_library_bytes(&first).expect("zero timestamps should be readable");
+
+        assert_eq!(first, second);
+        assert_eq!(parsed.timestamps(), Some(GdsTimestamps::ZERO));
+        assert_eq!(
+            parsed
+                .get_cell("top")
+                .expect("parsed cell should exist")
+                .timestamps(),
+            Some(GdsTimestamps::ZERO)
+        );
+    }
+
+    #[test]
+    fn current_policy_uses_one_time_for_the_entire_library() {
+        let mut library = Library::new("current");
+        library.add_cell(Cell::new("first"));
+        library.add_cell(Cell::new("second"));
+        let bytes = library
+            .write(&GdsFileWriter, DEFAULT_INTEGER_UNITS, DEFAULT_INTEGER_UNITS)
+            .expect("current timestamps should be writable");
+
+        let timestamps: Vec<_> = RecordReader::new(BufReader::new(bytes.as_slice()))
+            .filter_map(|record| {
+                let (record, data) = record.expect("written records should be readable");
+                match (record, data) {
+                    (GDSRecord::BgnLib | GDSRecord::BgnStr, GDSRecordData::I16(values)) => {
+                        Some(values)
+                    }
+                    _ => None,
+                }
+            })
+            .collect();
+
+        assert_eq!(timestamps.len(), 3);
+        assert!(timestamps.windows(2).all(|pair| pair[0] == pair[1]));
+        assert!(timestamps.iter().all(|values| values[..6] == values[6..]));
+    }
+
+    #[test]
+    fn preserve_requires_library_and_structure_metadata() {
+        let mut library = Library::new("missing");
+        library.add_cell(Cell::new("top"));
+
+        let error = library
+            .write_with_timestamp_policy(
+                &GdsFileWriter,
+                DEFAULT_INTEGER_UNITS,
+                DEFAULT_INTEGER_UNITS,
+                GdsTimestampPolicy::Preserve,
+            )
+            .expect_err("missing library timestamps should be rejected");
+        assert!(error.to_string().contains("library 'missing'"));
+
+        library.set_timestamps(timestamps(2020, 2021));
+        let error = library
+            .write_with_timestamp_policy(
+                &GdsFileWriter,
+                DEFAULT_INTEGER_UNITS,
+                DEFAULT_INTEGER_UNITS,
+                GdsTimestampPolicy::Preserve,
+            )
+            .expect_err("missing cell timestamps should be rejected");
+        assert!(error.to_string().contains("cell 'top'"));
+    }
+
+    #[test]
+    fn invalid_preserved_date_reports_the_raw_values() {
+        let library = Library::new("invalid");
+        let mut bytes = library
+            .write_with_timestamp_policy(
+                &GdsFileWriter,
+                DEFAULT_INTEGER_UNITS,
+                DEFAULT_INTEGER_UNITS,
+                GdsTimestampPolicy::Zero,
+            )
+            .expect("zero timestamps should be writable");
+
+        // HEADER is six bytes; the first BGNLIB month occupies bytes 12..14.
+        bytes
+            .get_mut(12..14)
+            .expect("BGNLIB timestamp should exist")
+            .copy_from_slice(&13_i16.to_be_bytes());
+        let error = read_library_bytes(&bytes).expect_err("month 13 should be rejected");
+
+        assert!(error.to_string().contains("BGNLIB"));
+        assert!(error.to_string().contains("13"));
+    }
+
+    #[test]
+    fn stream_writer_preserves_library_and_structure_timestamps() {
+        let library_timestamps = timestamps(2020, 2021);
+        let cell_timestamps = timestamps(2022, 2023);
+        let mut library = Library::new("streamed-preserve");
+        library.set_timestamps(library_timestamps);
+        let mut cell = Cell::new("top");
+        cell.set_timestamps(cell_timestamps);
+        library.add_cell(cell);
+
+        let mut writer = GdsStreamWriter::from_library_with_timestamp_policy(
+            Vec::new(),
+            &library,
+            DEFAULT_INTEGER_UNITS,
+            DEFAULT_INTEGER_UNITS,
+            GdsTimestampPolicy::Preserve,
+        )
+        .expect("stream header should be writable");
+        writer
+            .write_cell(library.get_cell("top").expect("source cell should exist"))
+            .expect("streamed cell should be writable");
+        let bytes = writer.finish().expect("stream should finish");
+        let parsed = read_library_bytes(&bytes).expect("streamed library should be readable");
+
+        assert_eq!(parsed.timestamps(), Some(library_timestamps));
+        assert_eq!(
+            parsed
+                .get_cell("top")
+                .expect("parsed cell should exist")
+                .timestamps(),
+            Some(cell_timestamps)
+        );
     }
 }

--- a/crates/gdsr/src/lib.rs
+++ b/crates/gdsr/src/lib.rs
@@ -15,6 +15,7 @@ mod point;
 #[cfg(test)]
 mod property_tests;
 mod stats;
+mod timestamp;
 mod traits;
 mod transformation;
 mod types;
@@ -37,6 +38,7 @@ pub use io::write::{GdsFileWriter, GdsStreamWriter, GdsWriter};
 pub use library::{CellConflictStrategy, DanglingCellReference, Library, LibraryMergeError};
 pub use point::Point;
 pub use stats::{CellStats, LibraryStats};
+pub use timestamp::{GdsTimestampPolicy, GdsTimestamps};
 pub use traits::{Dimensions, Movable, Transformable};
 pub use transformation::{Reflection, Rotation, Scale, Transformation, Translation};
 pub use types::{DataType, Degrees, Layer, LayerMapping, Radians};

--- a/crates/gdsr/src/library.rs
+++ b/crates/gdsr/src/library.rs
@@ -10,7 +10,7 @@ use crate::io::read::{from_gds, from_gds_filtered};
 use crate::io::write::validation::MAX_STRUCTURE_NAME_LENGTH;
 use crate::io::write::{GdsFileWriter, GdsWriter};
 use crate::types::LayerMapping;
-use crate::{DataType, Element, Instance, Layer};
+use crate::{DataType, Element, GdsTimestampPolicy, GdsTimestamps, Instance, Layer};
 
 /// A dangling reference: a cell contains a reference to a target that doesn't exist.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -65,10 +65,18 @@ impl fmt::Display for LibraryMergeError {
 impl std::error::Error for LibraryMergeError {}
 
 /// A GDSII library containing named cells. This is the top-level container for a GDSII design.
-#[derive(Clone, Debug, PartialEq)]
+/// Timestamp metadata is excluded from equality comparisons.
+#[derive(Clone, Debug)]
 pub struct Library {
     pub(crate) name: String,
     pub(crate) cells: HashMap<String, Cell>,
+    pub(crate) timestamps: Option<GdsTimestamps>,
+}
+
+impl PartialEq for Library {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name && self.cells == other.cells
+    }
 }
 
 impl Library {
@@ -77,12 +85,23 @@ impl Library {
         Self {
             name: name.to_string(),
             cells: HashMap::new(),
+            timestamps: None,
         }
     }
 
     /// Returns the library name.
     pub fn name(&self) -> &str {
         &self.name
+    }
+
+    /// Returns the parsed or explicitly assigned `BGNLIB` timestamps.
+    pub const fn timestamps(&self) -> Option<GdsTimestamps> {
+        self.timestamps
+    }
+
+    /// Assigns the last modification and access times used by Preserve writes.
+    pub fn set_timestamps(&mut self, timestamps: GdsTimestamps) {
+        self.timestamps = Some(timestamps);
     }
 
     /// Returns the map of cell names to cells.
@@ -267,6 +286,22 @@ impl Library {
         writer.write_library(self, user_units, database_units)
     }
 
+    /// Serializes the library with a custom writer and an explicit timestamp policy.
+    pub fn write_with_timestamp_policy(
+        &self,
+        writer: &impl GdsWriter,
+        user_units: f64,
+        database_units: f64,
+        timestamp_policy: GdsTimestampPolicy,
+    ) -> Result<Vec<u8>, GdsError> {
+        writer.write_library_with_timestamp_policy(
+            self,
+            user_units,
+            database_units,
+            timestamp_policy,
+        )
+    }
+
     /// Write the library to a GDS file.
     ///
     /// The given user units are only used when writing the GDSII header.
@@ -282,7 +317,28 @@ impl Library {
         user_units: f64,
         database_units: f64,
     ) -> Result<(), GdsError> {
-        let bytes = self.write(&GdsFileWriter, user_units, database_units)?;
+        self.write_file_with_timestamp_policy(
+            file_name,
+            user_units,
+            database_units,
+            GdsTimestampPolicy::Current,
+        )
+    }
+
+    /// Writes the library to a GDS file using an explicit timestamp policy.
+    pub fn write_file_with_timestamp_policy<P: AsRef<std::path::Path>>(
+        &self,
+        file_name: P,
+        user_units: f64,
+        database_units: f64,
+        timestamp_policy: GdsTimestampPolicy,
+    ) -> Result<(), GdsError> {
+        let bytes = self.write_with_timestamp_policy(
+            &GdsFileWriter,
+            user_units,
+            database_units,
+            timestamp_policy,
+        )?;
         let mut file = File::create(file_name)?;
         file.write_all(&bytes)?;
         Ok(file.flush()?)
@@ -1053,7 +1109,7 @@ mod tests {
     #[test]
     fn test_library_debug() {
         let library: Library = Library::new("debug_lib");
-        insta::assert_snapshot!(format!("{library:?}"), @r#"Library { name: "debug_lib", cells: {} }"#);
+        insta::assert_snapshot!(format!("{library:?}"), @r#"Library { name: "debug_lib", cells: {}, timestamps: None }"#);
     }
 
     #[test]

--- a/crates/gdsr/src/timestamp.rs
+++ b/crates/gdsr/src/timestamp.rs
@@ -1,0 +1,193 @@
+use chrono::{Datelike, Local, NaiveDate, NaiveDateTime, Timelike};
+
+use crate::error::GdsError;
+
+const MAX_GDS_YEAR: i32 = 9_999;
+
+/// The two date/time values stored in a GDS `BGNLIB` or `BGNSTR` record.
+///
+/// For `BGNLIB`, [`Self::first`] is the last modification time and
+/// [`Self::second`] is the last access time. For `BGNSTR`, they are the
+/// creation time and last modification time, respectively.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct GdsTimestamps {
+    first: Option<NaiveDateTime>,
+    second: Option<NaiveDateTime>,
+}
+
+impl GdsTimestamps {
+    /// The reproducible all-zero timestamp sentinel supported by GDS writers.
+    pub const ZERO: Self = Self {
+        first: None,
+        second: None,
+    };
+
+    /// Creates a validated pair of GDS timestamps.
+    pub fn try_new(first: NaiveDateTime, second: NaiveDateTime) -> Result<Self, GdsError> {
+        validate_datetime(first)?;
+        validate_datetime(second)?;
+        Ok(Self {
+            first: Some(first),
+            second: Some(second),
+        })
+    }
+
+    /// Returns the first date/time value.
+    ///
+    /// This is the last modification time for a library and the creation time
+    /// for a structure.
+    pub const fn first(&self) -> Option<&NaiveDateTime> {
+        self.first.as_ref()
+    }
+
+    /// Returns the second date/time value.
+    ///
+    /// This is the last access time for a library and the last modification
+    /// time for a structure.
+    pub const fn second(&self) -> Option<&NaiveDateTime> {
+        self.second.as_ref()
+    }
+
+    pub(crate) fn current() -> Self {
+        let now = Local::now().naive_utc();
+        Self {
+            first: Some(now),
+            second: Some(now),
+        }
+    }
+
+    pub(crate) fn from_record(values: &[i16], record: &str) -> Result<Self, GdsError> {
+        if values.len() != 12 {
+            return Err(invalid_record_timestamps(record, values));
+        }
+        let (first, second) = values.split_at(6);
+
+        let first = parse_datetime(first);
+        let second = parse_datetime(second);
+        match (first, second) {
+            (Some(first), Some(second)) => {
+                Self::try_new(first, second).map_err(|_| invalid_record_timestamps(record, values))
+            }
+            (None, None) if values.iter().all(|value| *value == 0) => Ok(Self::ZERO),
+            _ => Err(invalid_record_timestamps(record, values)),
+        }
+    }
+
+    pub(crate) fn to_record(self) -> [u16; 12] {
+        let mut values = [0; 12];
+        if let (Some(first), Some(second)) = (self.first, self.second) {
+            values[..6].copy_from_slice(&datetime_fields(first));
+            values[6..].copy_from_slice(&datetime_fields(second));
+        }
+        values
+    }
+}
+
+/// Controls which timestamps are written to GDS `BGNLIB` and `BGNSTR` records.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum GdsTimestampPolicy {
+    /// Write one current time consistently across the whole output.
+    #[default]
+    Current,
+    /// Write timestamps stored on the library and each structure.
+    Preserve,
+    /// Write all date/time fields as zero for reproducible output.
+    Zero,
+}
+
+fn validate_datetime(value: NaiveDateTime) -> Result<(), GdsError> {
+    if !(1..=MAX_GDS_YEAR).contains(&value.year()) {
+        return Err(GdsError::ValidationError {
+            message: format!(
+                "GDS timestamp year {} is outside the supported range 1..={MAX_GDS_YEAR}",
+                value.year()
+            ),
+        });
+    }
+    if value.nanosecond() != 0 {
+        return Err(GdsError::ValidationError {
+            message: "GDS timestamps do not support subsecond precision".to_string(),
+        });
+    }
+
+    Ok(())
+}
+
+fn parse_datetime(values: &[i16]) -> Option<NaiveDateTime> {
+    let [year, month, day, hour, minute, second] = *values else {
+        return None;
+    };
+    if !(1..=MAX_GDS_YEAR).contains(&i32::from(year)) {
+        return None;
+    }
+
+    NaiveDate::from_ymd_opt(
+        i32::from(year),
+        u32::try_from(month).ok()?,
+        u32::try_from(day).ok()?,
+    )?
+    .and_hms_opt(
+        u32::try_from(hour).ok()?,
+        u32::try_from(minute).ok()?,
+        u32::try_from(second).ok()?,
+    )
+}
+
+fn datetime_fields(value: NaiveDateTime) -> [u16; 6] {
+    [
+        value.year() as u16,
+        value.month() as u16,
+        value.day() as u16,
+        value.hour() as u16,
+        value.minute() as u16,
+        value.second() as u16,
+    ]
+}
+
+fn invalid_record_timestamps(record: &str, values: &[i16]) -> GdsError {
+    GdsError::InvalidData {
+        message: format!("Invalid {record} timestamps: {values:?}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::NaiveDate;
+
+    use super::*;
+
+    #[test]
+    fn rejects_dates_that_cannot_be_stored_in_gds() {
+        let date = NaiveDate::from_ymd_opt(10_000, 1, 1)
+            .expect("test date should be valid in chrono")
+            .and_hms_opt(0, 0, 0)
+            .expect("test time should be valid");
+
+        let error =
+            GdsTimestamps::try_new(date, date).expect_err("five-digit years should be rejected");
+
+        assert!(matches!(error, GdsError::ValidationError { .. }));
+        assert!(error.to_string().contains("10000"));
+    }
+
+    #[test]
+    fn rejects_subsecond_precision() {
+        let date = NaiveDate::from_ymd_opt(2024, 1, 1)
+            .expect("test date should be valid in chrono")
+            .and_hms_nano_opt(0, 0, 0, 1)
+            .expect("test time should be valid");
+
+        let error =
+            GdsTimestamps::try_new(date, date).expect_err("subsecond precision should be rejected");
+
+        assert!(matches!(error, GdsError::ValidationError { .. }));
+        assert!(error.to_string().contains("subsecond"));
+    }
+
+    #[test]
+    fn zero_is_a_distinct_timestamp_sentinel() {
+        assert_eq!(GdsTimestamps::ZERO.first(), None);
+        assert_eq!(GdsTimestamps::ZERO.second(), None);
+        assert_eq!(GdsTimestamps::ZERO.to_record(), [0; 12]);
+    }
+}


### PR DESCRIPTION
## Summary

Add validated BGNLIB/BGNSTR timestamp metadata and explicit Current, Preserve, and Zero write policies. Current captures one time for the complete output, Preserve round-trips distinct library and structure dates, Zero produces reproducible records, and malformed or missing preserved metadata returns a structured GDS error across buffered and streaming writers. Closes #305.

## Test Plan

Validated with the gdsr nextest suite, strict Clippy, and `uvx prek run -a`.