### PR TITLE
Add bulk layer visibility and solo controls

### DIFF
--- a/crates/gdsr-viewer/src/app.rs
+++ b/crates/gdsr-viewer/src/app.rs
@@ -289,8 +289,19 @@ impl ViewerApp {
     }
 
     fn invalidate_geometry(&mut self) {
+        self.sync_layer_state();
         self.geometry_generation = self.geometry_generation.saturating_add(1);
         self.invalidate_render();
+    }
+
+    fn sync_layer_state(&mut self) {
+        let Some(cell) = self.cell.as_ref() else {
+            return;
+        };
+        self.layer_state.sync_layers(&cell.layers);
+        for &(layer, data_type) in &cell.layers {
+            self.layer_state.layer_colors.get(layer, data_type);
+        }
     }
 
     pub(crate) const fn geometry_generation(&self) -> u64 {
@@ -366,6 +377,7 @@ impl ViewerApp {
         self.recent_projects.save();
 
         let cell_state = CellState::new(library);
+        self.layer_state.reset_for_library();
         self.cell = Some(cell_state);
         self.hovered_element = None;
         self.selected_element = None;
@@ -394,12 +406,9 @@ impl ViewerApp {
             self.scroll_to_selected = true;
             self.hovered_element = None;
             self.selected_element = None;
-            if cell.load_direct_cell_elements(name) {
-                for &(layer, data_type) in &cell.layers {
-                    self.layer_state.layer_colors.get(layer, data_type);
-                }
-            }
+            cell.load_direct_cell_elements(name);
         }
+        self.sync_layer_state();
         self.invalidate_render();
         self.polygon_dialog = None;
         self.polygon_tool = None;
@@ -1933,10 +1942,8 @@ impl ViewerApp {
         if depth_changed {
             if let Some(cell) = self.cell.as_mut() {
                 cell.refresh_layers();
-                for &(layer, data_type) in &cell.layers {
-                    self.layer_state.layer_colors.get(layer, data_type);
-                }
             }
+            self.sync_layer_state();
             self.invalidate_render();
         }
 

--- a/crates/gdsr-viewer/src/panels.rs
+++ b/crates/gdsr-viewer/src/panels.rs
@@ -213,13 +213,7 @@ fn draw_layer_panel(
         }
     });
 
-    if layer_state
-        .selected_layer
-        .is_some_and(|selected| !layers.contains(&selected))
-    {
-        layer_state.selected_layer = None;
-        layer_state.exit_solo();
-    }
+    layer_state.sync_layers(layers);
 
     let filtered_layers: Vec<_> = layer_state.filtered_layers(layers).collect();
     let selected_filtered = layer_state
@@ -276,6 +270,18 @@ fn draw_layer_panel(
             .clicked();
     });
 
+    let mut visibility_follows_selection = layer_state.visibility_follows_selection;
+    if ui
+        .checkbox(
+            &mut visibility_follows_selection,
+            "Visibility follows selection",
+        )
+        .on_hover_text("Show only selected layer")
+        .changed()
+    {
+        layer_state.set_visibility_follows_selection(layers, visibility_follows_selection);
+    }
+
     if show_all || show_all_key {
         layer_state.show_layers(&filtered_layers);
     } else if hide_all || hide_all_key {
@@ -306,21 +312,21 @@ fn draw_layer_panel(
                     }
 
                     let mut checked = visible;
-                    if ui.checkbox(&mut checked, "").changed() {
+                    let checkbox = ui.checkbox(&mut checked, "");
+                    let label = ui.add(
+                        egui::Button::selectable(
+                            layer_state.selected_layer == Some((layer, dt)),
+                            format!("L{layer} D{dt}"),
+                        )
+                        .truncate()
+                        .frame(false),
+                    );
+                    let checkbox = checkbox.labelled_by(label.id);
+                    if checkbox.changed() {
                         layer_state.set_layer_visible((layer, dt), checked);
                     }
-                    if ui
-                        .add(
-                            egui::Button::selectable(
-                                layer_state.selected_layer == Some((layer, dt)),
-                                format!("L{layer} D{dt}"),
-                            )
-                            .truncate()
-                            .frame(false),
-                        )
-                        .clicked()
-                    {
-                        layer_state.selected_layer = Some((layer, dt));
+                    if label.clicked() {
+                        layer_state.select_layer(layers, Some((layer, dt)));
                     }
                 });
             }

--- a/crates/gdsr-viewer/src/panels.rs
+++ b/crates/gdsr-viewer/src/panels.rs
@@ -213,13 +213,88 @@ fn draw_layer_panel(
         }
     });
 
+    if layer_state
+        .selected_layer
+        .is_some_and(|selected| !layers.contains(&selected))
+    {
+        layer_state.selected_layer = None;
+        layer_state.exit_solo();
+    }
+
+    let filtered_layers: Vec<_> = layer_state.filtered_layers(layers).collect();
+    let selected_filtered = layer_state
+        .selected_layer
+        .filter(|selected| filtered_layers.contains(selected));
+    let wants_keyboard_input = ui.ctx().egui_wants_keyboard_input();
+    let (show_all_key, hide_all_key, invert_key, toggle_key, solo_key) = ui.input(|input| {
+        let enabled = accepts_layer_shortcut(wants_keyboard_input, input.modifiers);
+        (
+            enabled && input.key_pressed(egui::Key::A),
+            enabled && input.key_pressed(egui::Key::H),
+            enabled && input.key_pressed(egui::Key::I),
+            enabled && input.key_pressed(egui::Key::V),
+            enabled && input.key_pressed(egui::Key::S),
+        )
+    });
+
+    let mut show_all = false;
+    let mut hide_all = false;
+    let mut invert = false;
+    let mut toggle = false;
+    let mut solo = false;
+    ui.horizontal_wrapped(|ui| {
+        show_all = ui
+            .add(egui::Button::new("Show All").shortcut_text("A"))
+            .on_hover_text("Show filtered layers")
+            .clicked();
+        hide_all = ui
+            .add(egui::Button::new("Hide All").shortcut_text("H"))
+            .on_hover_text("Hide filtered layers")
+            .clicked();
+        invert = ui
+            .add(egui::Button::new("Invert").shortcut_text("I"))
+            .on_hover_text("Invert filtered layers")
+            .clicked();
+        toggle = ui
+            .add_enabled(
+                selected_filtered.is_some(),
+                egui::Button::new("Toggle").shortcut_text("V"),
+            )
+            .on_hover_text("Toggle selected layer")
+            .clicked();
+        solo = ui
+            .add_enabled(
+                layer_state.is_solo_active() || selected_filtered.is_some(),
+                egui::Button::new(if layer_state.is_solo_active() {
+                    "Exit Solo"
+                } else {
+                    "Solo"
+                })
+                .shortcut_text("S"),
+            )
+            .on_hover_text("Show only selected layer, or restore previous visibility")
+            .clicked();
+    });
+
+    if show_all || show_all_key {
+        layer_state.show_layers(&filtered_layers);
+    } else if hide_all || hide_all_key {
+        layer_state.hide_layers(&filtered_layers);
+    } else if invert || invert_key {
+        layer_state.invert_layers(&filtered_layers);
+    } else if (toggle || toggle_key)
+        && let Some(selected) = selected_filtered
+    {
+        layer_state.toggle_layer(selected);
+    } else if solo || solo_key {
+        layer_state.toggle_solo(layers, selected_filtered);
+    }
+
+    ui.separator();
     egui::ScrollArea::vertical()
         .id_salt("layers")
         .show(ui, |ui| {
-            for &(layer, dt) in layers
-                .iter()
-                .filter(|&&(layer, dt)| layer_matches_filter(layer, dt, &layer_state.filter))
-            {
+            for &(layer, dt) in &filtered_layers {
                 let mut color = layer_state.layer_colors.get(layer, dt);
                 let visible = !layer_state.hidden_layers.contains(&(layer, dt));
 
@@ -231,27 +306,29 @@ fn draw_layer_panel(
                     }
 
                     let mut checked = visible;
+                    if ui.checkbox(&mut checked, "").changed() {
+                        layer_state.set_layer_visible((layer, dt), checked);
+                    }
                     if ui
-                        .checkbox(&mut checked, format!("L{layer} D{dt}"))
-                        .changed()
+                        .add(
+                            egui::Button::selectable(
+                                layer_state.selected_layer == Some((layer, dt)),
+                                format!("L{layer} D{dt}"),
+                            )
+                            .truncate()
+                            .frame(false),
+                        )
+                        .clicked()
                     {
-                        if checked {
-                            layer_state.hidden_layers.remove(&(layer, dt));
-                        } else {
-                            layer_state.hidden_layers.insert((layer, dt));
-                        }
+                        layer_state.selected_layer = Some((layer, dt));
                     }
                 });
             }
         });
 }
 
-fn layer_matches_filter(layer: Layer, data_type: DataType, filter: &str) -> bool {
-    let filter = filter.trim();
-    filter.is_empty()
-        || format!("L{layer} D{data_type}")
-            .to_ascii_lowercase()
-            .contains(&filter.to_ascii_lowercase())
+fn accepts_layer_shortcut(wants_keyboard_input: bool, modifiers: egui::Modifiers) -> bool {
+    !wants_keyboard_input && modifiers.is_none()
 }
 
 /// Draws the statistics detail panel in the bottom bar.
@@ -353,18 +430,12 @@ fn draw_tree_node(
 
 #[cfg(test)]
 mod tests {
-    use super::layer_matches_filter;
-    use gdsr::{DataType, Layer};
+    use super::accepts_layer_shortcut;
 
     #[test]
-    fn layer_filter_matches_layer_and_datatype() {
-        let layer = Layer::new(12);
-        let data_type = DataType::new(7);
-
-        assert!(layer_matches_filter(layer, data_type, ""));
-        assert!(layer_matches_filter(layer, data_type, "12"));
-        assert!(layer_matches_filter(layer, data_type, "D7"));
-        assert!(layer_matches_filter(layer, data_type, " l12 d7 "));
-        assert!(!layer_matches_filter(layer, data_type, "L7"));
+    fn layer_shortcuts_require_unmodified_non_text_input() {
+        assert!(accepts_layer_shortcut(false, egui::Modifiers::NONE));
+        assert!(!accepts_layer_shortcut(true, egui::Modifiers::NONE));
+        assert!(!accepts_layer_shortcut(false, egui::Modifiers::CTRL));
     }
 }

--- a/crates/gdsr-viewer/src/state.rs
+++ b/crates/gdsr-viewer/src/state.rs
@@ -387,6 +387,81 @@ mod tests {
     }
 
     #[test]
+    fn solo_hides_new_layers_when_layer_universe_changes() {
+        let layers = BTreeSet::from([layer(1, 0), layer(2, 0)]);
+        let previous = HashSet::from([layer(2, 0)]);
+        let mut state = LayerState {
+            hidden_layers: previous.clone(),
+            selected_layer: Some(layer(1, 0)),
+            ..Default::default()
+        };
+
+        state.toggle_solo(&layers, state.selected_layer);
+        state.sync_layers(&BTreeSet::from([layer(1, 0), layer(3, 0)]));
+
+        assert!(state.is_solo_active());
+        assert!(!state.hidden_layers.contains(&layer(1, 0)));
+        assert!(state.hidden_layers.contains(&layer(3, 0)));
+        assert!(state.exit_solo());
+        assert_eq!(state.hidden_layers, previous);
+    }
+
+    #[test]
+    fn missing_soloed_layer_clears_selection_and_restores_visibility() {
+        let layers = BTreeSet::from([layer(1, 0), layer(2, 0)]);
+        let previous = HashSet::from([layer(2, 0)]);
+        let mut state = LayerState {
+            hidden_layers: previous.clone(),
+            selected_layer: Some(layer(1, 0)),
+            ..Default::default()
+        };
+        state.toggle_solo(&layers, state.selected_layer);
+
+        state.sync_layers(&BTreeSet::from([layer(2, 0), layer(3, 0)]));
+
+        assert_eq!(state.selected_layer, None);
+        assert!(!state.is_solo_active());
+        assert_eq!(state.hidden_layers, previous);
+    }
+
+    #[test]
+    fn library_reset_clears_transient_layer_state() {
+        let layers = BTreeSet::from([layer(1, 0), layer(2, 0)]);
+        let mut state = LayerState {
+            selected_layer: Some(layer(1, 0)),
+            ..Default::default()
+        };
+        state.toggle_solo(&layers, state.selected_layer);
+
+        state.reset_for_library();
+
+        assert_eq!(state.selected_layer, None);
+        assert!(!state.is_solo_active());
+        assert!(state.hidden_layers.is_empty());
+    }
+
+    #[test]
+    fn visibility_follows_selected_layer() {
+        let layers = BTreeSet::from([layer(1, 0), layer(2, 0), layer(3, 0)]);
+        let mut state = LayerState {
+            selected_layer: Some(layer(1, 0)),
+            ..Default::default()
+        };
+
+        state.set_visibility_follows_selection(&layers, true);
+        assert_eq!(
+            state.hidden_layers,
+            HashSet::from([layer(2, 0), layer(3, 0)])
+        );
+
+        state.select_layer(&layers, Some(layer(3, 0)));
+        assert_eq!(
+            state.hidden_layers,
+            HashSet::from([layer(1, 0), layer(2, 0)])
+        );
+    }
+
+    #[test]
     fn empty_layer_actions_leave_visibility_unchanged() {
         let mut state = LayerState {
             hidden_layers: HashSet::from([layer(1, 0)]),
@@ -821,7 +896,13 @@ pub struct LayerState {
     pub hidden_layers: HashSet<(Layer, DataType)>,
     pub filter: String,
     pub selected_layer: Option<(Layer, DataType)>,
-    solo_restore: Option<HashSet<(Layer, DataType)>>,
+    pub visibility_follows_selection: bool,
+    solo: Option<SoloState>,
+}
+
+struct SoloState {
+    layer: (Layer, DataType),
+    hidden_layers: HashSet<(Layer, DataType)>,
 }
 
 impl LayerState {
@@ -875,6 +956,57 @@ impl LayerState {
         }
     }
 
+    pub fn select_layer(
+        &mut self,
+        layers: &BTreeSet<(Layer, DataType)>,
+        selected: Option<(Layer, DataType)>,
+    ) {
+        self.selected_layer = selected.filter(|layer| layers.contains(layer));
+        if self.visibility_follows_selection {
+            self.exit_solo();
+            self.show_only(layers, self.selected_layer);
+        }
+    }
+
+    pub fn set_visibility_follows_selection(
+        &mut self,
+        layers: &BTreeSet<(Layer, DataType)>,
+        enabled: bool,
+    ) {
+        self.visibility_follows_selection = enabled;
+        if enabled {
+            self.exit_solo();
+            self.show_only(layers, self.selected_layer);
+        }
+    }
+
+    pub fn sync_layers(&mut self, layers: &BTreeSet<(Layer, DataType)>) {
+        if let Some(solo_layer) = self.solo.as_ref().map(|solo| solo.layer) {
+            if layers.contains(&solo_layer) {
+                self.show_only(layers, Some(solo_layer));
+            } else {
+                self.exit_solo();
+            }
+        }
+
+        if self
+            .selected_layer
+            .is_some_and(|selected| !layers.contains(&selected))
+        {
+            self.selected_layer = None;
+        }
+
+        if self.visibility_follows_selection && !self.is_solo_active() {
+            self.show_only(layers, self.selected_layer);
+        }
+    }
+
+    pub fn reset_for_library(&mut self) {
+        self.hidden_layers.clear();
+        self.selected_layer = None;
+        self.solo = None;
+    }
+
     pub fn toggle_solo(
         &mut self,
         layers: &BTreeSet<(Layer, DataType)>,
@@ -887,20 +1019,33 @@ impl LayerState {
         let Some(selected) = selected.filter(|selected| layers.contains(selected)) else {
             return;
         };
-        self.solo_restore = Some(self.hidden_layers.clone());
-        self.hidden_layers.extend(layers.iter().copied());
-        self.hidden_layers.remove(&selected);
+        self.solo = Some(SoloState {
+            layer: selected,
+            hidden_layers: self.hidden_layers.clone(),
+        });
+        self.show_only(layers, Some(selected));
     }
 
     pub fn exit_solo(&mut self) -> bool {
-        let Some(hidden_layers) = self.solo_restore.take() else {
+        let Some(solo) = self.solo.take() else {
             return false;
         };
-        self.hidden_layers = hidden_layers;
+        self.hidden_layers = solo.hidden_layers;
         true
     }
 
     pub const fn is_solo_active(&self) -> bool {
-        self.solo_restore.is_some()
+        self.solo.is_some()
+    }
+
+    fn show_only(
+        &mut self,
+        layers: &BTreeSet<(Layer, DataType)>,
+        selected: Option<(Layer, DataType)>,
+    ) {
+        self.hidden_layers.extend(layers.iter().copied());
+        if let Some(selected) = selected {
+            self.hidden_layers.remove(&selected);
+        }
     }
 }

--- a/crates/gdsr-viewer/src/state.rs
+++ b/crates/gdsr-viewer/src/state.rs
@@ -273,6 +273,137 @@ mod tests {
         cell
     }
 
+    fn layer(number: u16, data_type: u16) -> (Layer, DataType) {
+        (Layer::new(number), DataType::new(data_type))
+    }
+
+    #[test]
+    fn layer_filter_matches_layer_and_datatype() {
+        let layers = BTreeSet::from([layer(7, 12), layer(12, 7)]);
+        let mut state = LayerState::default();
+
+        assert_eq!(
+            state.filtered_layers(&layers).collect::<Vec<_>>(),
+            vec![layer(7, 12), layer(12, 7)]
+        );
+
+        state.filter = " d7 ".to_string();
+        assert_eq!(
+            state.filtered_layers(&layers).collect::<Vec<_>>(),
+            vec![layer(12, 7)]
+        );
+
+        state.filter = "L7".to_string();
+        assert_eq!(
+            state.filtered_layers(&layers).collect::<Vec<_>>(),
+            vec![layer(7, 12)]
+        );
+
+        state.filter = "missing".to_string();
+        assert!(state.filtered_layers(&layers).next().is_none());
+    }
+
+    #[test]
+    fn bulk_visibility_uses_filtered_layers_only() {
+        let layers = BTreeSet::from([layer(1, 0), layer(2, 1), layer(3, 1)]);
+        let mut state = LayerState {
+            hidden_layers: layers.iter().copied().collect(),
+            filter: "D1".to_string(),
+            ..Default::default()
+        };
+        let filtered: Vec<_> = state.filtered_layers(&layers).collect();
+
+        state.show_layers(&filtered);
+        assert_eq!(state.hidden_layers, HashSet::from([layer(1, 0)]));
+
+        state.hide_layers(&filtered);
+        assert_eq!(
+            state.hidden_layers,
+            HashSet::from([layer(1, 0), layer(2, 1), layer(3, 1)])
+        );
+    }
+
+    #[test]
+    fn invert_visibility_flips_only_scoped_layers() {
+        let mut state = LayerState {
+            hidden_layers: HashSet::from([layer(1, 0), layer(9, 0)]),
+            ..Default::default()
+        };
+
+        state.invert_layers(&[layer(1, 0), layer(2, 0)]);
+
+        assert_eq!(
+            state.hidden_layers,
+            HashSet::from([layer(2, 0), layer(9, 0)])
+        );
+    }
+
+    #[test]
+    fn toggle_layer_flips_selected_visibility() {
+        let mut state = LayerState::default();
+
+        state.toggle_layer(layer(1, 0));
+        assert!(state.hidden_layers.contains(&layer(1, 0)));
+
+        state.toggle_layer(layer(1, 0));
+        assert!(!state.hidden_layers.contains(&layer(1, 0)));
+    }
+
+    #[test]
+    fn solo_restores_exact_previous_visibility() {
+        let layers = BTreeSet::from([layer(1, 0), layer(2, 0), layer(3, 0)]);
+        let previous = HashSet::from([layer(2, 0), layer(9, 0)]);
+        let mut state = LayerState {
+            hidden_layers: previous.clone(),
+            ..Default::default()
+        };
+
+        state.toggle_solo(&layers, Some(layer(2, 0)));
+        assert_eq!(
+            state.hidden_layers,
+            HashSet::from([layer(1, 0), layer(3, 0), layer(9, 0)])
+        );
+
+        state.toggle_solo(&layers, Some(layer(2, 0)));
+        assert_eq!(state.hidden_layers, previous);
+    }
+
+    #[test]
+    fn repeated_solo_cycles_keep_original_visibility() {
+        let layers = BTreeSet::from([layer(1, 0), layer(2, 0), layer(3, 0)]);
+        let previous = HashSet::from([layer(2, 0)]);
+        let mut state = LayerState {
+            hidden_layers: previous.clone(),
+            ..Default::default()
+        };
+
+        for selected in [layer(1, 0), layer(3, 0)] {
+            state.toggle_solo(&layers, Some(selected));
+            assert!(state.is_solo_active());
+            state.toggle_solo(&layers, Some(selected));
+            assert!(!state.is_solo_active());
+            assert_eq!(state.hidden_layers, previous);
+        }
+    }
+
+    #[test]
+    fn empty_layer_actions_leave_visibility_unchanged() {
+        let mut state = LayerState {
+            hidden_layers: HashSet::from([layer(1, 0)]),
+            ..Default::default()
+        };
+        let previous = state.hidden_layers.clone();
+        let layers = BTreeSet::new();
+
+        state.show_layers(&[]);
+        state.hide_layers(&[]);
+        state.invert_layers(&[]);
+        state.toggle_solo(&layers, Some(layer(1, 0)));
+
+        assert_eq!(state.hidden_layers, previous);
+        assert!(!state.is_solo_active());
+    }
+
     #[test]
     fn delete_element_rebuilds_render_indexes() {
         let mut cell = cell_state_with_elements(vec![
@@ -689,4 +820,87 @@ pub struct LayerState {
     pub layer_colors: LayerColorMap,
     pub hidden_layers: HashSet<(Layer, DataType)>,
     pub filter: String,
+    pub selected_layer: Option<(Layer, DataType)>,
+    solo_restore: Option<HashSet<(Layer, DataType)>>,
+}
+
+impl LayerState {
+    pub fn filtered_layers<'a>(
+        &self,
+        layers: &'a BTreeSet<(Layer, DataType)>,
+    ) -> impl Iterator<Item = (Layer, DataType)> + 'a {
+        let filter = self.filter.trim().to_ascii_lowercase();
+        layers.iter().copied().filter(move |(layer, data_type)| {
+            filter.is_empty()
+                || format!("L{layer} D{data_type}")
+                    .to_ascii_lowercase()
+                    .contains(&filter)
+        })
+    }
+
+    pub fn show_layers(&mut self, layers: &[(Layer, DataType)]) {
+        self.exit_solo();
+        for layer in layers {
+            self.hidden_layers.remove(layer);
+        }
+    }
+
+    pub fn hide_layers(&mut self, layers: &[(Layer, DataType)]) {
+        self.exit_solo();
+        self.hidden_layers.extend(layers.iter().copied());
+    }
+
+    pub fn invert_layers(&mut self, layers: &[(Layer, DataType)]) {
+        self.exit_solo();
+        for layer in layers {
+            if !self.hidden_layers.remove(layer) {
+                self.hidden_layers.insert(*layer);
+            }
+        }
+    }
+
+    pub fn set_layer_visible(&mut self, layer: (Layer, DataType), visible: bool) {
+        self.exit_solo();
+        if visible {
+            self.hidden_layers.remove(&layer);
+        } else {
+            self.hidden_layers.insert(layer);
+        }
+    }
+
+    pub fn toggle_layer(&mut self, layer: (Layer, DataType)) {
+        self.exit_solo();
+        if !self.hidden_layers.remove(&layer) {
+            self.hidden_layers.insert(layer);
+        }
+    }
+
+    pub fn toggle_solo(
+        &mut self,
+        layers: &BTreeSet<(Layer, DataType)>,
+        selected: Option<(Layer, DataType)>,
+    ) {
+        if self.exit_solo() {
+            return;
+        }
+
+        let Some(selected) = selected.filter(|selected| layers.contains(selected)) else {
+            return;
+        };
+        self.solo_restore = Some(self.hidden_layers.clone());
+        self.hidden_layers.extend(layers.iter().copied());
+        self.hidden_layers.remove(&selected);
+    }
+
+    pub fn exit_solo(&mut self) -> bool {
+        let Some(hidden_layers) = self.solo_restore.take() else {
+            return false;
+        };
+        self.hidden_layers = hidden_layers;
+        true
+    }
+
+    pub const fn is_solo_active(&self) -> bool {
+        self.solo_restore.is_some()
+    }
 }


### PR DESCRIPTION
## Summary

Add filtered Show All, Hide All, and Invert controls plus selected-layer Toggle, reversible Solo, and optional Visibility Follows Selection behavior to the viewer layer panel. Solo state now tracks layer-universe changes across cell, depth, edit, and library transitions; checkbox controls have accessible layer labels. Keyboard shortcuts A, H, I, V, and S remain suppressed during text entry, and visibility remains viewer-only.

This implements flat layer-list behavior from #340. Layer grouping and grouped visibility remain tracked by #337.

Closes #340

## Test Plan

Validated with focused layer transition tests, `cargo nextest run`, strict workspace Clippy, and `uvx prek run -a`.