### PR TITLE
Document strict pull request merge gates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,3 +86,13 @@ source content rather than hand-editing the generated file.
 Always use the pull request template and add labels. Write the description in
 concise prose paragraphs, with code examples only when they help the reviewer.
 Do not use checkboxes. Do not add AI tooling as an author or co-author.
+
+Never merge a pull request unless every required check for the exact current
+head commit has completed successfully. `main` must also be green. The only
+exception is a narrowly scoped pull request whose sole purpose is restoring
+`main`; that repair still requires exact-head CI green and independent review.
+The head must include current `main`: after another pull request merges, update
+the next branch with latest `main`, rerun every required check, and inspect the
+exact head SHA and check conclusions immediately before merging. A failing,
+pending, skipped, cancelled, stale, or missing required check blocks merging;
+never bypass, acknowledge, or ignore it.


### PR DESCRIPTION
## Summary

Document mandatory merge gates so pull requests cannot merge unless current `main` and every required check for the exact refreshed head are green. A narrow repair-only exception avoids blocking fixes when `main` itself is red while retaining exact-head CI and independent-review gates.

## Test Plan

`uvx prek run --files AGENTS.md` and `uvx prek run -a` passed after rebasing onto current green `main`.