### PR TITLE
Add live layer filtering

### DIFF
--- a/crates/gdsr-viewer/src/app.rs
+++ b/crates/gdsr-viewer/src/app.rs
@@ -1442,6 +1442,10 @@ fn hit_test_element(
     None
 }
 
+fn accepts_canvas_shortcut(wants_keyboard_input: bool, modifiers: egui::Modifiers) -> bool {
+    !wants_keyboard_input && modifiers.is_none()
+}
+
 impl ViewerApp {
     fn update(&mut self, ctx: &egui::Context) {
         if ctx.input(|i| i.viewport().close_requested()) && self.cancel_close_for_unsaved_changes()
@@ -1484,10 +1488,17 @@ impl ViewerApp {
         let drawing_tool_active = polygon_tool_active || path_tool_active;
 
         // Global keyboard shortcuts
-        if ctx.input(|i| i.key_pressed(egui::Key::F)) {
+        let wants_keyboard_input = ctx.wants_keyboard_input();
+        if ctx.input(|i| {
+            accepts_canvas_shortcut(wants_keyboard_input, i.modifiers)
+                && i.key_pressed(egui::Key::F)
+        }) {
             self.zoom_to_fit();
         }
-        if ctx.input(|i| i.key_pressed(egui::Key::G)) {
+        if ctx.input(|i| {
+            accepts_canvas_shortcut(wants_keyboard_input, i.modifiers)
+                && i.key_pressed(egui::Key::G)
+        }) {
             self.show_grid = !self.show_grid;
         }
         if ctx.input(|i| i.modifiers.command && i.key_pressed(egui::Key::O) && !i.modifiers.alt) {
@@ -2126,6 +2137,13 @@ mod tests {
 
     fn p(x: f64, y: f64) -> Point {
         Point::float(x, y, 1.0)
+    }
+
+    #[test]
+    fn canvas_shortcuts_require_unmodified_non_text_input() {
+        assert!(accepts_canvas_shortcut(false, egui::Modifiers::NONE));
+        assert!(!accepts_canvas_shortcut(true, egui::Modifiers::NONE));
+        assert!(!accepts_canvas_shortcut(false, egui::Modifiers::CTRL));
     }
 
     fn test_elements() -> Vec<Element> {

--- a/crates/gdsr-viewer/src/panels.rs
+++ b/crates/gdsr-viewer/src/panels.rs
@@ -193,7 +193,8 @@ fn draw_layer_panel(
     layer_state: &mut LayerState,
     color_changed: &mut bool,
 ) {
-    ui.horizontal(|ui| {
+    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+        let clear = ui.add_enabled(!layer_state.filter.is_empty(), egui::Button::new("Clear"));
         let filter = ui
             .add(
                 egui::TextEdit::singleline(&mut layer_state.filter)
@@ -206,10 +207,7 @@ fn draw_layer_panel(
             filter.request_focus();
         }
 
-        if ui
-            .add_enabled(!layer_state.filter.is_empty(), egui::Button::new("Clear"))
-            .clicked()
-        {
+        if clear.clicked() {
             layer_state.filter.clear();
             filter.request_focus();
         }

--- a/crates/gdsr-viewer/src/panels.rs
+++ b/crates/gdsr-viewer/src/panels.rs
@@ -193,10 +193,35 @@ fn draw_layer_panel(
     layer_state: &mut LayerState,
     color_changed: &mut bool,
 ) {
+    ui.horizontal(|ui| {
+        let filter = ui
+            .add(
+                egui::TextEdit::singleline(&mut layer_state.filter)
+                    .hint_text("Filter layers")
+                    .desired_width(f32::INFINITY),
+            )
+            .on_hover_text("Focus with Command/Ctrl+F");
+
+        if ui.input(|input| input.modifiers.command && input.key_pressed(egui::Key::F)) {
+            filter.request_focus();
+        }
+
+        if ui
+            .add_enabled(!layer_state.filter.is_empty(), egui::Button::new("Clear"))
+            .clicked()
+        {
+            layer_state.filter.clear();
+            filter.request_focus();
+        }
+    });
+
     egui::ScrollArea::vertical()
         .id_salt("layers")
         .show(ui, |ui| {
-            for &(layer, dt) in layers {
+            for &(layer, dt) in layers
+                .iter()
+                .filter(|&&(layer, dt)| layer_matches_filter(layer, dt, &layer_state.filter))
+            {
                 let mut color = layer_state.layer_colors.get(layer, dt);
                 let visible = !layer_state.hidden_layers.contains(&(layer, dt));
 
@@ -221,6 +246,14 @@ fn draw_layer_panel(
                 });
             }
         });
+}
+
+fn layer_matches_filter(layer: Layer, data_type: DataType, filter: &str) -> bool {
+    let filter = filter.trim();
+    filter.is_empty()
+        || format!("L{layer} D{data_type}")
+            .to_ascii_lowercase()
+            .contains(&filter.to_ascii_lowercase())
 }
 
 /// Draws the statistics detail panel in the bottom bar.
@@ -317,5 +350,23 @@ fn draw_tree_node(
                 scroll_to_selected,
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::layer_matches_filter;
+    use gdsr::{DataType, Layer};
+
+    #[test]
+    fn layer_filter_matches_layer_and_datatype() {
+        let layer = Layer::new(12);
+        let data_type = DataType::new(7);
+
+        assert!(layer_matches_filter(layer, data_type, ""));
+        assert!(layer_matches_filter(layer, data_type, "12"));
+        assert!(layer_matches_filter(layer, data_type, "D7"));
+        assert!(layer_matches_filter(layer, data_type, " l12 d7 "));
+        assert!(!layer_matches_filter(layer, data_type, "L7"));
     }
 }

--- a/crates/gdsr-viewer/src/state.rs
+++ b/crates/gdsr-viewer/src/state.rs
@@ -688,4 +688,5 @@ impl GridSpacing {
 pub struct LayerState {
     pub layer_colors: LayerColorMap,
     pub hidden_layers: HashSet<(Layer, DataType)>,
+    pub filter: String,
 }


### PR DESCRIPTION
## Summary

Add live case-insensitive filtering to the viewer layer panel by layer and datatype, with a clear action and Command/Ctrl+F focus shortcut. Visibility state remains independent from filtering, and canvas shortcuts no longer fire while typing in text fields.

Closes #336

## Test Plan

Validated with focused viewer tests, the full nextest suite, strict Clippy, and `uvx prek run -a`.