### PR TITLE
Enforce PR coverage ratchets

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -3,8 +3,12 @@ coverage:
     project:
       default:
         target: auto
-        threshold: "5%"
+        threshold: "1%"
+        if_not_found: failure
 
     patch:
       default:
-        enabled: false
+        target: "90%"
+        threshold: "0%"
+        if_not_found: failure
+        only_pulls: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,10 +166,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
-    needs: determine_changes
-
-    if: ${{ (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
-
     permissions:
       id-token: write
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
+    needs: determine_changes
+
     permissions:
       id-token: write
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,14 +194,13 @@ jobs:
         run: cargo llvm-cov nextest --lcov --output-path lcov.info
 
       - name: Upload coverage to Codecov
-        if: ${{ github.event_name != 'pull_request' }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
+          disable_search: true
+          fail_ci_if_error: true
           files: lcov.info
           slug: MatthewMckee4/gdsr
-          use_oidc: true
-          use_pypi: true
-          fail_ci_if_error: true
+          use_oidc: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
 
   benchmarks:
     name: "benchmarks"

--- a/crates/gdsr/src/lib.rs
+++ b/crates/gdsr/src/lib.rs
@@ -46,3 +46,12 @@ pub use traits::{Dimensions, Movable, Transformable};
 pub use transformation::{Reflection, Rotation, Scale, Transformation, Translation};
 pub use types::{DataType, Degrees, Layer, LayerMapping, Radians};
 pub use units::{DEFAULT_FLOAT_UNITS, DEFAULT_INTEGER_UNITS, FloatUnit, IntegerUnit, Unit};
+
+#[doc(hidden)]
+#[must_use]
+pub const fn coverage_gate_probe(value: u8) -> &'static str {
+    match value {
+        0 => "zero",
+        _ => "nonzero",
+    }
+}

--- a/crates/gdsr/src/lib.rs
+++ b/crates/gdsr/src/lib.rs
@@ -46,12 +46,3 @@ pub use traits::{Dimensions, Movable, Transformable};
 pub use transformation::{Reflection, Rotation, Scale, Transformation, Translation};
 pub use types::{DataType, Degrees, Layer, LayerMapping, Radians};
 pub use units::{DEFAULT_FLOAT_UNITS, DEFAULT_INTEGER_UNITS, FloatUnit, IntegerUnit, Unit};
-
-#[doc(hidden)]
-#[must_use]
-pub const fn coverage_gate_probe(value: u8) -> &'static str {
-    match value {
-        0 => "zero",
-        _ => "nonzero",
-    }
-}


### PR DESCRIPTION
## Summary

This makes coverage upload on every pull request and authenticates same-repository runs with OIDC while preserving Codecov's [documented tokenless flow](https://docs.codecov.com/docs/codecov-tokens#commits-on-unprotected-branches) for public fork pull requests. Codecov project coverage allows at most a 1% regression, patch coverage requires 90%, and missing or rejected reports fail.

Refs #389

## Test Plan

`uvx prek run -a`, pinned-action verification, Codecov YAML validation, and CI. Calibration commit [`f7d2a15`](https://github.com/MatthewMckee4/gdsr/commit/f7d2a1507dbe6999faf0381ac38c9c52608b1ef2) passed every workflow job while `codecov/patch` failed at 0.00% against the 90.00% target; the temporary probe is absent from the final diff.