### PR TITLE
Document docs-only CI behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,9 @@ Always use the pull request template and add labels. Write the description in
 concise prose paragraphs, with code examples only when they help the reviewer.
 Do not use checkboxes. Do not add AI tooling as an author or co-author.
 
+Every pull request must receive independent review from an agent that did not
+author its changes. Resolve all findings before merge.
+
 Never merge a pull request unless every required check for the exact current
 head commit has completed successfully. `main` must also be green. The only
 exception is a narrowly scoped pull request whose sole purpose is restoring

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,8 +160,9 @@ Documentation-only pull requests still run coverage so `codecov/project` and
 `codecov/patch` resolve. Rust platform tests and benchmarks may skip only when
 `determine changes` reports `code=false`; `CI gate` validates that combination.
 
-The repository has one code owner, so GitHub code-owner review is disabled.
-The independent-agent review policy in `AGENTS.md` remains mandatory.
+GitHub code-owner review is disabled because the sole code owner cannot approve
+their own pull request. Independent review by a non-author agent remains
+mandatory under `AGENTS.md`.
 
 The required status contexts are `CI gate`, `codecov/project`, and
 `codecov/patch`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,5 +156,9 @@ gh api repos/MatthewMckee4/gdsr/rulesets/1435762 \
   --jq '.rules as $rules | [$rules[] | select(.type == "required_status_checks")] as $status_rules | [$rules[] | select(.type == "pull_request")] as $pull_request_rules | ($status_rules[0].parameters) as $checks | ($pull_request_rules[0].parameters) as $pull_request | if (.target == "branch" and ($status_rules | length) == 1 and ($pull_request_rules | length) == 1 and .enforcement == "active" and .conditions.ref_name == {"exclude":[],"include":["~DEFAULT_BRANCH"]} and .bypass_actors == [] and $checks.strict_required_status_checks_policy == true and $checks.do_not_enforce_on_create == true and ([$checks.required_status_checks[].context] | sort) == (["CI gate","codecov/patch","codecov/project"] | sort) and $pull_request == {"required_approving_review_count":0,"dismiss_stale_reviews_on_push":true,"require_code_owner_review":true,"require_last_push_approval":false,"required_review_thread_resolution":false,"allowed_merge_methods":["merge","squash","rebase"]}) then {target, enforcement, conditions, bypass_actors, required_status_checks: $checks, pull_request: $pull_request} else error("ruleset mismatch") end'
 ```
 
+Documentation-only pull requests still run coverage so `codecov/project` and
+`codecov/patch` resolve. Rust platform tests and benchmarks may skip only when
+`determine changes` reports `code=false`; `CI gate` validates that combination.
+
 The required status contexts are `CI gate`, `codecov/project`, and
 `codecov/patch`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,12 +153,15 @@ Audit the active default-branch ruleset with:
 ```bash
 gh api repos/MatthewMckee4/gdsr/rulesets/1435762
 gh api repos/MatthewMckee4/gdsr/rulesets/1435762 \
-  --jq '.rules as $rules | [$rules[] | select(.type == "required_status_checks")] as $status_rules | [$rules[] | select(.type == "pull_request")] as $pull_request_rules | ($status_rules[0].parameters) as $checks | ($pull_request_rules[0].parameters) as $pull_request | if (.target == "branch" and ($status_rules | length) == 1 and ($pull_request_rules | length) == 1 and .enforcement == "active" and .conditions.ref_name == {"exclude":[],"include":["~DEFAULT_BRANCH"]} and .bypass_actors == [] and $checks.strict_required_status_checks_policy == true and $checks.do_not_enforce_on_create == true and ([$checks.required_status_checks[].context] | sort) == (["CI gate","codecov/patch","codecov/project"] | sort) and $pull_request == {"required_approving_review_count":0,"dismiss_stale_reviews_on_push":true,"require_code_owner_review":true,"require_last_push_approval":false,"required_review_thread_resolution":false,"allowed_merge_methods":["merge","squash","rebase"]}) then {target, enforcement, conditions, bypass_actors, required_status_checks: $checks, pull_request: $pull_request} else error("ruleset mismatch") end'
+  --jq '.rules as $rules | [$rules[] | select(.type == "required_status_checks")] as $status_rules | [$rules[] | select(.type == "pull_request")] as $pull_request_rules | ($status_rules[0].parameters) as $checks | ($pull_request_rules[0].parameters) as $pull_request | if (.target == "branch" and ($status_rules | length) == 1 and ($pull_request_rules | length) == 1 and .enforcement == "active" and .conditions.ref_name == {"exclude":[],"include":["~DEFAULT_BRANCH"]} and .bypass_actors == [] and $checks.strict_required_status_checks_policy == true and $checks.do_not_enforce_on_create == true and ([$checks.required_status_checks[].context] | sort) == (["CI gate","codecov/patch","codecov/project"] | sort) and $pull_request == {"required_approving_review_count":0,"dismiss_stale_reviews_on_push":true,"require_code_owner_review":false,"require_last_push_approval":false,"required_review_thread_resolution":false,"allowed_merge_methods":["merge","squash","rebase"]}) then {target, enforcement, conditions, bypass_actors, required_status_checks: $checks, pull_request: $pull_request} else error("ruleset mismatch") end'
 ```
 
 Documentation-only pull requests still run coverage so `codecov/project` and
 `codecov/patch` resolve. Rust platform tests and benchmarks may skip only when
 `determine changes` reports `code=false`; `CI gate` validates that combination.
+
+The repository has one code owner, so GitHub code-owner review is disabled.
+The independent-agent review policy in `AGENTS.md` remains mandatory.
 
 The required status contexts are `CI gate`, `codecov/project`, and
 `codecov/patch`.


### PR DESCRIPTION
## Summary

Documents documentation-only CI behavior and records the ruleset audit expected for a single-code-owner repository. GitHub code-owner review stays disabled to avoid self-review deadlock; `AGENTS.md` now requires independent review by a non-author agent with findings resolved before merge. Refs #392.

## Test Plan

`uvx prek run --files AGENTS.md CONTRIBUTING.md` and `uvx prek run -a`.