### PR TITLE
Reject malformed and incomplete GDS streams

### DIFF
--- a/crates/gdsr/src/io/read/mod.rs
+++ b/crates/gdsr/src/io/read/mod.rs
@@ -37,6 +37,8 @@ where
     let mut text: Option<Text> = None;
     let mut reference: Option<Reference> = None;
     let mut property_attribute: Option<u16> = None;
+    let mut element_open = false;
+    let mut end_library_seen = false;
 
     let mut scale = 1.0;
     let mut db_units = units.unwrap_or(DEFAULT_INTEGER_UNITS);
@@ -85,30 +87,38 @@ where
                         library.cells.insert(cell.name().to_string(), cell);
                     }
                 }
+                GDSRecord::EndLib => end_library_seen = true,
                 GDSRecord::Boundary => {
                     property_attribute = None;
                     polygon = Some(Polygon::default());
+                    element_open = true;
                 }
                 GDSRecord::Box => {
                     property_attribute = None;
                     gds_box = Some(GdsBox::default());
+                    element_open = true;
                 }
                 GDSRecord::Node => {
                     property_attribute = None;
                     node = Some(Node::default());
+                    element_open = true;
                 }
                 GDSRecord::Path => {
                     property_attribute = None;
                     path = Some(Path::default());
+                    element_open = true;
                 }
                 GDSRecord::ARef | GDSRecord::SRef => {
                     property_attribute = None;
                     reference = Some(Reference::default());
+                    element_open = true;
                 }
                 GDSRecord::Text => {
                     property_attribute = None;
                     text = Some(Text::default());
+                    element_open = true;
                 }
+                GDSRecord::TextNode => element_open = true,
                 GDSRecord::Layer => {
                     if let GDSRecordData::I16(layer) = data {
                         let layer_value = Layer::new(layer[0] as u16);
@@ -276,6 +286,7 @@ where
                     text = None;
                     reference = None;
                     property_attribute = None;
+                    element_open = false;
                 }
                 GDSRecord::SName => {
                     if let GDSRecordData::Str(cell_name) = data {
@@ -399,13 +410,27 @@ where
         }
     }
 
+    if element_open {
+        return Err(invalid_data("Unexpected EOF before ENDEL record"));
+    }
+    if cell.is_some() {
+        return Err(invalid_data("Unexpected EOF before ENDSTR record"));
+    }
+    if !end_library_seen {
+        return Err(invalid_data("Unexpected EOF before ENDLIB record"));
+    }
+
     Ok(library)
 }
 
-fn invalid_timestamp_record(record: &str) -> GdsError {
+fn invalid_data(message: impl Into<String>) -> GdsError {
     GdsError::InvalidData {
-        message: format!("Invalid {record} timestamp record"),
+        message: message.into(),
     }
+}
+
+fn invalid_timestamp_record(record: &str) -> GdsError {
+    invalid_data(format!("Invalid {record} timestamp record"))
 }
 
 fn should_parse_xy<F>(
@@ -456,81 +481,153 @@ impl<R: Read> Iterator for RecordReader<R> {
 
     fn next(&mut self) -> Option<Self::Item> {
         let mut header = [0u8; 4];
-        if let Err(e) = self.reader.read_exact(&mut header) {
+        if let Err(e) = self.reader.read_exact(&mut header[..1]) {
             if e.kind() == io::ErrorKind::UnexpectedEof {
                 return None;
             }
             return Some(Err(GdsError::from(e)));
         }
+        if let Err(error) = self.reader.read_exact(&mut header[1..]) {
+            return Some(Err(if error.kind() == io::ErrorKind::UnexpectedEof {
+                invalid_data("Truncated record header")
+            } else {
+                GdsError::from(error)
+            }));
+        }
 
         let size = u16::from_be_bytes([header[0], header[1]]) as usize;
-        let record_type = header[2];
-        let data_type = header[3];
+        if size < 4 {
+            return Some(Err(invalid_data(format!(
+                "Record size {size} is smaller than the four-byte header"
+            ))));
+        }
 
-        let data = if size > 4 {
-            let mut buf = vec![0u8; size - 4];
-            if let Err(e) = self.reader.read_exact(&mut buf) {
-                return Some(Err(GdsError::from(e)));
-            }
-
-            let Ok(parsed_data_type) = GDSDataType::try_from(data_type) else {
-                return Some(Err(GdsError::InvalidData {
-                    message: format!("Invalid data type byte: {data_type:#04x}"),
-                }));
-            };
-
-            match parsed_data_type {
-                GDSDataType::TwoByteSignedInteger | GDSDataType::BitArray => {
-                    let result = read_i16_be(&buf);
-                    GDSRecordData::I16(result)
-                }
-                GDSDataType::FourByteSignedInteger | GDSDataType::FourByteReal => {
-                    let result = read_i32_be(&buf);
-                    GDSRecordData::I32(result)
-                }
-                GDSDataType::EightByteReal => {
-                    let u64_values = read_u64_be(&buf);
-                    let result: Vec<f64> = u64_values
-                        .into_iter()
-                        .map(eight_byte_real_to_float)
-                        .collect();
-                    GDSRecordData::F64(result)
-                }
-                GDSDataType::AsciiString => match String::from_utf8(buf) {
-                    Ok(mut result) => {
-                        if result.ends_with('\0') {
-                            result.pop();
-                        }
-                        GDSRecordData::Str(result)
-                    }
-                    Err(e) => {
-                        return Some(Err(GdsError::InvalidData {
-                            message: format!("Invalid UTF-8 in ASCII string record: {e}"),
-                        }));
-                    }
-                },
-                GDSDataType::NoData => match String::from_utf8(buf) {
-                    Ok(result) => GDSRecordData::Str(result),
-                    Err(e) => {
-                        return Some(Err(GdsError::InvalidData {
-                            message: format!("Invalid UTF-8 in NoData record: {e}"),
-                        }));
-                    }
-                },
-            }
-        } else {
-            GDSRecordData::None
+        let Ok(record) = GDSRecord::try_from(header[2]) else {
+            return Some(Err(invalid_data(format!(
+                "Invalid record type byte: {:#04x}",
+                header[2]
+            ))));
+        };
+        let Ok(data_type) = GDSDataType::try_from(header[3]) else {
+            return Some(Err(invalid_data(format!(
+                "Invalid data type byte: {:#04x}",
+                header[3]
+            ))));
         };
 
-        GDSRecord::try_from(record_type).map_or_else(
-            |()| {
-                Some(Err(GdsError::InvalidData {
-                    message: "Invalid record type".to_string(),
-                }))
+        let mut buf = vec![0u8; size - 4];
+        if let Err(error) = self.reader.read_exact(&mut buf) {
+            return Some(Err(if error.kind() == io::ErrorKind::UnexpectedEof {
+                invalid_data(format!("Truncated {record:?} record payload"))
+            } else {
+                GdsError::from(error)
+            }));
+        }
+        if let Err(error) = validate_record_layout(record, data_type, buf.len()) {
+            return Some(Err(error));
+        }
+
+        let data = match data_type {
+            GDSDataType::TwoByteSignedInteger | GDSDataType::BitArray => {
+                GDSRecordData::I16(read_i16_be(&buf))
+            }
+            GDSDataType::FourByteSignedInteger | GDSDataType::FourByteReal => {
+                GDSRecordData::I32(read_i32_be(&buf))
+            }
+            GDSDataType::EightByteReal => GDSRecordData::F64(
+                read_u64_be(&buf)
+                    .into_iter()
+                    .map(eight_byte_real_to_float)
+                    .collect(),
+            ),
+            GDSDataType::AsciiString => match String::from_utf8(buf) {
+                Ok(mut result) => {
+                    if result.ends_with('\0') {
+                        result.pop();
+                    }
+                    GDSRecordData::Str(result)
+                }
+                Err(error) => {
+                    return Some(Err(invalid_data(format!(
+                        "Invalid UTF-8 in ASCII string record: {error}"
+                    ))));
+                }
             },
-            |record| Some(Ok((record, data))),
-        )
+            GDSDataType::NoData => GDSRecordData::None,
+        };
+
+        Some(Ok((record, data)))
     }
+}
+
+fn validate_record_layout(
+    record: GDSRecord,
+    data_type: GDSDataType,
+    payload_len: usize,
+) -> Result<(), GdsError> {
+    let value_size = usize::from(data_type.byte_size());
+    if value_size > 0 && !payload_len.is_multiple_of(value_size) {
+        return Err(invalid_data(format!(
+            "{record:?} payload length {payload_len} is not aligned to {value_size} bytes"
+        )));
+    }
+    if data_type == GDSDataType::NoData && payload_len != 0 {
+        return Err(invalid_data(format!(
+            "{record:?} NoData record has a non-empty payload"
+        )));
+    }
+
+    let expected = match record {
+        GDSRecord::Header => Some((GDSDataType::TwoByteSignedInteger, 1)),
+        GDSRecord::BgnLib | GDSRecord::BgnStr => Some((GDSDataType::TwoByteSignedInteger, 12)),
+        GDSRecord::Units => Some((GDSDataType::EightByteReal, 2)),
+        GDSRecord::Layer
+        | GDSRecord::DataType
+        | GDSRecord::TextType
+        | GDSRecord::NodeType
+        | GDSRecord::PathType
+        | GDSRecord::PropAttr
+        | GDSRecord::BoxType => Some((GDSDataType::TwoByteSignedInteger, 1)),
+        GDSRecord::Presentation | GDSRecord::STrans => Some((GDSDataType::BitArray, 1)),
+        GDSRecord::ColRow => Some((GDSDataType::TwoByteSignedInteger, 2)),
+        GDSRecord::Width | GDSRecord::BgnExtn | GDSRecord::EndExtn => {
+            Some((GDSDataType::FourByteSignedInteger, 1))
+        }
+        GDSRecord::Mag | GDSRecord::Angle => Some((GDSDataType::EightByteReal, 1)),
+        GDSRecord::EndLib
+        | GDSRecord::EndStr
+        | GDSRecord::Boundary
+        | GDSRecord::Path
+        | GDSRecord::SRef
+        | GDSRecord::ARef
+        | GDSRecord::Text
+        | GDSRecord::EndEl
+        | GDSRecord::TextNode
+        | GDSRecord::Node
+        | GDSRecord::Box
+        | GDSRecord::EndMasks => Some((GDSDataType::NoData, 0)),
+        _ => None,
+    };
+
+    if let Some((expected_type, expected_count)) = expected {
+        let actual_count = payload_len.checked_div(value_size).unwrap_or(0);
+        if data_type != expected_type || actual_count != expected_count {
+            return Err(invalid_data(format!(
+                "Invalid {record:?} payload: expected {expected_count} {expected_type:?} value(s)"
+            )));
+        }
+    }
+    if record == GDSRecord::XY
+        && (data_type != GDSDataType::FourByteSignedInteger
+            || !(payload_len / usize::from(GDSDataType::FourByteSignedInteger.byte_size()))
+                .is_multiple_of(2))
+    {
+        return Err(invalid_data(
+            "Invalid XY payload: expected coordinate pairs of four-byte integers",
+        ));
+    }
+
+    Ok(())
 }
 
 fn read_i16_be(buf: &[u8]) -> Vec<i16> {
@@ -607,4 +704,173 @@ pub fn get_points_from_i32_vec(vec: &[i32], db_units: f64) -> Vec<Point> {
     vec.chunks(2)
         .map(|chunk| Point::integer(chunk[0], chunk[1], db_units))
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{BufReader, Cursor, Write};
+
+    use quickcheck_macros::quickcheck;
+
+    use super::*;
+    use crate::GdsTimestampPolicy;
+
+    fn record(record: GDSRecord, data_type: GDSDataType, payload: &[u8]) -> Vec<u8> {
+        let size = 4 + payload.len() as u16;
+        let mut bytes = Vec::with_capacity(usize::from(size));
+        bytes.extend_from_slice(&size.to_be_bytes());
+        bytes.push(record as u8);
+        bytes.push(data_type as u8);
+        bytes.extend_from_slice(payload);
+        bytes
+    }
+
+    fn assert_invalid(result: &Result<Library, GdsError>) {
+        assert!(matches!(result, Err(GdsError::InvalidData { .. })));
+    }
+
+    #[test]
+    fn malformed_record_layouts_return_invalid_data() {
+        let cases = [
+            ("one-byte header", vec![0]),
+            ("two-byte header", vec![0, 4]),
+            ("three-byte header", vec![0, 4, GDSRecord::EndLib as u8]),
+            (
+                "undersized record",
+                vec![0, 3, GDSRecord::EndLib as u8, GDSDataType::NoData as u8],
+            ),
+            (
+                "truncated payload",
+                vec![
+                    0,
+                    6,
+                    GDSRecord::Layer as u8,
+                    GDSDataType::TwoByteSignedInteger as u8,
+                    0,
+                ],
+            ),
+            (
+                "misaligned integer payload",
+                vec![
+                    0,
+                    7,
+                    GDSRecord::Layer as u8,
+                    GDSDataType::TwoByteSignedInteger as u8,
+                    0,
+                    0,
+                    0,
+                ],
+            ),
+            (
+                "empty scalar payload",
+                record(GDSRecord::Layer, GDSDataType::TwoByteSignedInteger, &[]),
+            ),
+            (
+                "short fixed-cardinality payload",
+                record(
+                    GDSRecord::ColRow,
+                    GDSDataType::TwoByteSignedInteger,
+                    &[0, 1],
+                ),
+            ),
+            (
+                "wrong scalar data type",
+                record(
+                    GDSRecord::Layer,
+                    GDSDataType::FourByteSignedInteger,
+                    &[0, 0, 0, 1],
+                ),
+            ),
+            (
+                "odd XY coordinate count",
+                record(
+                    GDSRecord::XY,
+                    GDSDataType::FourByteSignedInteger,
+                    &[0, 0, 0, 1],
+                ),
+            ),
+        ];
+
+        for (name, bytes) in cases {
+            let mut reader = RecordReader::new(BufReader::new(Cursor::new(bytes)));
+            assert!(
+                matches!(reader.next(), Some(Err(GdsError::InvalidData { .. }))),
+                "{name}"
+            );
+        }
+    }
+
+    #[test]
+    fn every_proper_prefix_of_minimal_library_is_rejected() {
+        let bytes = Library::new("minimal")
+            .to_bytes_with_timestamp_policy(1e-3, 1e-9, GdsTimestampPolicy::Zero)
+            .expect("minimal library should serialize");
+
+        for end in 0..bytes.len() {
+            assert_invalid(&Library::from_bytes(&bytes[..end], None));
+        }
+        Library::from_bytes(&bytes, None).expect("complete minimal library should parse");
+    }
+
+    #[test]
+    fn eof_before_each_structural_terminator_is_rejected() {
+        let minimal = Library::new("minimal")
+            .to_bytes_with_timestamp_policy(1e-3, 1e-9, GdsTimestampPolicy::Zero)
+            .expect("minimal library should serialize");
+        let missing_end_library = &minimal[..minimal.len() - 4];
+        let missing_end_structure = record(
+            GDSRecord::BgnStr,
+            GDSDataType::TwoByteSignedInteger,
+            &[0; 24],
+        );
+        let missing_end_element = record(GDSRecord::Boundary, GDSDataType::NoData, &[]);
+
+        for (terminator, bytes) in [
+            ("ENDLIB", missing_end_library),
+            ("ENDSTR", missing_end_structure.as_slice()),
+            ("ENDEL", missing_end_element.as_slice()),
+        ] {
+            let error = Library::from_bytes(bytes, None).expect_err("stream should be incomplete");
+            assert!(
+                matches!(
+                    error,
+                    GdsError::InvalidData { ref message } if message.contains(terminator)
+                ),
+                "{terminator}: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn all_library_read_entry_points_reject_malformed_input() {
+        let bytes = [0, 4];
+        let mut file = tempfile::NamedTempFile::new().expect("temporary file should be created");
+        file.write_all(&bytes)
+            .expect("malformed test data should be written");
+        file.flush().expect("malformed test data should be flushed");
+
+        assert_invalid(&Library::from_bytes(&bytes, None));
+        assert_invalid(&Library::read_from(Cursor::new(bytes), None));
+        assert_invalid(&Library::read_from_filtered(
+            Cursor::new(bytes),
+            None,
+            |_, _| true,
+        ));
+        assert_invalid(&Library::read_file(file.path(), None));
+        assert_invalid(&Library::read_file_filtered(file.path(), None, |_, _| true));
+    }
+
+    #[quickcheck]
+    fn generated_record_never_panics(record_type: u8, data_type: u8, mut payload: Vec<u8>) -> bool {
+        payload.truncate(256);
+        let size = 4 + payload.len() as u16;
+        let mut bytes = Vec::with_capacity(usize::from(size) + 4);
+        bytes.extend_from_slice(&size.to_be_bytes());
+        bytes.push(record_type);
+        bytes.push(data_type);
+        bytes.extend_from_slice(&payload);
+        bytes.extend_from_slice(&[0, 4, GDSRecord::EndLib as u8, GDSDataType::NoData as u8]);
+
+        std::panic::catch_unwind(|| Library::from_bytes(&bytes, None)).is_ok()
+    }
 }

--- a/crates/gdsr/src/io/read/mod.rs
+++ b/crates/gdsr/src/io/read/mod.rs
@@ -1,4 +1,4 @@
-use std::io::{self, BufReader, Read};
+use std::io::{self, BufRead, BufReader, Read};
 
 use crate::cell::Cell;
 use crate::config::gds_file_types::GDSDataType::{
@@ -519,12 +519,29 @@ impl<R: Read> Iterator for RecordReader<R> {
 
     fn next(&mut self) -> Option<Self::Item> {
         let mut header = [0u8; 4];
-        if let Err(error) = self.reader.read_exact(&mut header) {
-            return if error.kind() == io::ErrorKind::UnexpectedEof {
-                None
-            } else {
-                Some(Err(GdsError::from(error)))
+        let header_len = header.len();
+        let buffered = self.reader.buffer();
+        if buffered.len() >= header_len {
+            header.copy_from_slice(&buffered[..header_len]);
+            self.reader.consume(header_len);
+        } else {
+            let bytes_read = loop {
+                match self.reader.read(&mut header) {
+                    Ok(0) => return None,
+                    Ok(bytes_read) => break bytes_read,
+                    Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+                    Err(error) => return Some(Err(GdsError::from(error))),
+                }
             };
+            if bytes_read < header_len
+                && let Err(error) = self.reader.read_exact(&mut header[bytes_read..])
+            {
+                return Some(Err(if error.kind() == io::ErrorKind::UnexpectedEof {
+                    invalid_data("Truncated record header")
+                } else {
+                    GdsError::from(error)
+                }));
+            }
         }
 
         let size = u16::from_be_bytes([header[0], header[1]]) as usize;
@@ -664,8 +681,8 @@ const RECORD_LAYOUTS: [RecordLayout; 60] = [
     layout(GDSRecord::Angle, EightByteReal, 8),
     layout(GDSRecord::UInteger, TwoByteSignedInteger, 2),
     layout(GDSRecord::UString, AsciiString, VARIABLE_PAYLOAD_LEN),
-    layout(GDSRecord::RefLibs, AsciiString, VARIABLE_PAYLOAD_LEN),
-    layout(GDSRecord::Fonts, AsciiString, VARIABLE_PAYLOAD_LEN),
+    layout(GDSRecord::RefLibs, AsciiString, 88),
+    layout(GDSRecord::Fonts, AsciiString, 176),
     layout(GDSRecord::PathType, TwoByteSignedInteger, 2),
     layout(GDSRecord::Generations, TwoByteSignedInteger, 2),
     layout(GDSRecord::AttrTable, AsciiString, VARIABLE_PAYLOAD_LEN),
@@ -788,7 +805,7 @@ pub fn get_points_from_i32_vec(vec: &[i32], db_units: f64) -> Vec<Point> {
 
 #[cfg(test)]
 mod tests {
-    use std::io::{Cursor, Write};
+    use std::io::{BufReader, Cursor, Write};
 
     use quickcheck_macros::quickcheck;
 
@@ -879,6 +896,21 @@ mod tests {
                 ),
                 "{name}"
             );
+        }
+    }
+
+    #[test]
+    fn record_reader_distinguishes_clean_eof_from_partial_header() {
+        let mut clean = RecordReader::new(BufReader::new(Cursor::new(Vec::<u8>::new())));
+        assert!(clean.next().is_none());
+
+        for bytes in [vec![0], vec![0, 4], vec![0, 4, GDSRecord::EndLib as u8]] {
+            let mut reader = RecordReader::new(BufReader::new(Cursor::new(bytes)));
+            assert!(matches!(
+                reader.next(),
+                Some(Err(GdsError::InvalidData { ref message }))
+                    if message == "Truncated record header"
+            ));
         }
     }
 
@@ -979,6 +1011,30 @@ mod tests {
                 ),
                 "{record_type:?}"
             );
+        }
+    }
+
+    #[test]
+    fn fixed_library_string_lengths_are_enforced() {
+        for (record_type, expected_payload_len) in
+            [(GDSRecord::RefLibs, 88), (GDSRecord::Fonts, 176)]
+        {
+            for (payload_len, is_valid) in [
+                (expected_payload_len, true),
+                (expected_payload_len - 2, false),
+                (expected_payload_len + 2, false),
+            ] {
+                let bytes = [
+                    record(record_type, GDSDataType::AsciiString, &vec![0; payload_len]),
+                    record(GDSRecord::EndLib, GDSDataType::NoData, &[]),
+                ]
+                .concat();
+                assert_eq!(
+                    Library::from_bytes(&bytes, None).is_ok(),
+                    is_valid,
+                    "{record_type:?} payload length {payload_len}"
+                );
+            }
         }
     }
 

--- a/crates/gdsr/src/io/read/mod.rs
+++ b/crates/gdsr/src/io/read/mod.rs
@@ -506,11 +506,27 @@ where
 
 pub struct RecordReader<R: Read> {
     reader: BufReader<R>,
+    payload: Vec<u8>,
 }
 
 impl<R: Read> RecordReader<R> {
     pub const fn new(reader: BufReader<R>) -> Self {
-        Self { reader }
+        Self {
+            reader,
+            payload: Vec::new(),
+        }
+    }
+
+    fn read_payload(&mut self, payload_len: usize, record: GDSRecord) -> Result<&[u8], GdsError> {
+        self.payload.resize(payload_len, 0);
+        self.reader.read_exact(&mut self.payload).map_err(|error| {
+            if error.kind() == io::ErrorKind::UnexpectedEof {
+                invalid_data(format!("Truncated {record:?} record payload"))
+            } else {
+                GdsError::from(error)
+            }
+        })?;
+        Ok(&self.payload)
     }
 }
 
@@ -576,35 +592,18 @@ impl<R: Read> Iterator for RecordReader<R> {
             ))));
         }
 
-        let mut buf = vec![0u8; payload_len];
-        if let Err(error) = self.reader.read_exact(&mut buf) {
-            return Some(Err(if error.kind() == io::ErrorKind::UnexpectedEof {
-                invalid_data(format!("Truncated {record:?} record payload"))
-            } else {
-                GdsError::from(error)
-            }));
-        }
-
-        let data = match data_type {
-            GDSDataType::TwoByteSignedInteger | GDSDataType::BitArray => {
-                GDSRecordData::I16(read_i16_be(&buf))
+        let data = if payload_len == 0 {
+            GDSRecordData::None
+        } else if data_type == GDSDataType::AsciiString {
+            let mut buf = vec![0u8; payload_len];
+            if let Err(error) = self.reader.read_exact(&mut buf) {
+                return Some(Err(if error.kind() == io::ErrorKind::UnexpectedEof {
+                    invalid_data(format!("Truncated {record:?} record payload"))
+                } else {
+                    GdsError::from(error)
+                }));
             }
-            GDSDataType::FourByteSignedInteger | GDSDataType::FourByteReal => {
-                if expected_payload_len == VARIABLE_PAYLOAD_LEN {
-                    let alignment = if record == GDSRecord::XY { 8 } else { 4 };
-                    if !buf.len().is_multiple_of(alignment) {
-                        return Some(Err(misaligned_payload(record, buf.len(), alignment)));
-                    }
-                }
-                GDSRecordData::I32(read_i32_be(&buf))
-            }
-            GDSDataType::EightByteReal => GDSRecordData::F64(
-                read_u64_be(&buf)
-                    .into_iter()
-                    .map(eight_byte_real_to_float)
-                    .collect(),
-            ),
-            GDSDataType::AsciiString => match String::from_utf8(buf) {
+            match String::from_utf8(buf) {
                 Ok(mut result) => {
                     if !result.len().is_multiple_of(2) {
                         return Some(Err(misaligned_payload(record, result.len(), 2)));
@@ -619,8 +618,38 @@ impl<R: Read> Iterator for RecordReader<R> {
                         "Invalid UTF-8 in ASCII string record: {error}"
                     ))));
                 }
-            },
-            GDSDataType::NoData => GDSRecordData::None,
+            }
+        } else {
+            let buf = match self.read_payload(payload_len, record) {
+                Ok(buf) => buf,
+                Err(error) => return Some(Err(error)),
+            };
+
+            match data_type {
+                GDSDataType::TwoByteSignedInteger | GDSDataType::BitArray => {
+                    GDSRecordData::I16(read_i16_be(buf))
+                }
+                GDSDataType::FourByteSignedInteger | GDSDataType::FourByteReal => {
+                    if expected_payload_len == VARIABLE_PAYLOAD_LEN {
+                        let alignment = if record == GDSRecord::XY { 8 } else { 4 };
+                        if !buf.len().is_multiple_of(alignment) {
+                            return Some(Err(misaligned_payload(record, buf.len(), alignment)));
+                        }
+                    }
+                    GDSRecordData::I32(read_i32_be(buf))
+                }
+                GDSDataType::EightByteReal => GDSRecordData::F64(
+                    read_u64_be(buf)
+                        .into_iter()
+                        .map(eight_byte_real_to_float)
+                        .collect(),
+                ),
+                GDSDataType::NoData | GDSDataType::AsciiString => {
+                    return Some(Err(invalid_data(format!(
+                        "Invalid {record:?} payload state"
+                    ))));
+                }
+            }
         };
 
         Some(Ok((record, data)))

--- a/crates/gdsr/src/io/read/mod.rs
+++ b/crates/gdsr/src/io/read/mod.rs
@@ -1,6 +1,9 @@
 use std::io::{self, BufReader, Read};
 
 use crate::cell::Cell;
+use crate::config::gds_file_types::GDSDataType::{
+    AsciiString, BitArray, EightByteReal, FourByteSignedInteger, NoData, TwoByteSignedInteger,
+};
 use crate::config::gds_file_types::{GDSDataType, GDSRecord, GDSRecordData, STRANS_X_REFLECTION};
 use crate::elements::text::get_presentations_from_value;
 use crate::elements::{GdsBox, Node, Path, PathType, Polygon, Property, Reference, Text};
@@ -10,6 +13,25 @@ use crate::library::Library;
 use crate::{
     DEFAULT_INTEGER_UNITS, DataType, Degrees, GdsTimestamps, Instance, Layer, Point, Unit,
 };
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ParserState {
+    Library,
+    Structure,
+    Element,
+}
+
+impl ParserState {
+    fn require(self, expected: Self, record: GDSRecord) -> Result<(), GdsError> {
+        if self == expected {
+            Ok(())
+        } else {
+            Err(invalid_data(format!(
+                "Unexpected {record:?} record while parsing {self:?}"
+            )))
+        }
+    }
+}
 
 pub fn from_gds_reader<R: Read>(reader: R, units: Option<f64>) -> Result<Library, GdsError> {
     from_gds_reader_filtered(reader, units, |_, _| true)
@@ -37,8 +59,7 @@ where
     let mut text: Option<Text> = None;
     let mut reference: Option<Reference> = None;
     let mut property_attribute: Option<u16> = None;
-    let mut element_open = false;
-    let mut end_library_seen = false;
+    let mut state = ParserState::Library;
 
     let mut scale = 1.0;
     let mut db_units = units.unwrap_or(DEFAULT_INTEGER_UNITS);
@@ -68,12 +89,14 @@ where
                     }
                 }
                 GDSRecord::BgnStr => {
+                    state.require(ParserState::Library, record_type)?;
                     let GDSRecordData::I16(values) = data else {
                         return Err(invalid_timestamp_record("BGNSTR"));
                     };
                     let mut new_cell = Cell::default();
                     new_cell.set_timestamps(GdsTimestamps::from_record(&values, "BGNSTR")?);
                     cell = Some(new_cell);
+                    state = ParserState::Structure;
                 }
                 GDSRecord::StrName => {
                     if let GDSRecordData::Str(cell_name) = data {
@@ -83,42 +106,56 @@ where
                     }
                 }
                 GDSRecord::EndStr => {
+                    state.require(ParserState::Structure, record_type)?;
                     if let Some(cell) = cell.take() {
                         library.cells.insert(cell.name().to_string(), cell);
                     }
+                    state = ParserState::Library;
                 }
-                GDSRecord::EndLib => end_library_seen = true,
+                GDSRecord::EndLib => {
+                    state.require(ParserState::Library, record_type)?;
+                    return Ok(library);
+                }
                 GDSRecord::Boundary => {
+                    state.require(ParserState::Structure, record_type)?;
                     property_attribute = None;
                     polygon = Some(Polygon::default());
-                    element_open = true;
+                    state = ParserState::Element;
                 }
                 GDSRecord::Box => {
+                    state.require(ParserState::Structure, record_type)?;
                     property_attribute = None;
                     gds_box = Some(GdsBox::default());
-                    element_open = true;
+                    state = ParserState::Element;
                 }
                 GDSRecord::Node => {
+                    state.require(ParserState::Structure, record_type)?;
                     property_attribute = None;
                     node = Some(Node::default());
-                    element_open = true;
+                    state = ParserState::Element;
                 }
                 GDSRecord::Path => {
+                    state.require(ParserState::Structure, record_type)?;
                     property_attribute = None;
                     path = Some(Path::default());
-                    element_open = true;
+                    state = ParserState::Element;
                 }
                 GDSRecord::ARef | GDSRecord::SRef => {
+                    state.require(ParserState::Structure, record_type)?;
                     property_attribute = None;
                     reference = Some(Reference::default());
-                    element_open = true;
+                    state = ParserState::Element;
                 }
                 GDSRecord::Text => {
+                    state.require(ParserState::Structure, record_type)?;
                     property_attribute = None;
                     text = Some(Text::default());
-                    element_open = true;
+                    state = ParserState::Element;
                 }
-                GDSRecord::TextNode => element_open = true,
+                GDSRecord::TextNode => {
+                    state.require(ParserState::Structure, record_type)?;
+                    state = ParserState::Element;
+                }
                 GDSRecord::Layer => {
                     if let GDSRecordData::I16(layer) = data {
                         let layer_value = Layer::new(layer[0] as u16);
@@ -254,6 +291,7 @@ where
                     }
                 }
                 GDSRecord::EndEl => {
+                    state.require(ParserState::Element, record_type)?;
                     if let Some(cell) = &mut cell {
                         if let Some(polygon) = polygon.take() {
                             if layer_filter(polygon.layer, polygon.data_type) {
@@ -286,7 +324,7 @@ where
                     text = None;
                     reference = None;
                     property_attribute = None;
-                    element_open = false;
+                    state = ParserState::Structure;
                 }
                 GDSRecord::SName => {
                     if let GDSRecordData::Str(cell_name) = data {
@@ -410,17 +448,11 @@ where
         }
     }
 
-    if element_open {
-        return Err(invalid_data("Unexpected EOF before ENDEL record"));
+    match state {
+        ParserState::Element => Err(invalid_data("Unexpected EOF before ENDEL record")),
+        ParserState::Structure => Err(invalid_data("Unexpected EOF before ENDSTR record")),
+        ParserState::Library => Err(invalid_data("Unexpected EOF before ENDLIB record")),
     }
-    if cell.is_some() {
-        return Err(invalid_data("Unexpected EOF before ENDSTR record"));
-    }
-    if !end_library_seen {
-        return Err(invalid_data("Unexpected EOF before ENDLIB record"));
-    }
-
-    Ok(library)
 }
 
 fn invalid_data(message: impl Into<String>) -> GdsError {
@@ -481,13 +513,17 @@ impl<R: Read> Iterator for RecordReader<R> {
 
     fn next(&mut self) -> Option<Self::Item> {
         let mut header = [0u8; 4];
-        if let Err(e) = self.reader.read_exact(&mut header[..1]) {
-            if e.kind() == io::ErrorKind::UnexpectedEof {
-                return None;
+        let bytes_read = loop {
+            match self.reader.read(&mut header) {
+                Ok(0) => return None,
+                Ok(bytes_read) => break bytes_read,
+                Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+                Err(error) => return Some(Err(GdsError::from(error))),
             }
-            return Some(Err(GdsError::from(e)));
-        }
-        if let Err(error) = self.reader.read_exact(&mut header[1..]) {
+        };
+        if bytes_read < header.len()
+            && let Err(error) = self.reader.read_exact(&mut header[bytes_read..])
+        {
             return Some(Err(if error.kind() == io::ErrorKind::UnexpectedEof {
                 invalid_data("Truncated record header")
             } else {
@@ -502,29 +538,32 @@ impl<R: Read> Iterator for RecordReader<R> {
             ))));
         }
 
-        let Ok(record) = GDSRecord::try_from(header[2]) else {
+        let Some(&schema) = RECORD_SCHEMAS.get(usize::from(header[2])) else {
             return Some(Err(invalid_data(format!(
                 "Invalid record type byte: {:#04x}",
                 header[2]
             ))));
         };
-        let Ok(data_type) = GDSDataType::try_from(header[3]) else {
+        let record = schema.record;
+        if header[3] != schema.data_type as u8 {
             return Some(Err(invalid_data(format!(
-                "Invalid data type byte: {:#04x}",
-                header[3]
+                "Invalid {record:?} data type: expected {:?}, found {:#04x}",
+                schema.data_type, header[3]
             ))));
-        };
+        }
+        let data_type = schema.data_type;
+        let payload_len = size - 4;
+        if let Err(error) = validate_record_layout(schema, payload_len) {
+            return Some(Err(error));
+        }
 
-        let mut buf = vec![0u8; size - 4];
+        let mut buf = vec![0u8; payload_len];
         if let Err(error) = self.reader.read_exact(&mut buf) {
             return Some(Err(if error.kind() == io::ErrorKind::UnexpectedEof {
                 invalid_data(format!("Truncated {record:?} record payload"))
             } else {
                 GdsError::from(error)
             }));
-        }
-        if let Err(error) = validate_record_layout(record, data_type, buf.len()) {
-            return Some(Err(error));
         }
 
         let data = match data_type {
@@ -560,74 +599,123 @@ impl<R: Read> Iterator for RecordReader<R> {
     }
 }
 
-fn validate_record_layout(
+#[derive(Clone, Copy)]
+struct RecordSchema {
     record: GDSRecord,
     data_type: GDSDataType,
-    payload_len: usize,
-) -> Result<(), GdsError> {
-    let value_size = usize::from(data_type.byte_size());
-    if value_size > 0 && !payload_len.is_multiple_of(value_size) {
-        return Err(invalid_data(format!(
-            "{record:?} payload length {payload_len} is not aligned to {value_size} bytes"
-        )));
+    payload_len: u16,
+}
+
+const VARIABLE_PAYLOAD_LEN: u16 = u16::MAX;
+
+const fn schema(record: GDSRecord, data_type: GDSDataType, payload_len: u16) -> RecordSchema {
+    RecordSchema {
+        record,
+        data_type,
+        payload_len,
     }
-    if data_type == GDSDataType::NoData && payload_len != 0 {
-        return Err(invalid_data(format!(
-            "{record:?} NoData record has a non-empty payload"
-        )));
+}
+
+const RECORD_SCHEMAS: [RecordSchema; 60] = [
+    schema(GDSRecord::Header, TwoByteSignedInteger, 2),
+    schema(GDSRecord::BgnLib, TwoByteSignedInteger, 24),
+    schema(GDSRecord::LibName, AsciiString, VARIABLE_PAYLOAD_LEN),
+    schema(GDSRecord::Units, EightByteReal, 16),
+    schema(GDSRecord::EndLib, NoData, 0),
+    schema(GDSRecord::BgnStr, TwoByteSignedInteger, 24),
+    schema(GDSRecord::StrName, AsciiString, VARIABLE_PAYLOAD_LEN),
+    schema(GDSRecord::EndStr, NoData, 0),
+    schema(GDSRecord::Boundary, NoData, 0),
+    schema(GDSRecord::Path, NoData, 0),
+    schema(GDSRecord::SRef, NoData, 0),
+    schema(GDSRecord::ARef, NoData, 0),
+    schema(GDSRecord::Text, NoData, 0),
+    schema(GDSRecord::Layer, TwoByteSignedInteger, 2),
+    schema(GDSRecord::DataType, TwoByteSignedInteger, 2),
+    schema(GDSRecord::Width, FourByteSignedInteger, 4),
+    schema(GDSRecord::XY, FourByteSignedInteger, VARIABLE_PAYLOAD_LEN),
+    schema(GDSRecord::EndEl, NoData, 0),
+    schema(GDSRecord::SName, AsciiString, VARIABLE_PAYLOAD_LEN),
+    schema(GDSRecord::ColRow, TwoByteSignedInteger, 4),
+    schema(GDSRecord::TextNode, NoData, 0),
+    schema(GDSRecord::Node, NoData, 0),
+    schema(GDSRecord::TextType, TwoByteSignedInteger, 2),
+    schema(GDSRecord::Presentation, BitArray, 2),
+    schema(
+        GDSRecord::Spacing,
+        FourByteSignedInteger,
+        VARIABLE_PAYLOAD_LEN,
+    ),
+    schema(GDSRecord::String, AsciiString, VARIABLE_PAYLOAD_LEN),
+    schema(GDSRecord::STrans, BitArray, 2),
+    schema(GDSRecord::Mag, EightByteReal, 8),
+    schema(GDSRecord::Angle, EightByteReal, 8),
+    schema(GDSRecord::UInteger, TwoByteSignedInteger, 2),
+    schema(GDSRecord::UString, AsciiString, VARIABLE_PAYLOAD_LEN),
+    schema(GDSRecord::RefLibs, AsciiString, VARIABLE_PAYLOAD_LEN),
+    schema(GDSRecord::Fonts, AsciiString, VARIABLE_PAYLOAD_LEN),
+    schema(GDSRecord::PathType, TwoByteSignedInteger, 2),
+    schema(GDSRecord::Generations, TwoByteSignedInteger, 2),
+    schema(GDSRecord::AttrTable, AsciiString, VARIABLE_PAYLOAD_LEN),
+    schema(GDSRecord::StyTable, AsciiString, VARIABLE_PAYLOAD_LEN),
+    schema(GDSRecord::StrType, TwoByteSignedInteger, 2),
+    schema(GDSRecord::ElFlags, BitArray, 2),
+    schema(GDSRecord::ElKey, FourByteSignedInteger, 4),
+    schema(GDSRecord::LinkType, TwoByteSignedInteger, 2),
+    schema(
+        GDSRecord::LinkKeys,
+        FourByteSignedInteger,
+        VARIABLE_PAYLOAD_LEN,
+    ),
+    schema(GDSRecord::NodeType, TwoByteSignedInteger, 2),
+    schema(GDSRecord::PropAttr, TwoByteSignedInteger, 2),
+    schema(GDSRecord::PropValue, AsciiString, VARIABLE_PAYLOAD_LEN),
+    schema(GDSRecord::Box, NoData, 0),
+    schema(GDSRecord::BoxType, TwoByteSignedInteger, 2),
+    schema(GDSRecord::Plex, FourByteSignedInteger, 4),
+    schema(GDSRecord::BgnExtn, FourByteSignedInteger, 4),
+    schema(GDSRecord::EndExtn, FourByteSignedInteger, 4),
+    schema(GDSRecord::TapeNum, TwoByteSignedInteger, 2),
+    schema(GDSRecord::TapeCode, TwoByteSignedInteger, 12),
+    schema(GDSRecord::StrClass, BitArray, 2),
+    schema(
+        GDSRecord::Reserved,
+        FourByteSignedInteger,
+        VARIABLE_PAYLOAD_LEN,
+    ),
+    schema(GDSRecord::Format, TwoByteSignedInteger, 2),
+    schema(GDSRecord::Mask, AsciiString, VARIABLE_PAYLOAD_LEN),
+    schema(GDSRecord::EndMasks, NoData, 0),
+    schema(GDSRecord::LibDirSize, TwoByteSignedInteger, 2),
+    schema(GDSRecord::SrfName, AsciiString, VARIABLE_PAYLOAD_LEN),
+    schema(GDSRecord::LibSecure, TwoByteSignedInteger, 2),
+];
+
+fn validate_record_layout(schema: RecordSchema, payload_len: usize) -> Result<(), GdsError> {
+    if schema.payload_len != VARIABLE_PAYLOAD_LEN {
+        return if payload_len == usize::from(schema.payload_len) {
+            Ok(())
+        } else {
+            Err(invalid_data(format!(
+                "Invalid {:?} payload length: expected {} bytes, found {payload_len}",
+                schema.record, schema.payload_len
+            )))
+        };
     }
 
-    let expected = match record {
-        GDSRecord::Header => Some((GDSDataType::TwoByteSignedInteger, 1)),
-        GDSRecord::BgnLib | GDSRecord::BgnStr => Some((GDSDataType::TwoByteSignedInteger, 12)),
-        GDSRecord::Units => Some((GDSDataType::EightByteReal, 2)),
-        GDSRecord::Layer
-        | GDSRecord::DataType
-        | GDSRecord::TextType
-        | GDSRecord::NodeType
-        | GDSRecord::PathType
-        | GDSRecord::PropAttr
-        | GDSRecord::BoxType => Some((GDSDataType::TwoByteSignedInteger, 1)),
-        GDSRecord::Presentation | GDSRecord::STrans => Some((GDSDataType::BitArray, 1)),
-        GDSRecord::ColRow => Some((GDSDataType::TwoByteSignedInteger, 2)),
-        GDSRecord::Width | GDSRecord::BgnExtn | GDSRecord::EndExtn => {
-            Some((GDSDataType::FourByteSignedInteger, 1))
-        }
-        GDSRecord::Mag | GDSRecord::Angle => Some((GDSDataType::EightByteReal, 1)),
-        GDSRecord::EndLib
-        | GDSRecord::EndStr
-        | GDSRecord::Boundary
-        | GDSRecord::Path
-        | GDSRecord::SRef
-        | GDSRecord::ARef
-        | GDSRecord::Text
-        | GDSRecord::EndEl
-        | GDSRecord::TextNode
-        | GDSRecord::Node
-        | GDSRecord::Box
-        | GDSRecord::EndMasks => Some((GDSDataType::NoData, 0)),
-        _ => None,
+    let alignment = if schema.record == GDSRecord::XY {
+        8
+    } else {
+        usize::from(schema.data_type.byte_size()).max(2)
     };
-
-    if let Some((expected_type, expected_count)) = expected {
-        let actual_count = payload_len.checked_div(value_size).unwrap_or(0);
-        if data_type != expected_type || actual_count != expected_count {
-            return Err(invalid_data(format!(
-                "Invalid {record:?} payload: expected {expected_count} {expected_type:?} value(s)"
-            )));
-        }
+    if payload_len.is_multiple_of(alignment) {
+        Ok(())
+    } else {
+        Err(invalid_data(format!(
+            "{:?} payload length {payload_len} is not aligned to {alignment} bytes",
+            schema.record
+        )))
     }
-    if record == GDSRecord::XY
-        && (data_type != GDSDataType::FourByteSignedInteger
-            || !(payload_len / usize::from(GDSDataType::FourByteSignedInteger.byte_size()))
-                .is_multiple_of(2))
-    {
-        return Err(invalid_data(
-            "Invalid XY payload: expected coordinate pairs of four-byte integers",
-        ));
-    }
-
-    Ok(())
 }
 
 fn read_i16_be(buf: &[u8]) -> Vec<i16> {
@@ -823,7 +911,12 @@ mod tests {
             GDSDataType::TwoByteSignedInteger,
             &[0; 24],
         );
-        let missing_end_element = record(GDSRecord::Boundary, GDSDataType::NoData, &[]);
+        let mut missing_end_element = missing_end_structure.clone();
+        missing_end_element.extend_from_slice(&record(
+            GDSRecord::Boundary,
+            GDSDataType::NoData,
+            &[],
+        ));
 
         for (terminator, bytes) in [
             ("ENDLIB", missing_end_library),
@@ -838,6 +931,98 @@ mod tests {
                 ),
                 "{terminator}: {error}"
             );
+        }
+    }
+
+    #[test]
+    fn fixed_and_string_record_grammar_is_enforced() {
+        for (record_type, data_type, payload_len) in [
+            (GDSRecord::Generations, GDSDataType::TwoByteSignedInteger, 2),
+            (GDSRecord::ElFlags, GDSDataType::BitArray, 2),
+            (GDSRecord::Plex, GDSDataType::FourByteSignedInteger, 4),
+            (GDSRecord::StrType, GDSDataType::TwoByteSignedInteger, 2),
+            (GDSRecord::TapeNum, GDSDataType::TwoByteSignedInteger, 2),
+            (GDSRecord::TapeCode, GDSDataType::TwoByteSignedInteger, 12),
+        ] {
+            let bytes = record(record_type, data_type, &vec![0; payload_len]);
+            let mut valid = RecordReader::new(BufReader::new(Cursor::new(bytes)));
+            assert!(matches!(valid.next(), Some(Ok(_))), "{record_type:?}");
+
+            let bytes = record(record_type, data_type, &[]);
+            let mut invalid = RecordReader::new(BufReader::new(Cursor::new(bytes)));
+            assert!(
+                matches!(invalid.next(), Some(Err(GdsError::InvalidData { .. }))),
+                "{record_type:?}"
+            );
+        }
+
+        for record_type in [
+            GDSRecord::LibName,
+            GDSRecord::StrName,
+            GDSRecord::SName,
+            GDSRecord::String,
+            GDSRecord::PropValue,
+        ] {
+            let bytes = record(record_type, GDSDataType::TwoByteSignedInteger, &[0, 0]);
+            let mut wrong_type = RecordReader::new(BufReader::new(Cursor::new(bytes)));
+            assert!(
+                matches!(wrong_type.next(), Some(Err(GdsError::InvalidData { .. }))),
+                "{record_type:?}"
+            );
+
+            let bytes = record(record_type, GDSDataType::AsciiString, b"x");
+            let mut odd_length = RecordReader::new(BufReader::new(Cursor::new(bytes)));
+            assert!(
+                matches!(odd_length.next(), Some(Err(GdsError::InvalidData { .. }))),
+                "{record_type:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_structural_sequences_are_rejected() {
+        let begin_structure = record(
+            GDSRecord::BgnStr,
+            GDSDataType::TwoByteSignedInteger,
+            &[0; 24],
+        );
+        let begin_boundary = record(GDSRecord::Boundary, GDSDataType::NoData, &[]);
+        let begin_path = record(GDSRecord::Path, GDSDataType::NoData, &[]);
+
+        for records in [
+            vec![begin_structure.clone(), begin_structure.clone()],
+            vec![begin_structure.clone(), begin_boundary.clone(), begin_path],
+            vec![record(GDSRecord::EndEl, GDSDataType::NoData, &[])],
+            vec![
+                begin_structure,
+                record(GDSRecord::EndLib, GDSDataType::NoData, &[]),
+            ],
+        ] {
+            let bytes = records.concat();
+            assert_invalid(&Library::from_bytes(&bytes, None));
+        }
+    }
+
+    #[test]
+    fn end_library_ignores_trailing_padding_and_records() {
+        let bytes = Library::new("minimal")
+            .to_bytes_with_timestamp_policy(1e-3, 1e-9, GdsTimestampPolicy::Zero)
+            .expect("minimal library should serialize");
+        let expected = Library::from_bytes(&bytes, None).expect("minimal library should parse");
+
+        for suffix in [
+            vec![0],
+            record(
+                GDSRecord::BgnStr,
+                GDSDataType::TwoByteSignedInteger,
+                &[0; 24],
+            ),
+        ] {
+            let mut padded = bytes.clone();
+            padded.extend_from_slice(&suffix);
+            let parsed = Library::from_bytes(&padded, None)
+                .expect("bytes after ENDLIB should not be semantically parsed");
+            assert_eq!(parsed, expected);
         }
     }
 
@@ -861,14 +1046,17 @@ mod tests {
     }
 
     #[quickcheck]
-    fn generated_record_never_panics(record_type: u8, data_type: u8, mut payload: Vec<u8>) -> bool {
-        payload.truncate(256);
-        let size = 4 + payload.len() as u16;
-        let mut bytes = Vec::with_capacity(usize::from(size) + 4);
-        bytes.extend_from_slice(&size.to_be_bytes());
-        bytes.push(record_type);
-        bytes.push(data_type);
-        bytes.extend_from_slice(&payload);
+    fn generated_record_sequence_never_panics(mut records: Vec<(u8, u8, Vec<u8>)>) -> bool {
+        records.truncate(16);
+        let mut bytes = Vec::new();
+        for (record_type, data_type, mut payload) in records {
+            payload.truncate(256);
+            let size = 4 + payload.len() as u16;
+            bytes.extend_from_slice(&size.to_be_bytes());
+            bytes.push(record_type);
+            bytes.push(data_type);
+            bytes.extend_from_slice(&payload);
+        }
         bytes.extend_from_slice(&[0, 4, GDSRecord::EndLib as u8, GDSDataType::NoData as u8]);
 
         std::panic::catch_unwind(|| Library::from_bytes(&bytes, None)).is_ok()

--- a/crates/gdsr/src/io/read/mod.rs
+++ b/crates/gdsr/src/io/read/mod.rs
@@ -959,7 +959,7 @@ const RECORD_LAYOUTS: [RecordLayout; 60] = [
     layout(GDSRecord::STrans, BitArray, 2),
     layout(GDSRecord::Mag, EightByteReal, 8),
     layout(GDSRecord::Angle, EightByteReal, 8),
-    layout(GDSRecord::UInteger, TwoByteSignedInteger, 2),
+    layout(GDSRecord::UInteger, FourByteSignedInteger, 4),
     layout(GDSRecord::UString, AsciiString, VARIABLE_PAYLOAD_LEN),
     layout(GDSRecord::RefLibs, AsciiString, 88),
     layout(GDSRecord::Fonts, AsciiString, 176),
@@ -1327,6 +1327,7 @@ mod tests {
             (GDSRecord::StrType, GDSDataType::TwoByteSignedInteger, 2),
             (GDSRecord::TapeNum, GDSDataType::TwoByteSignedInteger, 2),
             (GDSRecord::TapeCode, GDSDataType::TwoByteSignedInteger, 12),
+            (GDSRecord::UInteger, GDSDataType::FourByteSignedInteger, 4),
         ] {
             let bytes = [record(record_type, data_type, &vec![0; payload_len])].concat();
             assert_record_decodes(bytes);
@@ -1858,19 +1859,51 @@ mod tests {
     }
 
     #[quickcheck]
-    fn generated_record_sequence_never_panics(mut records: Vec<(u8, u8, Vec<u8>)>) -> bool {
-        records.truncate(16);
-        let mut bytes = Vec::new();
-        for (record_type, data_type, mut payload) in records {
-            payload.truncate(256);
-            let size = 4 + payload.len() as u16;
-            bytes.extend_from_slice(&size.to_be_bytes());
-            bytes.push(record_type);
-            bytes.push(data_type);
-            bytes.extend_from_slice(&payload);
+    fn mutations_of_schema_valid_records_are_rejected(mutation: u8, selector: usize) -> bool {
+        let bytes = Library::new("mutation")
+            .to_bytes_with_timestamp_policy(1e-3, 1e-9, GdsTimestampPolicy::Zero)
+            .expect("minimal library should serialize");
+        let mut ranges = Vec::new();
+        let mut offset = 0;
+        while offset < bytes.len() {
+            let size = usize::from(u16::from_be_bytes([bytes[offset], bytes[offset + 1]]));
+            ranges.push(offset..offset + size);
+            offset += size;
         }
-        bytes.extend_from_slice(&[0, 4, GDSRecord::EndLib as u8, GDSDataType::NoData as u8]);
 
-        std::panic::catch_unwind(|| Library::from_bytes(&bytes, None)).is_ok()
+        let mutated = match mutation % 3 {
+            0 => {
+                let mut mutated = bytes;
+                let range = &ranges[selector % ranges.len()];
+                mutated[range.start..range.start + 2].copy_from_slice(&u16::MAX.to_be_bytes());
+                mutated
+            }
+            1 => {
+                let range = &ranges[[0, 1, 3][selector % 3]];
+                let mut mutated = bytes;
+                let new_size = range.len() - 2;
+                mutated[range.start..range.start + 2]
+                    .copy_from_slice(&(new_size as u16).to_be_bytes());
+                mutated.drain(range.end - 2..range.end);
+                mutated
+            }
+            _ => {
+                let first = selector % (ranges.len() - 1);
+                let left = &ranges[first];
+                let right = &ranges[first + 1];
+                [
+                    &bytes[..left.start],
+                    &bytes[right.clone()],
+                    &bytes[left.clone()],
+                    &bytes[right.end..],
+                ]
+                .concat()
+            }
+        };
+
+        matches!(
+            std::panic::catch_unwind(|| Library::from_bytes(&mutated, None)),
+            Ok(Err(GdsError::InvalidData { .. }))
+        )
     }
 }

--- a/crates/gdsr/src/io/read/mod.rs
+++ b/crates/gdsr/src/io/read/mod.rs
@@ -20,7 +20,7 @@ enum ParserState {
     BeginLibrary,
     LibraryName(u8),
     LibraryOptions(u8),
-    Format,
+    Format(FormatKind),
     Masks,
     EndMasks,
     Library,
@@ -33,7 +33,7 @@ enum ParserState {
 
 impl ParserState {
     #[inline]
-    fn accept(&mut self, record: GDSRecord) -> Result<(), GdsError> {
+    fn accept(&mut self, record: GDSRecord, data: &GDSRecordData) -> Result<(), GdsError> {
         *self = match (*self, record) {
             (Self::Header, GDSRecord::Header) => Self::BeginLibrary,
             (Self::BeginLibrary, GDSRecord::BgnLib) => Self::LibraryName(0),
@@ -45,13 +45,14 @@ impl ParserState {
             (Self::LibraryOptions(0 | 1), GDSRecord::Fonts) => Self::LibraryOptions(2),
             (Self::LibraryOptions(0..=2), GDSRecord::AttrTable) => Self::LibraryOptions(3),
             (Self::LibraryOptions(0..=3), GDSRecord::Generations) => Self::LibraryOptions(4),
-            (Self::LibraryOptions(_), GDSRecord::Format) => Self::Format,
-            (Self::Format, GDSRecord::Mask) => Self::Masks,
+            (Self::LibraryOptions(_), GDSRecord::Format) => Self::Format(FormatKind::from(data)?),
+            (Self::Format(FormatKind::Filtered), GDSRecord::Mask) => Self::Masks,
             (Self::Masks, GDSRecord::Mask) => Self::Masks,
             (Self::Masks, GDSRecord::EndMasks) => Self::EndMasks,
-            (Self::LibraryOptions(_) | Self::Format | Self::EndMasks, GDSRecord::Units) => {
-                Self::Library
-            }
+            (
+                Self::LibraryOptions(_) | Self::Format(FormatKind::Archive) | Self::EndMasks,
+                GDSRecord::Units,
+            ) => Self::Library,
             (Self::Library, GDSRecord::PropAttr) => Self::LibraryProperty,
             (Self::LibraryProperty, GDSRecord::PropValue) => Self::Library,
             (Self::Library, GDSRecord::BgnStr) => Self::StructureName,
@@ -90,12 +91,28 @@ impl ParserState {
                 Self::Structure(1)
             }
             (Self::Element(mut element), record) => {
-                element.accept(record)?;
+                element.accept(record, data)?;
                 Self::Element(element)
             }
             (state, record) => return Err(invalid_parser_state(record, state)),
         };
         Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum FormatKind {
+    Archive,
+    Filtered,
+}
+
+impl FormatKind {
+    fn from(data: &GDSRecordData) -> Result<Self, GdsError> {
+        match data {
+            GDSRecordData::I16(values) if values.as_slice() == [0] => Ok(Self::Archive),
+            GDSRecordData::I16(values) if values.as_slice() == [1] => Ok(Self::Filtered),
+            _ => Err(invalid_data("FORMAT must be 0 (archive) or 1 (filtered)")),
+        }
     }
 }
 
@@ -127,7 +144,7 @@ impl ElementState {
     }
 
     #[inline]
-    fn accept(&mut self, record: GDSRecord) -> Result<(), GdsError> {
+    fn accept(&mut self, record: GDSRecord, data: &GDSRecordData) -> Result<(), GdsError> {
         if self.property_pending {
             if record == GDSRecord::PropValue {
                 self.property_pending = false;
@@ -186,6 +203,9 @@ impl ElementState {
             (ElementKind::Text, 11, GDSRecord::String) => 12,
             _ => return self.unexpected(record),
         };
+        if record == GDSRecord::XY {
+            self.validate_xy(data)?;
+        }
         self.phase = next_phase;
         Ok(())
     }
@@ -219,6 +239,30 @@ impl ElementState {
             "Unexpected {record:?} record in {:?} element",
             self.kind
         )))
+    }
+
+    fn validate_xy(self, data: &GDSRecordData) -> Result<(), GdsError> {
+        let GDSRecordData::I32(values) = data else {
+            return Err(invalid_data("Invalid XY record data"));
+        };
+        let pair_count = values.len() / 2;
+        let closed = values.len() >= 4 && values[..2] == values[values.len() - 2..];
+        let valid = match self.kind {
+            ElementKind::Boundary => pair_count >= 4 && closed,
+            ElementKind::Path => pair_count >= 2,
+            ElementKind::Box => pair_count == 5 && closed,
+            ElementKind::SRef | ElementKind::Text => pair_count == 1,
+            ElementKind::ARef => pair_count == 3,
+            ElementKind::Node => pair_count >= 1,
+        };
+        if valid {
+            Ok(())
+        } else {
+            Err(invalid_data(format!(
+                "Invalid XY coordinates for {:?} element",
+                self.kind
+            )))
+        }
     }
 }
 
@@ -262,7 +306,7 @@ where
 
     for record in reader {
         let record = record.and_then(|(record_type, data)| {
-            state.accept(record_type)?;
+            state.accept(record_type, &data)?;
             Ok((record_type, data))
         });
         match record {
@@ -522,6 +566,11 @@ where
                 }
                 GDSRecord::ColRow => {
                     if let GDSRecordData::I16(col_row) = data {
+                        if !col_row.iter().all(|value| (1..=i16::MAX).contains(value)) {
+                            return Err(invalid_data(
+                                "COLROW columns and rows must be between 1 and 32767",
+                            ));
+                        }
                         if let Some(reference) = &mut reference {
                             reference.grid.set_columns(col_row[0] as u32);
                             reference.grid.set_rows(col_row[1] as u32);
@@ -638,7 +687,7 @@ where
         ParserState::BeginLibrary => Err(invalid_data("Unexpected EOF before BGNLIB record")),
         ParserState::LibraryName(_) => Err(invalid_data("Unexpected EOF before LIBNAME record")),
         ParserState::LibraryOptions(_)
-        | ParserState::Format
+        | ParserState::Format(_)
         | ParserState::Masks
         | ParserState::EndMasks => Err(invalid_data("Unexpected EOF before UNITS record")),
         ParserState::LibraryProperty | ParserState::StructureProperty => {
@@ -1390,11 +1439,11 @@ mod tests {
     #[test]
     fn every_supported_element_requires_its_mandatory_records() {
         let i16_field = |record_type| (record_type, GDSDataType::TwoByteSignedInteger, vec![0, 1]);
-        let xy = || {
+        let xy = |pair_count: usize| {
             (
                 GDSRecord::XY,
                 GDSDataType::FourByteSignedInteger,
-                vec![0; 8],
+                vec![0; pair_count * 8],
             )
         };
         let cases = [
@@ -1404,7 +1453,7 @@ mod tests {
                     (GDSRecord::Boundary, GDSDataType::NoData, vec![]),
                     i16_field(GDSRecord::Layer),
                     i16_field(GDSRecord::DataType),
-                    xy(),
+                    xy(4),
                 ],
             ),
             (
@@ -1413,7 +1462,7 @@ mod tests {
                     (GDSRecord::Path, GDSDataType::NoData, vec![]),
                     i16_field(GDSRecord::Layer),
                     i16_field(GDSRecord::DataType),
-                    xy(),
+                    xy(2),
                 ],
             ),
             (
@@ -1422,7 +1471,7 @@ mod tests {
                     (GDSRecord::Box, GDSDataType::NoData, vec![]),
                     i16_field(GDSRecord::Layer),
                     i16_field(GDSRecord::BoxType),
-                    xy(),
+                    xy(5),
                 ],
             ),
             (
@@ -1431,7 +1480,7 @@ mod tests {
                     (GDSRecord::Node, GDSDataType::NoData, vec![]),
                     i16_field(GDSRecord::Layer),
                     i16_field(GDSRecord::NodeType),
-                    xy(),
+                    xy(1),
                 ],
             ),
             (
@@ -1439,7 +1488,7 @@ mod tests {
                 vec![
                     (GDSRecord::SRef, GDSDataType::NoData, vec![]),
                     (GDSRecord::SName, GDSDataType::AsciiString, b"c\0".to_vec()),
-                    xy(),
+                    xy(1),
                 ],
             ),
             (
@@ -1465,7 +1514,7 @@ mod tests {
                     (GDSRecord::Text, GDSDataType::NoData, vec![]),
                     i16_field(GDSRecord::Layer),
                     i16_field(GDSRecord::TextType),
-                    xy(),
+                    xy(1),
                     (GDSRecord::String, GDSDataType::AsciiString, b"x\0".to_vec()),
                 ],
             ),
@@ -1487,6 +1536,59 @@ mod tests {
                     records[missing].0
                 );
             }
+
+            let unclosed = |pair_count: usize| {
+                let mut payload = vec![0; pair_count * 8];
+                let last = payload.len() - 1;
+                payload[last] = 1;
+                payload
+            };
+            let invalid_xy_payloads = match name {
+                "BOUNDARY" => vec![vec![0; 24], unclosed(4)],
+                "PATH" => vec![vec![0; 8]],
+                "BOX" => vec![vec![0; 32], vec![0; 48], unclosed(5)],
+                "SREF" | "TEXT" => vec![vec![0; 16]],
+                "AREF" => vec![vec![0; 16], vec![0; 32]],
+                "NODE" => vec![vec![]],
+                _ => Vec::new(),
+            };
+            for payload in invalid_xy_payloads {
+                let mut malformed = records.clone();
+                malformed
+                    .iter_mut()
+                    .find(|(record_type, _, _)| *record_type == GDSRecord::XY)
+                    .expect("element should contain XY")
+                    .2 = payload;
+                assert_invalid(&Library::from_bytes(&element_stream(&malformed), None));
+            }
+        }
+    }
+
+    #[test]
+    fn aref_colrow_values_must_be_positive_i16_values() {
+        let aref = |colrow| {
+            vec![
+                (GDSRecord::ARef, GDSDataType::NoData, vec![]),
+                (GDSRecord::SName, GDSDataType::AsciiString, b"c\0".to_vec()),
+                (GDSRecord::ColRow, GDSDataType::TwoByteSignedInteger, colrow),
+                (
+                    GDSRecord::XY,
+                    GDSDataType::FourByteSignedInteger,
+                    vec![0; 24],
+                ),
+            ]
+        };
+
+        Library::from_bytes(&element_stream(&aref(vec![0x7f, 0xff, 0x7f, 0xff])), None)
+            .expect("maximum positive COLROW values should parse");
+
+        for colrow in [
+            vec![0, 0, 0, 1],
+            vec![0, 1, 0, 0],
+            vec![0xff, 0xff, 0, 1],
+            vec![0, 1, 0xff, 0xff],
+        ] {
+            assert_invalid(&Library::from_bytes(&element_stream(&aref(colrow)), None));
         }
     }
 
@@ -1512,7 +1614,7 @@ mod tests {
             (
                 GDSRecord::XY,
                 GDSDataType::FourByteSignedInteger,
-                vec![0; 8],
+                vec![0; 32],
             ),
         ];
 
@@ -1605,7 +1707,12 @@ mod tests {
 
     #[test]
     fn library_option_and_format_mask_order_is_enforced() {
-        let format = (
+        let archive_format = (
+            GDSRecord::Format,
+            GDSDataType::TwoByteSignedInteger,
+            vec![0, 0],
+        );
+        let filtered_format = (
             GDSRecord::Format,
             GDSDataType::TwoByteSignedInteger,
             vec![0, 1],
@@ -1614,14 +1721,34 @@ mod tests {
         let end_masks = (GDSRecord::EndMasks, GDSDataType::NoData, vec![]);
 
         Library::from_bytes(
-            &library_with_options(&[format.clone(), mask.clone(), end_masks.clone()], &[]),
+            &library_with_options(std::slice::from_ref(&archive_format), &[]),
             None,
         )
-        .expect("complete FORMAT/MASK section should parse");
+        .expect("archive FORMAT should proceed directly to UNITS");
+        Library::from_bytes(
+            &library_with_options(
+                &[
+                    filtered_format.clone(),
+                    mask.clone(),
+                    mask.clone(),
+                    end_masks.clone(),
+                ],
+                &[],
+            ),
+            None,
+        )
+        .expect("filtered FORMAT with complete MASK section should parse");
 
         for options in [
-            vec![format.clone(), mask],
-            vec![format, end_masks],
+            vec![archive_format, mask.clone(), end_masks.clone()],
+            vec![filtered_format.clone()],
+            vec![filtered_format.clone(), mask],
+            vec![filtered_format, end_masks],
+            vec![(
+                GDSRecord::Format,
+                GDSDataType::TwoByteSignedInteger,
+                vec![0, 2],
+            )],
             vec![
                 (GDSRecord::Fonts, GDSDataType::AsciiString, vec![0; 176]),
                 (GDSRecord::RefLibs, GDSDataType::AsciiString, vec![0; 88]),

--- a/crates/gdsr/src/io/read/mod.rs
+++ b/crates/gdsr/src/io/read/mod.rs
@@ -16,19 +16,209 @@ use crate::{
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ParserState {
+    Header,
+    BeginLibrary,
+    LibraryName(u8),
+    LibraryOptions(u8),
+    Format,
+    Masks,
+    EndMasks,
     Library,
-    Structure,
-    Element,
+    LibraryProperty,
+    StructureName,
+    Structure(u8),
+    StructureProperty,
+    Element(ElementState),
 }
 
 impl ParserState {
     #[inline]
-    fn require(self, expected: Self, record: GDSRecord) -> Result<(), GdsError> {
-        if self == expected {
+    fn accept(&mut self, record: GDSRecord) -> Result<(), GdsError> {
+        *self = match (*self, record) {
+            (Self::Header, GDSRecord::Header) => Self::BeginLibrary,
+            (Self::BeginLibrary, GDSRecord::BgnLib) => Self::LibraryName(0),
+            (Self::LibraryName(0), GDSRecord::LibDirSize) => Self::LibraryName(1),
+            (Self::LibraryName(0 | 1), GDSRecord::SrfName) => Self::LibraryName(2),
+            (Self::LibraryName(0..=2), GDSRecord::LibSecure) => Self::LibraryName(3),
+            (Self::LibraryName(_), GDSRecord::LibName) => Self::LibraryOptions(0),
+            (Self::LibraryOptions(0), GDSRecord::RefLibs) => Self::LibraryOptions(1),
+            (Self::LibraryOptions(0 | 1), GDSRecord::Fonts) => Self::LibraryOptions(2),
+            (Self::LibraryOptions(0..=2), GDSRecord::AttrTable) => Self::LibraryOptions(3),
+            (Self::LibraryOptions(0..=3), GDSRecord::Generations) => Self::LibraryOptions(4),
+            (Self::LibraryOptions(_), GDSRecord::Format) => Self::Format,
+            (Self::Format, GDSRecord::Mask) => Self::Masks,
+            (Self::Masks, GDSRecord::Mask) => Self::Masks,
+            (Self::Masks, GDSRecord::EndMasks) => Self::EndMasks,
+            (Self::LibraryOptions(_) | Self::Format | Self::EndMasks, GDSRecord::Units) => {
+                Self::Library
+            }
+            (Self::Library, GDSRecord::PropAttr) => Self::LibraryProperty,
+            (Self::LibraryProperty, GDSRecord::PropValue) => Self::Library,
+            (Self::Library, GDSRecord::BgnStr) => Self::StructureName,
+            (Self::Library, GDSRecord::EndLib) => Self::Library,
+            (Self::StructureName, GDSRecord::StrName) => Self::Structure(0),
+            (Self::Structure(0), GDSRecord::StrClass) => Self::Structure(1),
+            (Self::Structure(_), GDSRecord::PropAttr) => Self::StructureProperty,
+            (Self::StructureProperty, GDSRecord::PropValue) => Self::Structure(1),
+            (Self::Structure(_), GDSRecord::Boundary) => {
+                Self::Element(ElementState::new(ElementKind::Boundary))
+            }
+            (Self::Structure(_), GDSRecord::Path) => {
+                Self::Element(ElementState::new(ElementKind::Path))
+            }
+            (Self::Structure(_), GDSRecord::Box) => {
+                Self::Element(ElementState::new(ElementKind::Box))
+            }
+            (Self::Structure(_), GDSRecord::Node) => {
+                Self::Element(ElementState::new(ElementKind::Node))
+            }
+            (Self::Structure(_), GDSRecord::SRef) => {
+                Self::Element(ElementState::new(ElementKind::SRef))
+            }
+            (Self::Structure(_), GDSRecord::ARef) => {
+                Self::Element(ElementState::new(ElementKind::ARef))
+            }
+            (Self::Structure(_), GDSRecord::Text) => {
+                Self::Element(ElementState::new(ElementKind::Text))
+            }
+            (Self::Structure(_), GDSRecord::TextNode) => {
+                return Err(invalid_data("TEXTNODE elements are unsupported"));
+            }
+            (Self::Structure(_), GDSRecord::EndStr) => Self::Library,
+            (Self::Element(element), GDSRecord::EndEl) => {
+                element.finish()?;
+                Self::Structure(1)
+            }
+            (Self::Element(mut element), record) => {
+                element.accept(record)?;
+                Self::Element(element)
+            }
+            (state, record) => return Err(invalid_parser_state(record, state)),
+        };
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ElementKind {
+    Boundary,
+    Path,
+    Box,
+    Node,
+    SRef,
+    ARef,
+    Text,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct ElementState {
+    kind: ElementKind,
+    phase: u8,
+    property_pending: bool,
+}
+
+impl ElementState {
+    const fn new(kind: ElementKind) -> Self {
+        Self {
+            kind,
+            phase: 0,
+            property_pending: false,
+        }
+    }
+
+    #[inline]
+    fn accept(&mut self, record: GDSRecord) -> Result<(), GdsError> {
+        if self.property_pending {
+            if record == GDSRecord::PropValue {
+                self.property_pending = false;
+                return Ok(());
+            }
+            return self.unexpected(record);
+        }
+
+        if record == GDSRecord::PropAttr && self.is_complete() {
+            self.property_pending = true;
+            return Ok(());
+        }
+        if record == GDSRecord::ElFlags && self.phase == 0 {
+            self.phase = 1;
+            return Ok(());
+        }
+        if record == GDSRecord::Plex && self.phase <= 1 {
+            self.phase = 2;
+            return Ok(());
+        }
+
+        let next_phase = match (self.kind, self.phase, record) {
+            (
+                ElementKind::Boundary
+                | ElementKind::Path
+                | ElementKind::Box
+                | ElementKind::Node
+                | ElementKind::Text,
+                0..=2,
+                GDSRecord::Layer,
+            ) => 3,
+            (ElementKind::Boundary | ElementKind::Path, 3, GDSRecord::DataType)
+            | (ElementKind::Box, 3, GDSRecord::BoxType)
+            | (ElementKind::Node, 3, GDSRecord::NodeType)
+            | (ElementKind::Text, 3, GDSRecord::TextType) => 4,
+            (ElementKind::Boundary | ElementKind::Box | ElementKind::Node, 4, GDSRecord::XY) => 5,
+            (ElementKind::Path, 4, GDSRecord::PathType) => 5,
+            (ElementKind::Path, 4..=5, GDSRecord::Width) => 6,
+            (ElementKind::Path, 4..=6, GDSRecord::BgnExtn) => 7,
+            (ElementKind::Path, 4..=7, GDSRecord::EndExtn) => 8,
+            (ElementKind::Path, 4..=8, GDSRecord::XY) => 9,
+            (ElementKind::SRef | ElementKind::ARef, 0..=2, GDSRecord::SName) => 3,
+            (ElementKind::SRef | ElementKind::ARef, 3, GDSRecord::STrans) => 4,
+            (ElementKind::SRef | ElementKind::ARef, 4, GDSRecord::Mag) => 5,
+            (ElementKind::SRef | ElementKind::ARef, 4..=5, GDSRecord::Angle) => 6,
+            (ElementKind::SRef, 3..=6, GDSRecord::XY) => 7,
+            (ElementKind::ARef, 3..=6, GDSRecord::ColRow) => 7,
+            (ElementKind::ARef, 7, GDSRecord::XY) => 8,
+            (ElementKind::Text, 4, GDSRecord::Presentation) => 5,
+            (ElementKind::Text, 4..=5, GDSRecord::PathType) => 6,
+            (ElementKind::Text, 4..=6, GDSRecord::Width) => 7,
+            (ElementKind::Text, 4..=7, GDSRecord::STrans) => 8,
+            (ElementKind::Text, 8, GDSRecord::Mag) => 9,
+            (ElementKind::Text, 8..=9, GDSRecord::Angle) => 10,
+            (ElementKind::Text, 4..=10, GDSRecord::XY) => 11,
+            (ElementKind::Text, 11, GDSRecord::String) => 12,
+            _ => return self.unexpected(record),
+        };
+        self.phase = next_phase;
+        Ok(())
+    }
+
+    fn finish(self) -> Result<(), GdsError> {
+        if self.is_complete() && !self.property_pending {
             Ok(())
         } else {
-            Err(invalid_parser_state(record, self))
+            Err(invalid_data(format!(
+                "Incomplete {:?} element before ENDEL",
+                self.kind
+            )))
         }
+    }
+
+    const fn is_complete(self) -> bool {
+        matches!(
+            (self.kind, self.phase),
+            (
+                ElementKind::Boundary | ElementKind::Box | ElementKind::Node,
+                5
+            ) | (ElementKind::Path, 9)
+                | (ElementKind::SRef, 7)
+                | (ElementKind::ARef, 8)
+                | (ElementKind::Text, 12)
+        )
+    }
+
+    fn unexpected<T>(self, record: GDSRecord) -> Result<T, GdsError> {
+        Err(invalid_data(format!(
+            "Unexpected {record:?} record in {:?} element",
+            self.kind
+        )))
     }
 }
 
@@ -65,12 +255,16 @@ where
     let mut text: Option<Text> = None;
     let mut reference: Option<Reference> = None;
     let mut property_attribute: Option<u16> = None;
-    let mut state = ParserState::Library;
+    let mut state = ParserState::Header;
 
     let mut scale = 1.0;
     let mut db_units = units.unwrap_or(DEFAULT_INTEGER_UNITS);
 
     for record in reader {
+        let record = record.and_then(|(record_type, data)| {
+            state.accept(record_type)?;
+            Ok((record_type, data))
+        });
         match record {
             Ok((record_type, data)) => match record_type {
                 GDSRecord::BgnLib => {
@@ -95,72 +289,55 @@ where
                     }
                 }
                 GDSRecord::BgnStr => {
-                    state.require(ParserState::Library, record_type)?;
                     let GDSRecordData::I16(values) = data else {
                         return Err(invalid_timestamp_record("BGNSTR"));
                     };
                     let mut new_cell = Cell::default();
                     new_cell.set_timestamps(GdsTimestamps::from_record(&values, "BGNSTR")?);
                     cell = Some(new_cell);
-                    state = ParserState::Structure;
                 }
                 GDSRecord::StrName => {
-                    if let GDSRecordData::Str(cell_name) = data {
-                        if let Some(cell) = &mut cell {
-                            cell.set_name(&cell_name);
-                        }
+                    let GDSRecordData::Str(cell_name) = data else {
+                        return Err(invalid_data("Empty STRNAME record"));
+                    };
+                    if cell_name.is_empty() {
+                        return Err(invalid_data("Empty STRNAME record"));
+                    }
+                    if let Some(cell) = &mut cell {
+                        cell.set_name(&cell_name);
                     }
                 }
                 GDSRecord::EndStr => {
-                    state.require(ParserState::Structure, record_type)?;
                     if let Some(cell) = cell.take() {
                         library.cells.insert(cell.name().to_string(), cell);
                     }
-                    state = ParserState::Library;
                 }
                 GDSRecord::EndLib => {
-                    state.require(ParserState::Library, record_type)?;
                     return Ok(library);
                 }
                 GDSRecord::Boundary => {
-                    state.require(ParserState::Structure, record_type)?;
                     property_attribute = None;
                     polygon = Some(Polygon::default());
-                    state = ParserState::Element;
                 }
                 GDSRecord::Box => {
-                    state.require(ParserState::Structure, record_type)?;
                     property_attribute = None;
                     gds_box = Some(GdsBox::default());
-                    state = ParserState::Element;
                 }
                 GDSRecord::Node => {
-                    state.require(ParserState::Structure, record_type)?;
                     property_attribute = None;
                     node = Some(Node::default());
-                    state = ParserState::Element;
                 }
                 GDSRecord::Path => {
-                    state.require(ParserState::Structure, record_type)?;
                     property_attribute = None;
                     path = Some(Path::default());
-                    state = ParserState::Element;
                 }
                 GDSRecord::ARef | GDSRecord::SRef => {
-                    state.require(ParserState::Structure, record_type)?;
                     property_attribute = None;
                     reference = Some(Reference::default());
-                    state = ParserState::Element;
                 }
                 GDSRecord::Text => {
-                    state.require(ParserState::Structure, record_type)?;
                     property_attribute = None;
                     text = Some(Text::default());
-                    state = ParserState::Element;
-                }
-                GDSRecord::TextNode => {
-                    state.require(ParserState::Structure, record_type)?;
-                    state = ParserState::Element;
                 }
                 GDSRecord::Layer => {
                     if let GDSRecordData::I16(layer) = data {
@@ -297,7 +474,6 @@ where
                     }
                 }
                 GDSRecord::EndEl => {
-                    state.require(ParserState::Element, record_type)?;
                     if let Some(cell) = &mut cell {
                         if let Some(polygon) = polygon.take() {
                             if layer_filter(polygon.layer, polygon.data_type) {
@@ -330,14 +506,17 @@ where
                     text = None;
                     reference = None;
                     property_attribute = None;
-                    state = ParserState::Structure;
                 }
                 GDSRecord::SName => {
-                    if let GDSRecordData::Str(cell_name) = data {
-                        if let Some(reference) = &mut reference {
-                            if let Instance::Cell(_) = reference.instance {
-                                reference.instance = Instance::Cell(cell_name);
-                            }
+                    let GDSRecordData::Str(cell_name) = data else {
+                        return Err(invalid_data("Empty SNAME record"));
+                    };
+                    if cell_name.is_empty() {
+                        return Err(invalid_data("Empty SNAME record"));
+                    }
+                    if let Some(reference) = &mut reference {
+                        if let Instance::Cell(_) = reference.instance {
+                            reference.instance = Instance::Cell(cell_name);
                         }
                     }
                 }
@@ -450,13 +629,24 @@ where
                 }
                 _ => {}
             },
-            Err(e) => return Err(e),
+            Err(error) => return Err(error),
         }
     }
 
     match state {
-        ParserState::Element => Err(invalid_data("Unexpected EOF before ENDEL record")),
-        ParserState::Structure => Err(invalid_data("Unexpected EOF before ENDSTR record")),
+        ParserState::Header => Err(invalid_data("Unexpected EOF before HEADER record")),
+        ParserState::BeginLibrary => Err(invalid_data("Unexpected EOF before BGNLIB record")),
+        ParserState::LibraryName(_) => Err(invalid_data("Unexpected EOF before LIBNAME record")),
+        ParserState::LibraryOptions(_)
+        | ParserState::Format
+        | ParserState::Masks
+        | ParserState::EndMasks => Err(invalid_data("Unexpected EOF before UNITS record")),
+        ParserState::LibraryProperty | ParserState::StructureProperty => {
+            Err(invalid_data("Unexpected EOF before PROPVALUE record"))
+        }
+        ParserState::Element(_) => Err(invalid_data("Unexpected EOF before ENDEL record")),
+        ParserState::StructureName => Err(invalid_data("Unexpected EOF before STRNAME record")),
+        ParserState::Structure(_) => Err(invalid_data("Unexpected EOF before ENDSTR record")),
         ParserState::Library => Err(invalid_data("Unexpected EOF before ENDLIB record")),
     }
 }
@@ -590,6 +780,18 @@ impl<R: Read> Iterator for RecordReader<R> {
             return Some(Err(invalid_data(format!(
                 "Invalid {record:?} payload length: expected {expected_payload_len} bytes, found {payload_len}"
             ))));
+        }
+        if record == GDSRecord::LibSecure
+            && (!(6..=192).contains(&payload_len) || !payload_len.is_multiple_of(6))
+        {
+            return Some(Err(invalid_data(format!(
+                "Invalid LibSecure payload length: expected 6 to 192 bytes in six-byte ACL entries, found {payload_len}"
+            ))));
+        }
+        if record == GDSRecord::XY && payload_len < 8 {
+            return Some(Err(invalid_data(
+                "Invalid XY payload length: expected at least one coordinate pair",
+            )));
         }
 
         let data = if payload_len == 0 {
@@ -746,7 +948,11 @@ const RECORD_LAYOUTS: [RecordLayout; 60] = [
     layout(GDSRecord::EndMasks, NoData, 0),
     layout(GDSRecord::LibDirSize, TwoByteSignedInteger, 2),
     layout(GDSRecord::SrfName, AsciiString, VARIABLE_PAYLOAD_LEN),
-    layout(GDSRecord::LibSecure, TwoByteSignedInteger, 2),
+    layout(
+        GDSRecord::LibSecure,
+        TwoByteSignedInteger,
+        VARIABLE_PAYLOAD_LEN,
+    ),
 ];
 
 #[cold]
@@ -855,6 +1061,84 @@ mod tests {
         assert!(matches!(result, Err(GdsError::InvalidData { .. })));
     }
 
+    fn assert_record_decodes(bytes: Vec<u8>) {
+        let mut reader = RecordReader::new(BufReader::new(Cursor::new(bytes)));
+        assert!(matches!(reader.next(), Some(Ok(_))));
+    }
+
+    fn assert_record_is_invalid(bytes: Vec<u8>) {
+        let mut reader = RecordReader::new(BufReader::new(Cursor::new(bytes)));
+        assert!(matches!(
+            reader.next(),
+            Some(Err(GdsError::InvalidData { .. }))
+        ));
+    }
+
+    fn library_prefix() -> Vec<u8> {
+        let mut bytes = Library::new("minimal")
+            .to_bytes_with_timestamp_policy(1e-3, 1e-9, GdsTimestampPolicy::Zero)
+            .expect("minimal library should serialize");
+        bytes.truncate(bytes.len() - 4);
+        bytes
+    }
+
+    fn structure_prefix() -> Vec<u8> {
+        [
+            library_prefix(),
+            record(
+                GDSRecord::BgnStr,
+                GDSDataType::TwoByteSignedInteger,
+                &[0; 24],
+            ),
+            record(GDSRecord::StrName, GDSDataType::AsciiString, b"s\0"),
+        ]
+        .concat()
+    }
+
+    fn library_with_options(
+        before_units: &[(GDSRecord, GDSDataType, Vec<u8>)],
+        after_units: &[(GDSRecord, GDSDataType, Vec<u8>)],
+    ) -> Vec<u8> {
+        let mut bytes = [
+            record(
+                GDSRecord::Header,
+                GDSDataType::TwoByteSignedInteger,
+                &[0, 7],
+            ),
+            record(
+                GDSRecord::BgnLib,
+                GDSDataType::TwoByteSignedInteger,
+                &[0; 24],
+            ),
+            record(GDSRecord::LibName, GDSDataType::AsciiString, b"l\0"),
+        ]
+        .concat();
+        for (record_type, data_type, payload) in before_units {
+            bytes.extend_from_slice(&record(*record_type, *data_type, payload));
+        }
+        bytes.extend_from_slice(&record(
+            GDSRecord::Units,
+            GDSDataType::EightByteReal,
+            &[0; 16],
+        ));
+        for (record_type, data_type, payload) in after_units {
+            bytes.extend_from_slice(&record(*record_type, *data_type, payload));
+        }
+        bytes.extend_from_slice(&record(GDSRecord::EndLib, GDSDataType::NoData, &[]));
+        bytes
+    }
+
+    fn element_stream(records: &[(GDSRecord, GDSDataType, Vec<u8>)]) -> Vec<u8> {
+        let mut bytes = structure_prefix();
+        for (record_type, data_type, payload) in records {
+            bytes.extend_from_slice(&record(*record_type, *data_type, payload));
+        }
+        bytes.extend_from_slice(&record(GDSRecord::EndEl, GDSDataType::NoData, &[]));
+        bytes.extend_from_slice(&record(GDSRecord::EndStr, GDSDataType::NoData, &[]));
+        bytes.extend_from_slice(&record(GDSRecord::EndLib, GDSDataType::NoData, &[]));
+        bytes
+    }
+
     #[test]
     fn malformed_record_layouts_return_invalid_data() {
         let cases = [
@@ -961,11 +1245,7 @@ mod tests {
             .to_bytes_with_timestamp_policy(1e-3, 1e-9, GdsTimestampPolicy::Zero)
             .expect("minimal library should serialize");
         let missing_end_library = &minimal[..minimal.len() - 4];
-        let missing_end_structure = record(
-            GDSRecord::BgnStr,
-            GDSDataType::TwoByteSignedInteger,
-            &[0; 24],
-        );
+        let missing_end_structure = structure_prefix();
         let mut missing_end_element = missing_end_structure.clone();
         missing_end_element.extend_from_slice(&record(
             GDSRecord::Boundary,
@@ -999,21 +1279,11 @@ mod tests {
             (GDSRecord::TapeNum, GDSDataType::TwoByteSignedInteger, 2),
             (GDSRecord::TapeCode, GDSDataType::TwoByteSignedInteger, 12),
         ] {
-            let bytes = [
-                record(record_type, data_type, &vec![0; payload_len]),
-                record(GDSRecord::EndLib, GDSDataType::NoData, &[]),
-            ]
-            .concat();
-            assert!(Library::from_bytes(&bytes, None).is_ok(), "{record_type:?}");
+            let bytes = [record(record_type, data_type, &vec![0; payload_len])].concat();
+            assert_record_decodes(bytes);
 
             let bytes = record(record_type, data_type, &[]);
-            assert!(
-                matches!(
-                    Library::from_bytes(&bytes, None),
-                    Err(GdsError::InvalidData { .. })
-                ),
-                "{record_type:?}"
-            );
+            assert_record_is_invalid(bytes);
         }
 
         for record_type in [
@@ -1024,22 +1294,10 @@ mod tests {
             GDSRecord::PropValue,
         ] {
             let bytes = record(record_type, GDSDataType::TwoByteSignedInteger, &[0, 0]);
-            assert!(
-                matches!(
-                    Library::from_bytes(&bytes, None),
-                    Err(GdsError::InvalidData { .. })
-                ),
-                "{record_type:?}"
-            );
+            assert_record_is_invalid(bytes);
 
             let bytes = record(record_type, GDSDataType::AsciiString, b"x");
-            assert!(
-                matches!(
-                    Library::from_bytes(&bytes, None),
-                    Err(GdsError::InvalidData { .. })
-                ),
-                "{record_type:?}"
-            );
+            assert_record_is_invalid(bytes);
         }
     }
 
@@ -1053,17 +1311,356 @@ mod tests {
                 (expected_payload_len - 2, false),
                 (expected_payload_len + 2, false),
             ] {
-                let bytes = [
-                    record(record_type, GDSDataType::AsciiString, &vec![0; payload_len]),
-                    record(GDSRecord::EndLib, GDSDataType::NoData, &[]),
-                ]
-                .concat();
-                assert_eq!(
-                    Library::from_bytes(&bytes, None).is_ok(),
-                    is_valid,
-                    "{record_type:?} payload length {payload_len}"
+                let bytes = record(record_type, GDSDataType::AsciiString, &vec![0; payload_len]);
+                let mut reader = RecordReader::new(BufReader::new(Cursor::new(bytes)));
+                assert_eq!(matches!(reader.next(), Some(Ok(_))), is_valid);
+            }
+        }
+    }
+
+    #[test]
+    fn invalid_library_structure_and_element_phases_are_rejected() {
+        let mut missing_structure_name = library_prefix();
+        missing_structure_name.extend_from_slice(&record(
+            GDSRecord::BgnStr,
+            GDSDataType::TwoByteSignedInteger,
+            &[0; 24],
+        ));
+        missing_structure_name.extend_from_slice(&record(
+            GDSRecord::EndStr,
+            GDSDataType::NoData,
+            &[],
+        ));
+
+        let mut empty_structure_name = library_prefix();
+        empty_structure_name.extend_from_slice(&record(
+            GDSRecord::BgnStr,
+            GDSDataType::TwoByteSignedInteger,
+            &[0; 24],
+        ));
+        empty_structure_name.extend_from_slice(&record(
+            GDSRecord::StrName,
+            GDSDataType::AsciiString,
+            &[],
+        ));
+
+        let mut incomplete_boundary = structure_prefix();
+        incomplete_boundary.extend_from_slice(&record(
+            GDSRecord::Boundary,
+            GDSDataType::NoData,
+            &[],
+        ));
+        incomplete_boundary.extend_from_slice(&record(GDSRecord::EndEl, GDSDataType::NoData, &[]));
+
+        let mut library_record_in_element = structure_prefix();
+        library_record_in_element.extend_from_slice(&record(
+            GDSRecord::Boundary,
+            GDSDataType::NoData,
+            &[],
+        ));
+        library_record_in_element.extend_from_slice(&record(
+            GDSRecord::BgnLib,
+            GDSDataType::TwoByteSignedInteger,
+            &[0; 24],
+        ));
+
+        for (name, bytes) in [
+            (
+                "ENDLIB without a library preamble",
+                record(GDSRecord::EndLib, GDSDataType::NoData, &[]),
+            ),
+            ("ENDSTR without STRNAME", missing_structure_name),
+            ("empty STRNAME", empty_structure_name),
+            ("BOUNDARY without mandatory fields", incomplete_boundary),
+            (
+                "library record inside an element",
+                library_record_in_element,
+            ),
+        ] {
+            assert!(
+                matches!(
+                    Library::from_bytes(&bytes, None),
+                    Err(GdsError::InvalidData { .. })
+                ),
+                "{name}"
+            );
+        }
+    }
+
+    #[test]
+    fn every_supported_element_requires_its_mandatory_records() {
+        let i16_field = |record_type| (record_type, GDSDataType::TwoByteSignedInteger, vec![0, 1]);
+        let xy = || {
+            (
+                GDSRecord::XY,
+                GDSDataType::FourByteSignedInteger,
+                vec![0; 8],
+            )
+        };
+        let cases = [
+            (
+                "BOUNDARY",
+                vec![
+                    (GDSRecord::Boundary, GDSDataType::NoData, vec![]),
+                    i16_field(GDSRecord::Layer),
+                    i16_field(GDSRecord::DataType),
+                    xy(),
+                ],
+            ),
+            (
+                "PATH",
+                vec![
+                    (GDSRecord::Path, GDSDataType::NoData, vec![]),
+                    i16_field(GDSRecord::Layer),
+                    i16_field(GDSRecord::DataType),
+                    xy(),
+                ],
+            ),
+            (
+                "BOX",
+                vec![
+                    (GDSRecord::Box, GDSDataType::NoData, vec![]),
+                    i16_field(GDSRecord::Layer),
+                    i16_field(GDSRecord::BoxType),
+                    xy(),
+                ],
+            ),
+            (
+                "NODE",
+                vec![
+                    (GDSRecord::Node, GDSDataType::NoData, vec![]),
+                    i16_field(GDSRecord::Layer),
+                    i16_field(GDSRecord::NodeType),
+                    xy(),
+                ],
+            ),
+            (
+                "SREF",
+                vec![
+                    (GDSRecord::SRef, GDSDataType::NoData, vec![]),
+                    (GDSRecord::SName, GDSDataType::AsciiString, b"c\0".to_vec()),
+                    xy(),
+                ],
+            ),
+            (
+                "AREF",
+                vec![
+                    (GDSRecord::ARef, GDSDataType::NoData, vec![]),
+                    (GDSRecord::SName, GDSDataType::AsciiString, b"c\0".to_vec()),
+                    (
+                        GDSRecord::ColRow,
+                        GDSDataType::TwoByteSignedInteger,
+                        vec![0, 1, 0, 1],
+                    ),
+                    (
+                        GDSRecord::XY,
+                        GDSDataType::FourByteSignedInteger,
+                        vec![0; 24],
+                    ),
+                ],
+            ),
+            (
+                "TEXT",
+                vec![
+                    (GDSRecord::Text, GDSDataType::NoData, vec![]),
+                    i16_field(GDSRecord::Layer),
+                    i16_field(GDSRecord::TextType),
+                    xy(),
+                    (GDSRecord::String, GDSDataType::AsciiString, b"x\0".to_vec()),
+                ],
+            ),
+        ];
+
+        for (name, records) in cases {
+            Library::from_bytes(&element_stream(&records), None)
+                .unwrap_or_else(|error| panic!("{name} should parse: {error}"));
+
+            for missing in 1..records.len() {
+                let mut incomplete = records.clone();
+                incomplete.remove(missing);
+                assert!(
+                    matches!(
+                        Library::from_bytes(&element_stream(&incomplete), None),
+                        Err(GdsError::InvalidData { .. })
+                    ),
+                    "{name} accepted input missing {:?}",
+                    records[missing].0
                 );
             }
+        }
+    }
+
+    #[test]
+    fn textnode_elements_are_explicitly_rejected() {
+        let mut bytes = structure_prefix();
+        bytes.extend_from_slice(&record(GDSRecord::TextNode, GDSDataType::NoData, &[]));
+
+        let error = Library::from_bytes(&bytes, None).expect_err("TEXTNODE is unsupported");
+        assert!(matches!(
+            error,
+            GdsError::InvalidData { ref message } if message.contains("TEXTNODE")
+        ));
+    }
+
+    #[test]
+    fn record_order_uniqueness_and_property_pairing_are_enforced() {
+        let i16_field = |record_type| (record_type, GDSDataType::TwoByteSignedInteger, vec![0, 1]);
+        let valid_boundary = vec![
+            (GDSRecord::Boundary, GDSDataType::NoData, vec![]),
+            i16_field(GDSRecord::Layer),
+            i16_field(GDSRecord::DataType),
+            (
+                GDSRecord::XY,
+                GDSDataType::FourByteSignedInteger,
+                vec![0; 8],
+            ),
+        ];
+
+        let mut wrong_element_order = valid_boundary.clone();
+        wrong_element_order.swap(1, 2);
+        let mut duplicate_element_field = valid_boundary.clone();
+        duplicate_element_field.insert(2, i16_field(GDSRecord::Layer));
+        let property_before_body = vec![
+            (GDSRecord::Boundary, GDSDataType::NoData, vec![]),
+            i16_field(GDSRecord::PropAttr),
+        ];
+        let transform_without_strans = vec![
+            (GDSRecord::SRef, GDSDataType::NoData, vec![]),
+            (GDSRecord::SName, GDSDataType::AsciiString, b"c\0".to_vec()),
+            (GDSRecord::Mag, GDSDataType::EightByteReal, vec![0; 8]),
+        ];
+
+        for (name, bytes) in [
+            ("element field order", element_stream(&wrong_element_order)),
+            (
+                "duplicate element field",
+                element_stream(&duplicate_element_field),
+            ),
+            (
+                "property before body",
+                element_stream(&property_before_body),
+            ),
+            (
+                "transform without STRANS",
+                element_stream(&transform_without_strans),
+            ),
+            (
+                "unpaired file property",
+                library_with_options(
+                    &[],
+                    &[(
+                        GDSRecord::PropAttr,
+                        GDSDataType::TwoByteSignedInteger,
+                        vec![0, 1],
+                    )],
+                ),
+            ),
+        ] {
+            assert!(
+                matches!(
+                    Library::from_bytes(&bytes, None),
+                    Err(GdsError::InvalidData { .. })
+                ),
+                "{name}"
+            );
+        }
+
+        let properties = [
+            (
+                GDSRecord::PropAttr,
+                GDSDataType::TwoByteSignedInteger,
+                vec![0, 1],
+            ),
+            (
+                GDSRecord::PropValue,
+                GDSDataType::AsciiString,
+                b"v\0".to_vec(),
+            ),
+        ];
+        Library::from_bytes(&library_with_options(&[], &properties), None)
+            .expect("paired file property should parse");
+
+        let mut structure_with_property = structure_prefix();
+        for (record_type, data_type, payload) in &properties {
+            structure_with_property.extend_from_slice(&record(*record_type, *data_type, payload));
+        }
+        structure_with_property.extend_from_slice(&record(
+            GDSRecord::EndStr,
+            GDSDataType::NoData,
+            &[],
+        ));
+        structure_with_property.extend_from_slice(&record(
+            GDSRecord::EndLib,
+            GDSDataType::NoData,
+            &[],
+        ));
+        Library::from_bytes(&structure_with_property, None)
+            .expect("paired structure property should parse");
+
+        let mut element_with_property = valid_boundary;
+        element_with_property.extend(properties);
+        Library::from_bytes(&element_stream(&element_with_property), None)
+            .expect("paired element property after its body should parse");
+    }
+
+    #[test]
+    fn library_option_and_format_mask_order_is_enforced() {
+        let format = (
+            GDSRecord::Format,
+            GDSDataType::TwoByteSignedInteger,
+            vec![0, 1],
+        );
+        let mask = (GDSRecord::Mask, GDSDataType::AsciiString, b"m\0".to_vec());
+        let end_masks = (GDSRecord::EndMasks, GDSDataType::NoData, vec![]);
+
+        Library::from_bytes(
+            &library_with_options(&[format.clone(), mask.clone(), end_masks.clone()], &[]),
+            None,
+        )
+        .expect("complete FORMAT/MASK section should parse");
+
+        for options in [
+            vec![format.clone(), mask],
+            vec![format, end_masks],
+            vec![
+                (GDSRecord::Fonts, GDSDataType::AsciiString, vec![0; 176]),
+                (GDSRecord::RefLibs, GDSDataType::AsciiString, vec![0; 88]),
+            ],
+            vec![
+                (
+                    GDSRecord::Generations,
+                    GDSDataType::TwoByteSignedInteger,
+                    vec![0, 1],
+                ),
+                (
+                    GDSRecord::Generations,
+                    GDSDataType::TwoByteSignedInteger,
+                    vec![0, 1],
+                ),
+            ],
+        ] {
+            assert_invalid(&Library::from_bytes(
+                &library_with_options(&options, &[]),
+                None,
+            ));
+        }
+    }
+
+    #[test]
+    fn libsecure_contains_one_to_thirty_two_acl_entries() {
+        for payload_len in [6, 12, 192] {
+            assert_record_decodes(record(
+                GDSRecord::LibSecure,
+                GDSDataType::TwoByteSignedInteger,
+                &vec![0; payload_len],
+            ));
+        }
+        for payload_len in [0, 2, 7, 198] {
+            assert_record_is_invalid(record(
+                GDSRecord::LibSecure,
+                GDSDataType::TwoByteSignedInteger,
+                &vec![0; payload_len],
+            ));
         }
     }
 

--- a/crates/gdsr/src/io/read/mod.rs
+++ b/crates/gdsr/src/io/read/mod.rs
@@ -837,6 +837,13 @@ impl<R: Read> Iterator for RecordReader<R> {
                 "Invalid LibSecure payload length: expected 6 to 192 bytes in six-byte ACL entries, found {payload_len}"
             ))));
         }
+        if record == GDSRecord::UInteger
+            && (!(2..=64).contains(&payload_len) || !payload_len.is_multiple_of(2))
+        {
+            return Some(Err(invalid_data(format!(
+                "Invalid UInteger payload length: expected 2 to 64 bytes in two-byte values, found {payload_len}"
+            ))));
+        }
         if record == GDSRecord::XY && payload_len < 8 {
             return Some(Err(invalid_data(
                 "Invalid XY payload length: expected at least one coordinate pair",
@@ -959,7 +966,11 @@ const RECORD_LAYOUTS: [RecordLayout; 60] = [
     layout(GDSRecord::STrans, BitArray, 2),
     layout(GDSRecord::Mag, EightByteReal, 8),
     layout(GDSRecord::Angle, EightByteReal, 8),
-    layout(GDSRecord::UInteger, FourByteSignedInteger, 4),
+    layout(
+        GDSRecord::UInteger,
+        TwoByteSignedInteger,
+        VARIABLE_PAYLOAD_LEN,
+    ),
     layout(GDSRecord::UString, AsciiString, VARIABLE_PAYLOAD_LEN),
     layout(GDSRecord::RefLibs, AsciiString, 88),
     layout(GDSRecord::Fonts, AsciiString, 176),
@@ -1090,8 +1101,6 @@ pub fn get_points_from_i32_vec(vec: &[i32], db_units: f64) -> Vec<Point> {
 #[cfg(test)]
 mod tests {
     use std::io::{BufReader, Cursor, Write};
-
-    use quickcheck_macros::quickcheck;
 
     use super::*;
     use crate::GdsTimestampPolicy;
@@ -1327,7 +1336,6 @@ mod tests {
             (GDSRecord::StrType, GDSDataType::TwoByteSignedInteger, 2),
             (GDSRecord::TapeNum, GDSDataType::TwoByteSignedInteger, 2),
             (GDSRecord::TapeCode, GDSDataType::TwoByteSignedInteger, 12),
-            (GDSRecord::UInteger, GDSDataType::FourByteSignedInteger, 4),
         ] {
             let bytes = [record(record_type, data_type, &vec![0; payload_len])].concat();
             assert_record_decodes(bytes);
@@ -1793,6 +1801,24 @@ mod tests {
     }
 
     #[test]
+    fn uinteger_contains_one_to_thirty_two_two_byte_values() {
+        for payload_len in [2, 4, 64] {
+            assert_record_decodes(record(
+                GDSRecord::UInteger,
+                GDSDataType::TwoByteSignedInteger,
+                &vec![0; payload_len],
+            ));
+        }
+        for payload_len in [0, 1, 3, 66] {
+            assert_record_is_invalid(record(
+                GDSRecord::UInteger,
+                GDSDataType::TwoByteSignedInteger,
+                &vec![0; payload_len],
+            ));
+        }
+    }
+
+    #[test]
     fn invalid_structural_sequences_are_rejected() {
         let begin_structure = record(
             GDSRecord::BgnStr,
@@ -1858,52 +1884,42 @@ mod tests {
         assert_invalid(&Library::read_file_filtered(file.path(), None, |_, _| true));
     }
 
-    #[quickcheck]
-    fn mutations_of_schema_valid_records_are_rejected(mutation: u8, selector: usize) -> bool {
+    #[test]
+    fn whole_record_grammar_mutations_are_rejected_without_panicking() {
         let bytes = Library::new("mutation")
             .to_bytes_with_timestamp_policy(1e-3, 1e-9, GdsTimestampPolicy::Zero)
             .expect("minimal library should serialize");
-        let mut ranges = Vec::new();
+        let mut records = Vec::new();
         let mut offset = 0;
         while offset < bytes.len() {
             let size = usize::from(u16::from_be_bytes([bytes[offset], bytes[offset + 1]]));
-            ranges.push(offset..offset + size);
+            records.push(bytes[offset..offset + size].to_vec());
             offset += size;
         }
-
-        let mutated = match mutation % 3 {
-            0 => {
-                let mut mutated = bytes;
-                let range = &ranges[selector % ranges.len()];
-                mutated[range.start..range.start + 2].copy_from_slice(&u16::MAX.to_be_bytes());
-                mutated
-            }
-            1 => {
-                let range = &ranges[[0, 1, 3][selector % 3]];
-                let mut mutated = bytes;
-                let new_size = range.len() - 2;
-                mutated[range.start..range.start + 2]
-                    .copy_from_slice(&(new_size as u16).to_be_bytes());
-                mutated.drain(range.end - 2..range.end);
-                mutated
-            }
-            _ => {
-                let first = selector % (ranges.len() - 1);
-                let left = &ranges[first];
-                let right = &ranges[first + 1];
-                [
-                    &bytes[..left.start],
-                    &bytes[right.clone()],
-                    &bytes[left.clone()],
-                    &bytes[right.end..],
-                ]
-                .concat()
-            }
+        let assert_rejected = |records: &[Vec<u8>]| {
+            let bytes = records.concat();
+            assert!(matches!(
+                std::panic::catch_unwind(|| Library::from_bytes(&bytes, None)),
+                Ok(Err(GdsError::InvalidData { .. }))
+            ));
         };
 
-        matches!(
-            std::panic::catch_unwind(|| Library::from_bytes(&mutated, None)),
-            Ok(Err(GdsError::InvalidData { .. }))
-        )
+        for index in 0..records.len() {
+            let mut mutated = records.clone();
+            mutated.remove(index);
+            assert_rejected(&mutated);
+        }
+
+        for index in 0..records.len() - 1 {
+            let mut mutated = records.clone();
+            mutated.insert(index, records[index].clone());
+            assert_rejected(&mutated);
+        }
+
+        for index in 0..records.len() - 1 {
+            let mut mutated = records.clone();
+            mutated.swap(index, index + 1);
+            assert_rejected(&mutated);
+        }
     }
 }

--- a/crates/gdsr/src/io/read/mod.rs
+++ b/crates/gdsr/src/io/read/mod.rs
@@ -22,15 +22,21 @@ enum ParserState {
 }
 
 impl ParserState {
+    #[inline]
     fn require(self, expected: Self, record: GDSRecord) -> Result<(), GdsError> {
         if self == expected {
             Ok(())
         } else {
-            Err(invalid_data(format!(
-                "Unexpected {record:?} record while parsing {self:?}"
-            )))
+            Err(invalid_parser_state(record, self))
         }
     }
+}
+
+#[cold]
+fn invalid_parser_state(record: GDSRecord, state: ParserState) -> GdsError {
+    invalid_data(format!(
+        "Unexpected {record:?} record while parsing {state:?}"
+    ))
 }
 
 pub fn from_gds_reader<R: Read>(reader: R, units: Option<f64>) -> Result<Library, GdsError> {
@@ -513,22 +519,12 @@ impl<R: Read> Iterator for RecordReader<R> {
 
     fn next(&mut self) -> Option<Self::Item> {
         let mut header = [0u8; 4];
-        let bytes_read = loop {
-            match self.reader.read(&mut header) {
-                Ok(0) => return None,
-                Ok(bytes_read) => break bytes_read,
-                Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
-                Err(error) => return Some(Err(GdsError::from(error))),
-            }
-        };
-        if bytes_read < header.len()
-            && let Err(error) = self.reader.read_exact(&mut header[bytes_read..])
-        {
-            return Some(Err(if error.kind() == io::ErrorKind::UnexpectedEof {
-                invalid_data("Truncated record header")
+        if let Err(error) = self.reader.read_exact(&mut header) {
+            return if error.kind() == io::ErrorKind::UnexpectedEof {
+                None
             } else {
-                GdsError::from(error)
-            }));
+                Some(Err(GdsError::from(error)))
+            };
         }
 
         let size = u16::from_be_bytes([header[0], header[1]]) as usize;
@@ -538,23 +534,29 @@ impl<R: Read> Iterator for RecordReader<R> {
             ))));
         }
 
-        let Some(&schema) = RECORD_SCHEMAS.get(usize::from(header[2])) else {
+        let Some(&layout) = RECORD_LAYOUTS.get(usize::from(header[2])) else {
             return Some(Err(invalid_data(format!(
                 "Invalid record type byte: {:#04x}",
                 header[2]
             ))));
         };
-        let record = schema.record;
-        if header[3] != schema.data_type as u8 {
+        let record = layout.record;
+        let expected_data_type = layout.data_type;
+        if header[3] != expected_data_type as u8 {
             return Some(Err(invalid_data(format!(
-                "Invalid {record:?} data type: expected {:?}, found {:#04x}",
-                schema.data_type, header[3]
+                "Invalid {record:?} data type: expected {expected_data_type:?}, found {:#04x}",
+                header[3]
             ))));
         }
-        let data_type = schema.data_type;
+        let data_type = expected_data_type;
         let payload_len = size - 4;
-        if let Err(error) = validate_record_layout(schema, payload_len) {
-            return Some(Err(error));
+        let expected_payload_len = layout.payload_len;
+        if expected_payload_len != VARIABLE_PAYLOAD_LEN
+            && payload_len != usize::from(expected_payload_len)
+        {
+            return Some(Err(invalid_data(format!(
+                "Invalid {record:?} payload length: expected {expected_payload_len} bytes, found {payload_len}"
+            ))));
         }
 
         let mut buf = vec![0u8; payload_len];
@@ -571,6 +573,12 @@ impl<R: Read> Iterator for RecordReader<R> {
                 GDSRecordData::I16(read_i16_be(&buf))
             }
             GDSDataType::FourByteSignedInteger | GDSDataType::FourByteReal => {
+                if expected_payload_len == VARIABLE_PAYLOAD_LEN {
+                    let alignment = if record == GDSRecord::XY { 8 } else { 4 };
+                    if !buf.len().is_multiple_of(alignment) {
+                        return Some(Err(misaligned_payload(record, buf.len(), alignment)));
+                    }
+                }
                 GDSRecordData::I32(read_i32_be(&buf))
             }
             GDSDataType::EightByteReal => GDSRecordData::F64(
@@ -581,6 +589,9 @@ impl<R: Read> Iterator for RecordReader<R> {
             ),
             GDSDataType::AsciiString => match String::from_utf8(buf) {
                 Ok(mut result) => {
+                    if !result.len().is_multiple_of(2) {
+                        return Some(Err(misaligned_payload(record, result.len(), 2)));
+                    }
                     if result.ends_with('\0') {
                         result.pop();
                     }
@@ -599,123 +610,104 @@ impl<R: Read> Iterator for RecordReader<R> {
     }
 }
 
+#[repr(C)]
 #[derive(Clone, Copy)]
-struct RecordSchema {
+struct RecordLayout {
     record: GDSRecord,
     data_type: GDSDataType,
-    payload_len: u16,
+    payload_len: u8,
 }
 
-const VARIABLE_PAYLOAD_LEN: u16 = u16::MAX;
+const VARIABLE_PAYLOAD_LEN: u8 = u8::MAX;
 
-const fn schema(record: GDSRecord, data_type: GDSDataType, payload_len: u16) -> RecordSchema {
-    RecordSchema {
+const fn layout(record: GDSRecord, data_type: GDSDataType, payload_len: u8) -> RecordLayout {
+    RecordLayout {
         record,
         data_type,
         payload_len,
     }
 }
 
-const RECORD_SCHEMAS: [RecordSchema; 60] = [
-    schema(GDSRecord::Header, TwoByteSignedInteger, 2),
-    schema(GDSRecord::BgnLib, TwoByteSignedInteger, 24),
-    schema(GDSRecord::LibName, AsciiString, VARIABLE_PAYLOAD_LEN),
-    schema(GDSRecord::Units, EightByteReal, 16),
-    schema(GDSRecord::EndLib, NoData, 0),
-    schema(GDSRecord::BgnStr, TwoByteSignedInteger, 24),
-    schema(GDSRecord::StrName, AsciiString, VARIABLE_PAYLOAD_LEN),
-    schema(GDSRecord::EndStr, NoData, 0),
-    schema(GDSRecord::Boundary, NoData, 0),
-    schema(GDSRecord::Path, NoData, 0),
-    schema(GDSRecord::SRef, NoData, 0),
-    schema(GDSRecord::ARef, NoData, 0),
-    schema(GDSRecord::Text, NoData, 0),
-    schema(GDSRecord::Layer, TwoByteSignedInteger, 2),
-    schema(GDSRecord::DataType, TwoByteSignedInteger, 2),
-    schema(GDSRecord::Width, FourByteSignedInteger, 4),
-    schema(GDSRecord::XY, FourByteSignedInteger, VARIABLE_PAYLOAD_LEN),
-    schema(GDSRecord::EndEl, NoData, 0),
-    schema(GDSRecord::SName, AsciiString, VARIABLE_PAYLOAD_LEN),
-    schema(GDSRecord::ColRow, TwoByteSignedInteger, 4),
-    schema(GDSRecord::TextNode, NoData, 0),
-    schema(GDSRecord::Node, NoData, 0),
-    schema(GDSRecord::TextType, TwoByteSignedInteger, 2),
-    schema(GDSRecord::Presentation, BitArray, 2),
-    schema(
+const RECORD_LAYOUTS: [RecordLayout; 60] = [
+    layout(GDSRecord::Header, TwoByteSignedInteger, 2),
+    layout(GDSRecord::BgnLib, TwoByteSignedInteger, 24),
+    layout(GDSRecord::LibName, AsciiString, VARIABLE_PAYLOAD_LEN),
+    layout(GDSRecord::Units, EightByteReal, 16),
+    layout(GDSRecord::EndLib, NoData, 0),
+    layout(GDSRecord::BgnStr, TwoByteSignedInteger, 24),
+    layout(GDSRecord::StrName, AsciiString, VARIABLE_PAYLOAD_LEN),
+    layout(GDSRecord::EndStr, NoData, 0),
+    layout(GDSRecord::Boundary, NoData, 0),
+    layout(GDSRecord::Path, NoData, 0),
+    layout(GDSRecord::SRef, NoData, 0),
+    layout(GDSRecord::ARef, NoData, 0),
+    layout(GDSRecord::Text, NoData, 0),
+    layout(GDSRecord::Layer, TwoByteSignedInteger, 2),
+    layout(GDSRecord::DataType, TwoByteSignedInteger, 2),
+    layout(GDSRecord::Width, FourByteSignedInteger, 4),
+    layout(GDSRecord::XY, FourByteSignedInteger, VARIABLE_PAYLOAD_LEN),
+    layout(GDSRecord::EndEl, NoData, 0),
+    layout(GDSRecord::SName, AsciiString, VARIABLE_PAYLOAD_LEN),
+    layout(GDSRecord::ColRow, TwoByteSignedInteger, 4),
+    layout(GDSRecord::TextNode, NoData, 0),
+    layout(GDSRecord::Node, NoData, 0),
+    layout(GDSRecord::TextType, TwoByteSignedInteger, 2),
+    layout(GDSRecord::Presentation, BitArray, 2),
+    layout(
         GDSRecord::Spacing,
         FourByteSignedInteger,
         VARIABLE_PAYLOAD_LEN,
     ),
-    schema(GDSRecord::String, AsciiString, VARIABLE_PAYLOAD_LEN),
-    schema(GDSRecord::STrans, BitArray, 2),
-    schema(GDSRecord::Mag, EightByteReal, 8),
-    schema(GDSRecord::Angle, EightByteReal, 8),
-    schema(GDSRecord::UInteger, TwoByteSignedInteger, 2),
-    schema(GDSRecord::UString, AsciiString, VARIABLE_PAYLOAD_LEN),
-    schema(GDSRecord::RefLibs, AsciiString, VARIABLE_PAYLOAD_LEN),
-    schema(GDSRecord::Fonts, AsciiString, VARIABLE_PAYLOAD_LEN),
-    schema(GDSRecord::PathType, TwoByteSignedInteger, 2),
-    schema(GDSRecord::Generations, TwoByteSignedInteger, 2),
-    schema(GDSRecord::AttrTable, AsciiString, VARIABLE_PAYLOAD_LEN),
-    schema(GDSRecord::StyTable, AsciiString, VARIABLE_PAYLOAD_LEN),
-    schema(GDSRecord::StrType, TwoByteSignedInteger, 2),
-    schema(GDSRecord::ElFlags, BitArray, 2),
-    schema(GDSRecord::ElKey, FourByteSignedInteger, 4),
-    schema(GDSRecord::LinkType, TwoByteSignedInteger, 2),
-    schema(
+    layout(GDSRecord::String, AsciiString, VARIABLE_PAYLOAD_LEN),
+    layout(GDSRecord::STrans, BitArray, 2),
+    layout(GDSRecord::Mag, EightByteReal, 8),
+    layout(GDSRecord::Angle, EightByteReal, 8),
+    layout(GDSRecord::UInteger, TwoByteSignedInteger, 2),
+    layout(GDSRecord::UString, AsciiString, VARIABLE_PAYLOAD_LEN),
+    layout(GDSRecord::RefLibs, AsciiString, VARIABLE_PAYLOAD_LEN),
+    layout(GDSRecord::Fonts, AsciiString, VARIABLE_PAYLOAD_LEN),
+    layout(GDSRecord::PathType, TwoByteSignedInteger, 2),
+    layout(GDSRecord::Generations, TwoByteSignedInteger, 2),
+    layout(GDSRecord::AttrTable, AsciiString, VARIABLE_PAYLOAD_LEN),
+    layout(GDSRecord::StyTable, AsciiString, VARIABLE_PAYLOAD_LEN),
+    layout(GDSRecord::StrType, TwoByteSignedInteger, 2),
+    layout(GDSRecord::ElFlags, BitArray, 2),
+    layout(GDSRecord::ElKey, FourByteSignedInteger, 4),
+    layout(GDSRecord::LinkType, TwoByteSignedInteger, 2),
+    layout(
         GDSRecord::LinkKeys,
         FourByteSignedInteger,
         VARIABLE_PAYLOAD_LEN,
     ),
-    schema(GDSRecord::NodeType, TwoByteSignedInteger, 2),
-    schema(GDSRecord::PropAttr, TwoByteSignedInteger, 2),
-    schema(GDSRecord::PropValue, AsciiString, VARIABLE_PAYLOAD_LEN),
-    schema(GDSRecord::Box, NoData, 0),
-    schema(GDSRecord::BoxType, TwoByteSignedInteger, 2),
-    schema(GDSRecord::Plex, FourByteSignedInteger, 4),
-    schema(GDSRecord::BgnExtn, FourByteSignedInteger, 4),
-    schema(GDSRecord::EndExtn, FourByteSignedInteger, 4),
-    schema(GDSRecord::TapeNum, TwoByteSignedInteger, 2),
-    schema(GDSRecord::TapeCode, TwoByteSignedInteger, 12),
-    schema(GDSRecord::StrClass, BitArray, 2),
-    schema(
+    layout(GDSRecord::NodeType, TwoByteSignedInteger, 2),
+    layout(GDSRecord::PropAttr, TwoByteSignedInteger, 2),
+    layout(GDSRecord::PropValue, AsciiString, VARIABLE_PAYLOAD_LEN),
+    layout(GDSRecord::Box, NoData, 0),
+    layout(GDSRecord::BoxType, TwoByteSignedInteger, 2),
+    layout(GDSRecord::Plex, FourByteSignedInteger, 4),
+    layout(GDSRecord::BgnExtn, FourByteSignedInteger, 4),
+    layout(GDSRecord::EndExtn, FourByteSignedInteger, 4),
+    layout(GDSRecord::TapeNum, TwoByteSignedInteger, 2),
+    layout(GDSRecord::TapeCode, TwoByteSignedInteger, 12),
+    layout(GDSRecord::StrClass, BitArray, 2),
+    layout(
         GDSRecord::Reserved,
         FourByteSignedInteger,
         VARIABLE_PAYLOAD_LEN,
     ),
-    schema(GDSRecord::Format, TwoByteSignedInteger, 2),
-    schema(GDSRecord::Mask, AsciiString, VARIABLE_PAYLOAD_LEN),
-    schema(GDSRecord::EndMasks, NoData, 0),
-    schema(GDSRecord::LibDirSize, TwoByteSignedInteger, 2),
-    schema(GDSRecord::SrfName, AsciiString, VARIABLE_PAYLOAD_LEN),
-    schema(GDSRecord::LibSecure, TwoByteSignedInteger, 2),
+    layout(GDSRecord::Format, TwoByteSignedInteger, 2),
+    layout(GDSRecord::Mask, AsciiString, VARIABLE_PAYLOAD_LEN),
+    layout(GDSRecord::EndMasks, NoData, 0),
+    layout(GDSRecord::LibDirSize, TwoByteSignedInteger, 2),
+    layout(GDSRecord::SrfName, AsciiString, VARIABLE_PAYLOAD_LEN),
+    layout(GDSRecord::LibSecure, TwoByteSignedInteger, 2),
 ];
 
-fn validate_record_layout(schema: RecordSchema, payload_len: usize) -> Result<(), GdsError> {
-    if schema.payload_len != VARIABLE_PAYLOAD_LEN {
-        return if payload_len == usize::from(schema.payload_len) {
-            Ok(())
-        } else {
-            Err(invalid_data(format!(
-                "Invalid {:?} payload length: expected {} bytes, found {payload_len}",
-                schema.record, schema.payload_len
-            )))
-        };
-    }
-
-    let alignment = if schema.record == GDSRecord::XY {
-        8
-    } else {
-        usize::from(schema.data_type.byte_size()).max(2)
-    };
-    if payload_len.is_multiple_of(alignment) {
-        Ok(())
-    } else {
-        Err(invalid_data(format!(
-            "{:?} payload length {payload_len} is not aligned to {alignment} bytes",
-            schema.record
-        )))
-    }
+#[cold]
+fn misaligned_payload(record: GDSRecord, payload_len: usize, alignment: usize) -> GdsError {
+    invalid_data(format!(
+        "{record:?} payload length {payload_len} is not aligned to {alignment} bytes"
+    ))
 }
 
 fn read_i16_be(buf: &[u8]) -> Vec<i16> {
@@ -796,7 +788,7 @@ pub fn get_points_from_i32_vec(vec: &[i32], db_units: f64) -> Vec<Point> {
 
 #[cfg(test)]
 mod tests {
-    use std::io::{BufReader, Cursor, Write};
+    use std::io::{Cursor, Write};
 
     use quickcheck_macros::quickcheck;
 
@@ -880,9 +872,11 @@ mod tests {
         ];
 
         for (name, bytes) in cases {
-            let mut reader = RecordReader::new(BufReader::new(Cursor::new(bytes)));
             assert!(
-                matches!(reader.next(), Some(Err(GdsError::InvalidData { .. }))),
+                matches!(
+                    Library::from_bytes(&bytes, None),
+                    Err(GdsError::InvalidData { .. })
+                ),
                 "{name}"
             );
         }
@@ -944,14 +938,19 @@ mod tests {
             (GDSRecord::TapeNum, GDSDataType::TwoByteSignedInteger, 2),
             (GDSRecord::TapeCode, GDSDataType::TwoByteSignedInteger, 12),
         ] {
-            let bytes = record(record_type, data_type, &vec![0; payload_len]);
-            let mut valid = RecordReader::new(BufReader::new(Cursor::new(bytes)));
-            assert!(matches!(valid.next(), Some(Ok(_))), "{record_type:?}");
+            let bytes = [
+                record(record_type, data_type, &vec![0; payload_len]),
+                record(GDSRecord::EndLib, GDSDataType::NoData, &[]),
+            ]
+            .concat();
+            assert!(Library::from_bytes(&bytes, None).is_ok(), "{record_type:?}");
 
             let bytes = record(record_type, data_type, &[]);
-            let mut invalid = RecordReader::new(BufReader::new(Cursor::new(bytes)));
             assert!(
-                matches!(invalid.next(), Some(Err(GdsError::InvalidData { .. }))),
+                matches!(
+                    Library::from_bytes(&bytes, None),
+                    Err(GdsError::InvalidData { .. })
+                ),
                 "{record_type:?}"
             );
         }
@@ -964,16 +963,20 @@ mod tests {
             GDSRecord::PropValue,
         ] {
             let bytes = record(record_type, GDSDataType::TwoByteSignedInteger, &[0, 0]);
-            let mut wrong_type = RecordReader::new(BufReader::new(Cursor::new(bytes)));
             assert!(
-                matches!(wrong_type.next(), Some(Err(GdsError::InvalidData { .. }))),
+                matches!(
+                    Library::from_bytes(&bytes, None),
+                    Err(GdsError::InvalidData { .. })
+                ),
                 "{record_type:?}"
             );
 
             let bytes = record(record_type, GDSDataType::AsciiString, b"x");
-            let mut odd_length = RecordReader::new(BufReader::new(Cursor::new(bytes)));
             assert!(
-                matches!(odd_length.next(), Some(Err(GdsError::InvalidData { .. }))),
+                matches!(
+                    Library::from_bytes(&bytes, None),
+                    Err(GdsError::InvalidData { .. })
+                ),
                 "{record_type:?}"
             );
         }
@@ -991,7 +994,7 @@ mod tests {
 
         for records in [
             vec![begin_structure.clone(), begin_structure.clone()],
-            vec![begin_structure.clone(), begin_boundary.clone(), begin_path],
+            vec![begin_structure.clone(), begin_boundary, begin_path],
             vec![record(GDSRecord::EndEl, GDSDataType::NoData, &[])],
             vec![
                 begin_structure,

--- a/crates/gdsr/src/io/write/mod.rs
+++ b/crates/gdsr/src/io/write/mod.rs
@@ -17,8 +17,8 @@ use crate::{
 };
 use gds_format::{eight_byte_real, write_u16_array_as_big_endian};
 use validation::{
-    MAX_POINTS, validate_col_row, validate_data_type, validate_layer, validate_path_points,
-    validate_polygon_points, validate_string_length, validate_structure_name,
+    MAX_POINTS, validate_col_row, validate_data_type, validate_layer, validate_node_points,
+    validate_path_points, validate_polygon_points, validate_string_length, validate_structure_name,
 };
 
 /// Trait for customizing GDS file serialization.
@@ -700,6 +700,19 @@ pub fn write_text(text: &Text, db_units: f64) -> Result<Vec<u8>, GdsError> {
 ///
 /// Properties on inline references are appended to each expanded element.
 pub fn write_reference(reference: &Reference, db_units: f64) -> Result<Vec<u8>, GdsError> {
+    let grid = reference.grid();
+    validate_col_row(grid.columns(), grid.rows())?;
+    if grid.columns() > 1 && grid.spacing_x().is_none() {
+        return Err(GdsError::ValidationError {
+            message: "Array references with multiple columns require column spacing".to_string(),
+        });
+    }
+    if grid.rows() > 1 && grid.spacing_y().is_none() {
+        return Err(GdsError::ValidationError {
+            message: "Array references with multiple rows require row spacing".to_string(),
+        });
+    }
+
     match reference.instance() {
         Instance::Cell(cell_name) => write_reference_cell(reference, db_units, cell_name),
         Instance::Element(element) => {
@@ -748,7 +761,7 @@ fn write_reference_cell(
     cell_name: &str,
 ) -> Result<Vec<u8>, GdsError> {
     let grid = reference.grid();
-    validate_col_row(grid.columns(), grid.rows())?;
+    validate_structure_name(cell_name)?;
 
     let is_single_instance = grid.columns() == 1 && grid.rows() == 1;
 
@@ -791,11 +804,7 @@ fn write_reference_cell(
             .map(|sy| (origin + sy * grid.rows()).rotate_around_point(grid.angle(), &origin))
             .unwrap_or(origin);
 
-        if grid.spacing_x().is_some() || grid.spacing_y().is_some() {
-            write_points_to_file(&mut buffer, &[origin, point2, point3], db_units)?;
-        } else {
-            write_points_to_file(&mut buffer, &[origin], db_units)?;
-        }
+        write_points_to_file(&mut buffer, &[origin, point2, point3], db_units)?;
     }
 
     write_element_tail_to_file(&mut buffer, reference.properties())?;
@@ -826,6 +835,7 @@ pub fn write_box(gds_box: &GdsBox, db_units: f64) -> Result<Vec<u8>, GdsError> {
 
 /// Serializes a node to GDS bytes.
 pub fn write_node(node: &Node, db_units: f64) -> Result<Vec<u8>, GdsError> {
+    validate_node_points(node.points())?;
     validate_layer(node.layer())?;
     validate_data_type(node.node_type())?;
 
@@ -855,7 +865,7 @@ mod tests {
     use crate::config::gds_file_types::GDSRecordData;
     use crate::io::read::RecordReader;
     use crate::{
-        DEFAULT_INTEGER_UNITS, DataType, GdsTimestampPolicy, GdsTimestamps, Layer, Library,
+        DEFAULT_INTEGER_UNITS, DataType, GdsTimestampPolicy, GdsTimestamps, Grid, Layer, Library,
         Property,
     };
 
@@ -920,6 +930,10 @@ mod tests {
         let path = directory.path().join("timestamps.gds");
         fs::write(&path, bytes).expect("test GDS should be writable");
         Library::read_file(path, Some(DEFAULT_INTEGER_UNITS))
+    }
+
+    fn assert_validation_error(result: &Result<Vec<u8>, GdsError>) {
+        assert!(matches!(result, Err(GdsError::ValidationError { .. })));
     }
 
     fn library_with_cells(cells: &[(String, u16)]) -> Library {
@@ -1095,6 +1109,89 @@ mod tests {
             .collect();
 
         assert_eq!(property_values, ["inner", "outer"]);
+    }
+
+    #[test]
+    fn invalid_public_writer_states_return_validation_errors() {
+        assert_validation_error(&GdsFileWriter.write_cell(&Cell::new(""), DEFAULT_INTEGER_UNITS));
+        assert_validation_error(&write_reference(&Reference::new(""), DEFAULT_INTEGER_UNITS));
+        assert_validation_error(&write_node(&Node::default(), DEFAULT_INTEGER_UNITS));
+
+        let spacing_x = Point::integer(10, 0, DEFAULT_INTEGER_UNITS);
+        let spacing_y = Point::integer(0, 10, DEFAULT_INTEGER_UNITS);
+        for grid in [
+            Grid::default().with_columns(0),
+            Grid::default().with_rows(0),
+            Grid::default()
+                .with_columns(validation::MAX_COL_ROW + 1)
+                .with_spacing_x(Some(spacing_x)),
+            Grid::default()
+                .with_rows(validation::MAX_COL_ROW + 1)
+                .with_spacing_y(Some(spacing_y)),
+            Grid::default().with_columns(2),
+            Grid::default().with_rows(2),
+        ] {
+            assert_validation_error(&write_reference(
+                &Reference::new("target").with_grid(grid),
+                DEFAULT_INTEGER_UNITS,
+            ));
+        }
+    }
+
+    #[test]
+    fn valid_array_references_always_write_three_points_and_reread() {
+        let spacing_x = Point::integer(10, 0, DEFAULT_INTEGER_UNITS);
+        let spacing_y = Point::integer(0, 10, DEFAULT_INTEGER_UNITS);
+        for grid in [
+            Grid::default()
+                .with_columns(2)
+                .with_spacing_x(Some(spacing_x)),
+            Grid::default().with_rows(2).with_spacing_y(Some(spacing_y)),
+            Grid::default()
+                .with_columns(2)
+                .with_rows(2)
+                .with_spacing_x(Some(spacing_x))
+                .with_spacing_y(Some(spacing_y)),
+        ] {
+            let columns = grid.columns();
+            let rows = grid.rows();
+            let reference = Reference::new("target").with_grid(grid);
+            let element_bytes = write_reference(&reference, DEFAULT_INTEGER_UNITS)
+                .expect("valid AREF should be writable");
+            let records = RecordReader::new(BufReader::new(element_bytes.as_slice()))
+                .collect::<Result<Vec<_>, _>>()
+                .expect("written AREF records should decode");
+            assert!(records.iter().any(|(record, data)| matches!(
+                (record, data),
+                (GDSRecord::XY, GDSRecordData::I32(values)) if values.len() == 6
+            )));
+
+            let mut top = Cell::new("top");
+            top.add(reference);
+            let mut library = Library::new("arrays");
+            library.add_cell(Cell::new("target"));
+            library.add_cell(top);
+            let bytes = library
+                .write_with_timestamp_policy(
+                    &GdsFileWriter,
+                    DEFAULT_INTEGER_UNITS,
+                    DEFAULT_INTEGER_UNITS,
+                    GdsTimestampPolicy::Zero,
+                )
+                .expect("library with valid AREF should be writable");
+            let parsed =
+                Library::from_bytes(&bytes, None).expect("written AREF should be readable");
+            let parsed_reference = parsed
+                .get_cell("top")
+                .and_then(|cell| cell.elements().first())
+                .and_then(|element| match element {
+                    Element::Reference(reference) => Some(reference),
+                    _ => None,
+                })
+                .expect("top element should reread as a reference");
+            assert_eq!(parsed_reference.grid().columns(), columns);
+            assert_eq!(parsed_reference.grid().rows(), rows);
+        }
     }
 
     #[test]

--- a/crates/gdsr/src/io/write/mod.rs
+++ b/crates/gdsr/src/io/write/mod.rs
@@ -700,19 +700,6 @@ pub fn write_text(text: &Text, db_units: f64) -> Result<Vec<u8>, GdsError> {
 ///
 /// Properties on inline references are appended to each expanded element.
 pub fn write_reference(reference: &Reference, db_units: f64) -> Result<Vec<u8>, GdsError> {
-    let grid = reference.grid();
-    validate_col_row(grid.columns(), grid.rows())?;
-    if grid.columns() > 1 && grid.spacing_x().is_none() {
-        return Err(GdsError::ValidationError {
-            message: "Array references with multiple columns require column spacing".to_string(),
-        });
-    }
-    if grid.rows() > 1 && grid.spacing_y().is_none() {
-        return Err(GdsError::ValidationError {
-            message: "Array references with multiple rows require row spacing".to_string(),
-        });
-    }
-
     match reference.instance() {
         Instance::Cell(cell_name) => write_reference_cell(reference, db_units, cell_name),
         Instance::Element(element) => {
@@ -762,6 +749,17 @@ fn write_reference_cell(
 ) -> Result<Vec<u8>, GdsError> {
     let grid = reference.grid();
     validate_structure_name(cell_name)?;
+    validate_col_row(grid.columns(), grid.rows())?;
+    if grid.columns() > 1 && grid.spacing_x().is_none() {
+        return Err(GdsError::ValidationError {
+            message: "Array references with multiple columns require column spacing".to_string(),
+        });
+    }
+    if grid.rows() > 1 && grid.spacing_y().is_none() {
+        return Err(GdsError::ValidationError {
+            message: "Array references with multiple rows require row spacing".to_string(),
+        });
+    }
 
     let is_single_instance = grid.columns() == 1 && grid.rows() == 1;
 
@@ -1109,6 +1107,20 @@ mod tests {
             .collect();
 
         assert_eq!(property_values, ["inner", "outer"]);
+    }
+
+    #[test]
+    fn inline_reference_grid_without_spacing_remains_writable() {
+        let reference = Reference::new(polygon_with_property("inner"))
+            .with_grid(Grid::default().with_columns(2).with_rows(2));
+
+        let bytes = write_reference(&reference, DEFAULT_INTEGER_UNITS)
+            .expect("inline grid should use zero spacing");
+        let boundaries = RecordReader::new(BufReader::new(bytes.as_slice()))
+            .filter(|record| matches!(record, Ok((GDSRecord::Boundary, GDSRecordData::None))))
+            .count();
+
+        assert_eq!(boundaries, 4);
     }
 
     #[test]

--- a/crates/gdsr/src/io/write/validation.rs
+++ b/crates/gdsr/src/io/write/validation.rs
@@ -51,6 +51,11 @@ pub fn validate_string_length(s: &str) -> Result<(), GdsError> {
 /// Returns a validation error if the structure name exceeds 32 characters or contains
 /// invalid characters (only alphanumeric, `_`, `?`, `$` are allowed).
 pub fn validate_structure_name(name: &str) -> Result<(), GdsError> {
+    if name.is_empty() {
+        return Err(GdsError::ValidationError {
+            message: "Structure name cannot be empty".to_string(),
+        });
+    }
     if name.len() > MAX_STRUCTURE_NAME_LENGTH {
         return Err(GdsError::ValidationError {
             message: format!(
@@ -70,16 +75,26 @@ pub fn validate_structure_name(name: &str) -> Result<(), GdsError> {
     Ok(())
 }
 
-/// Returns a validation error if columns or rows exceed 32767.
+/// Returns a validation error if columns or rows are outside 1..=32767.
 pub fn validate_col_row(columns: u32, rows: u32) -> Result<(), GdsError> {
-    if columns > MAX_COL_ROW {
+    if !(1..=MAX_COL_ROW).contains(&columns) {
         return Err(GdsError::ValidationError {
-            message: format!("Column count {columns} exceeds maximum value of {MAX_COL_ROW}"),
+            message: format!("Column count {columns} must be between 1 and {MAX_COL_ROW}"),
         });
     }
-    if rows > MAX_COL_ROW {
+    if !(1..=MAX_COL_ROW).contains(&rows) {
         return Err(GdsError::ValidationError {
-            message: format!("Row count {rows} exceeds maximum value of {MAX_COL_ROW}"),
+            message: format!("Row count {rows} must be between 1 and {MAX_COL_ROW}"),
+        });
+    }
+    Ok(())
+}
+
+/// Returns a validation error if a node has no points.
+pub fn validate_node_points(points: &[Point]) -> Result<(), GdsError> {
+    if points.is_empty() {
+        return Err(GdsError::ValidationError {
+            message: "Node must have at least one point".to_string(),
         });
     }
     Ok(())

--- a/crates/gdsr/src/property_tests/validation.rs
+++ b/crates/gdsr/src/property_tests/validation.rs
@@ -1313,7 +1313,13 @@ fn test_reference_col_row_at_max() {
 
     let mut cell = Cell::new("cell");
     cell.add(
-        Reference::new("base").with_grid(Grid::default().with_columns(32767).with_rows(32767)),
+        Reference::new("base").with_grid(
+            Grid::default()
+                .with_columns(32767)
+                .with_rows(32767)
+                .with_spacing_x(Some(Point::integer(1, 0, units)))
+                .with_spacing_y(Some(Point::integer(0, 1, units))),
+        ),
     );
     library.add_cell(cell);
     let temp_dir = tempdir().unwrap();


### PR DESCRIPTION
## Summary

Rejects malformed record framing, invalid record schemas and payloads, illegal library/structure/element grammar, and incomplete streams. Writer validation now prevents public model states from emitting records the strict reader rejects, while a reusable numeric payload buffer keeps validated reads faster than current `main`.

Closes #384

## Test Plan

Ran focused parser/writer tests, `cargo nextest run`, strict workspace Clippy, `uvx prek run -a`, and same-machine Criterion read comparisons against `30f33c0`.