### PR TITLE
Fix egui keyboard input API

### DIFF
--- a/crates/gdsr-viewer/src/app.rs
+++ b/crates/gdsr-viewer/src/app.rs
@@ -1488,7 +1488,7 @@ impl ViewerApp {
         let drawing_tool_active = polygon_tool_active || path_tool_active;
 
         // Global keyboard shortcuts
-        let wants_keyboard_input = ctx.wants_keyboard_input();
+        let wants_keyboard_input = ctx.egui_wants_keyboard_input();
         if ctx.input(|i| {
             accepts_canvas_shortcut(wants_keyboard_input, i.modifiers)
                 && i.key_pressed(egui::Key::F)


### PR DESCRIPTION
## Summary

Use egui 0.34’s current keyboard-input method. This fixes strict Clippy on `main` after the layer-filter and egui upgrade PRs were merged together.

## Test Plan

`cargo nextest run`, strict workspace Clippy, and `uvx prek run -a`.