### PR TITLE
Add checked database-unit conversion policies

### DIFF
--- a/crates/gdsr-benchmark/benches/io.rs
+++ b/crates/gdsr-benchmark/benches/io.rs
@@ -3,9 +3,9 @@ use std::io::Write;
 
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
 use gdsr::{
-    Cell, DataType, Element, GdsBox, GdsFileWriter, Grid, HorizontalPresentation, Layer, Library,
-    Node, Path, PathType, Point, Polygon, Property, Radians, Reference, Text, Unit,
-    VerticalPresentation,
+    Cell, DataType, Element, GdsBox, GdsFileWriter, GdsRoundingPolicy, GdsWriteOptions, Grid,
+    HorizontalPresentation, Layer, Library, Node, Path, PathType, Point, Polygon, Property,
+    Radians, Reference, Text, Unit, VerticalPresentation,
 };
 use tempfile::NamedTempFile;
 
@@ -198,6 +198,35 @@ fn mixed_library(element_count: usize) -> Library {
     library
 }
 
+fn float_library(element_count: usize) -> Library {
+    let mut library = Library::new("bench_float");
+    let mut cell = Cell::new("top");
+    for index in 0..element_count {
+        let coordinate = index as f64 * 100.0 + 0.25;
+        let points = [
+            Point::float(coordinate, 0.25, DATABASE_UNITS),
+            Point::float(coordinate + 10.5, 20.75, DATABASE_UNITS),
+        ];
+        let layer = Layer::new((index % 64) as u16);
+        let data_type = DataType::new((index % 8) as u16);
+        if index % 2 == 0 {
+            cell.add(Node::new(points.to_vec(), layer, data_type));
+        } else {
+            cell.add(Path::new(
+                points,
+                layer,
+                data_type,
+                None,
+                Some(Unit::float(10.25, DATABASE_UNITS)),
+                None,
+                None,
+            ));
+        }
+    }
+    library.add_cell(cell);
+    library
+}
+
 fn hierarchy_library() -> Library {
     const LEAF_CELLS: i32 = 50;
     const SHAPES_PER_LEAF: i32 = 200;
@@ -323,6 +352,29 @@ fn bench_write_bytes(c: &mut Criterion, fixtures: &[Fixture]) {
     group.finish();
 }
 
+fn bench_write_bytes_with_options(c: &mut Criterion) {
+    let library = float_library(10_000);
+    let database_units = DATABASE_UNITS * 2.0;
+    let options = GdsWriteOptions::new(GdsRoundingPolicy::Nearest);
+    let encoded_size = library
+        .to_bytes_with_options(USER_UNITS, database_units, options)
+        .expect("benchmark library should serialize")
+        .0
+        .len() as u64;
+    let mut group = c.benchmark_group("write_bytes_options");
+    group.throughput(Throughput::Bytes(encoded_size));
+    group.bench_function("quantized_float_10k", |b| {
+        b.iter(|| {
+            black_box(
+                library
+                    .to_bytes_with_options(USER_UNITS, database_units, options)
+                    .expect("benchmark library should serialize"),
+            )
+        });
+    });
+    group.finish();
+}
+
 fn bench_write_stream(c: &mut Criterion, fixture: &Fixture) {
     let mut group = c.benchmark_group("write_stream");
     group.throughput(Throughput::Bytes(fixture.encoded_size));
@@ -374,6 +426,7 @@ fn bench_io(c: &mut Criterion) {
     bench_read_file(c, &fixtures);
     bench_read_file_filtered(c, mixed_50k);
     bench_write_bytes(c, &fixtures);
+    bench_write_bytes_with_options(c);
     bench_write_stream(c, hierarchy_10k);
     bench_write_file(c, mixed_50k);
 }

--- a/crates/gdsr-viewer/src/app.rs
+++ b/crates/gdsr-viewer/src/app.rs
@@ -2918,8 +2918,24 @@ mod tests {
     fn save_file_to_path_writes_library_and_clears_dirty_state() {
         let dir = tempfile::tempdir().expect("temporary directory should be created");
         let path = dir.path().join("saved.gds");
+        let mut source_cell = Cell::new("top");
+        source_cell.add(Polygon::new(
+            [
+                Point::integer(0, 0, DEFAULT_INTEGER_UNITS),
+                Point::integer(10, 0, DEFAULT_INTEGER_UNITS),
+                Point::integer(10, 10, DEFAULT_INTEGER_UNITS),
+                Point::integer(0, 10, DEFAULT_INTEGER_UNITS),
+            ],
+            Layer::new(1),
+            DataType::new(0),
+        ));
+        let mut library = Library::new("test");
+        library.add_cell(source_cell);
+        let mut cell = CellState::new(library);
+        cell.selected_cell = Some("top".to_string());
+        assert!(cell.load_direct_cell_elements("top"));
         let mut app = ViewerApp {
-            cell: Some(cell_state_with_test_elements()),
+            cell: Some(cell),
             has_unsaved_changes: true,
             ..Default::default()
         };

--- a/crates/gdsr/src/io/write/conversion.rs
+++ b/crates/gdsr/src/io/write/conversion.rs
@@ -1,0 +1,781 @@
+use std::fmt;
+
+use super::gds_format::eight_byte_real;
+use crate::{GdsError, GdsTimestampPolicy, Unit};
+
+/// Rounding applied when physical values do not fall on the output database grid.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum GdsRoundingPolicy {
+    /// Round to the nearest grid point. Half-grid values round away from zero.
+    #[default]
+    Nearest,
+    /// Round toward negative infinity.
+    ///
+    /// Scaled values within one ULP of an integer are treated as exact.
+    Floor,
+    /// Round toward positive infinity.
+    ///
+    /// Scaled values within one ULP of an integer are treated as exact.
+    Ceil,
+    /// Reject values that do not fall on the database grid.
+    ///
+    /// A one-ULP tolerance avoids rejecting exact physical values solely because of
+    /// binary floating-point representation.
+    ErrorIfOffGrid,
+}
+
+/// Options for built-in GDS serialization.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct GdsWriteOptions {
+    rounding_policy: GdsRoundingPolicy,
+    timestamp_policy: GdsTimestampPolicy,
+    collect_report: bool,
+}
+
+impl Default for GdsWriteOptions {
+    fn default() -> Self {
+        Self::new(GdsRoundingPolicy::Nearest)
+    }
+}
+
+impl GdsWriteOptions {
+    /// Creates options using `rounding_policy` and current timestamps.
+    pub const fn new(rounding_policy: GdsRoundingPolicy) -> Self {
+        Self {
+            rounding_policy,
+            timestamp_policy: GdsTimestampPolicy::Current,
+            collect_report: true,
+        }
+    }
+
+    /// Returns the coordinate rounding policy.
+    pub const fn rounding_policy(self) -> GdsRoundingPolicy {
+        self.rounding_policy
+    }
+
+    /// Returns the timestamp policy.
+    pub const fn timestamp_policy(self) -> GdsTimestampPolicy {
+        self.timestamp_policy
+    }
+
+    /// Sets the timestamp policy.
+    #[must_use]
+    pub const fn with_timestamp_policy(mut self, timestamp_policy: GdsTimestampPolicy) -> Self {
+        self.timestamp_policy = timestamp_policy;
+        self
+    }
+
+    pub(super) const fn without_report(mut self) -> Self {
+        self.collect_report = false;
+        self
+    }
+
+    pub(super) const fn collects_report(self) -> bool {
+        self.collect_report
+    }
+}
+
+/// One element affected by database-grid quantization.
+#[derive(Clone, Debug, PartialEq)]
+pub struct GdsQuantization {
+    cell_name: String,
+    element_index: usize,
+    element_type: String,
+    representative_field: String,
+    affected_field_count: usize,
+    physical_value: f64,
+    database_value: i32,
+    physical_error: f64,
+}
+
+impl GdsQuantization {
+    /// Returns the containing cell name.
+    pub fn cell_name(&self) -> &str {
+        &self.cell_name
+    }
+
+    /// Returns the element index within the cell.
+    pub const fn element_index(&self) -> usize {
+        self.element_index
+    }
+
+    /// Returns the element kind.
+    pub fn element_type(&self) -> &str {
+        &self.element_type
+    }
+
+    /// Returns a field with the element's largest quantization error.
+    pub fn field(&self) -> &str {
+        &self.representative_field
+    }
+
+    /// Returns how many fields in this element changed.
+    pub const fn affected_field_count(&self) -> usize {
+        self.affected_field_count
+    }
+
+    /// Returns the source physical value in metres.
+    pub const fn physical_value(&self) -> f64 {
+        self.physical_value
+    }
+
+    /// Returns the written database-unit value.
+    pub const fn database_value(&self) -> i32 {
+        self.database_value
+    }
+
+    /// Returns the absolute physical quantization error in metres.
+    pub const fn physical_error(&self) -> f64 {
+        self.physical_error
+    }
+}
+
+/// Summary of physical values changed while writing.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct GdsConversionReport {
+    max_physical_quantization_error: f64,
+    affected_locations: Vec<GdsQuantization>,
+}
+
+impl GdsConversionReport {
+    /// Returns the largest absolute physical quantization error in metres.
+    pub const fn max_physical_quantization_error(&self) -> f64 {
+        self.max_physical_quantization_error
+    }
+
+    /// Returns affected elements in this report's established order.
+    ///
+    /// Completed library writes and finished stream reports are sorted by cell name
+    /// and numeric element index. A report borrowed from a live stream writer uses
+    /// cell write order until that writer is finished.
+    pub fn affected_locations(&self) -> &[GdsQuantization] {
+        &self.affected_locations
+    }
+
+    pub(super) fn extend(&mut self, mut other: Self) {
+        self.max_physical_quantization_error = self
+            .max_physical_quantization_error
+            .max(other.max_physical_quantization_error);
+        for location in other.affected_locations.drain(..) {
+            if let Some(existing) = self.affected_locations.last_mut()
+                && existing.cell_name == location.cell_name
+                && existing.element_index == location.element_index
+                && existing.element_type == location.element_type
+            {
+                existing.affected_field_count += location.affected_field_count;
+                if location.physical_error > existing.physical_error {
+                    existing.representative_field = location.representative_field;
+                    existing.physical_value = location.physical_value;
+                    existing.database_value = location.database_value;
+                    existing.physical_error = location.physical_error;
+                }
+            } else {
+                self.affected_locations.push(location);
+            }
+        }
+    }
+
+    pub(super) fn sort(&mut self) {
+        self.affected_locations.sort_by(|left, right| {
+            (
+                &left.cell_name,
+                left.element_index,
+                &left.element_type,
+                &left.representative_field,
+            )
+                .cmp(&(
+                    &right.cell_name,
+                    right.element_index,
+                    &right.element_type,
+                    &right.representative_field,
+                ))
+        });
+    }
+}
+
+pub(super) struct CoordinateConverter<'a> {
+    database_units: f64,
+    policy: GdsRoundingPolicy,
+    cell_name: &'a str,
+    element_index: usize,
+    element_type: &'a str,
+    field_prefix: Option<String>,
+    collect_report: bool,
+    report: GdsConversionReport,
+}
+
+pub(super) trait CoordinateConversion {
+    fn convert_unit(&mut self, value: Unit, field: impl fmt::Display) -> Result<i32, GdsError>;
+    fn physical_value(
+        &self,
+        value: Unit,
+        field: &(impl fmt::Display + ?Sized),
+    ) -> Result<f64, GdsError>;
+    fn convert_physical(
+        &mut self,
+        physical_value: f64,
+        field: impl fmt::Display,
+    ) -> Result<i32, GdsError>;
+    fn checked_array_endpoint(
+        &mut self,
+        origin: i32,
+        spacing: i32,
+        count: u32,
+        physical_value: f64,
+        field: impl fmt::Display,
+    ) -> Result<i32, GdsError>;
+    fn validate_finite(&self, value: f64, field: &str) -> Result<(), GdsError>;
+    fn validate_positive(&self, value: f64, field: &str) -> Result<(), GdsError>;
+    fn encode_gds_real8(&self, value: f64, field: &str) -> Result<[u8; 8], GdsError>;
+    fn validate_closed(&self, first: [i32; 2], last: [i32; 2], field: &str)
+    -> Result<(), GdsError>;
+}
+
+pub(super) struct NearestCoordinateConverter<'a> {
+    database_units: f64,
+    cell_name: &'a str,
+    element_index: usize,
+    element_type: &'a str,
+}
+
+impl<'a> NearestCoordinateConverter<'a> {
+    #[inline]
+    pub(super) fn new(database_units: f64, element_type: &'a str) -> Result<Self, GdsError> {
+        validate_database_units(database_units)?;
+        Ok(Self::new_validated(
+            database_units,
+            "<standalone>",
+            0,
+            element_type,
+        ))
+    }
+
+    #[inline]
+    pub(super) const fn new_validated(
+        database_units: f64,
+        cell_name: &'a str,
+        element_index: usize,
+        element_type: &'a str,
+    ) -> Self {
+        Self {
+            database_units,
+            cell_name,
+            element_index,
+            element_type,
+        }
+    }
+
+    #[cold]
+    fn error(&self, field: &(impl fmt::Display + ?Sized), message: &str) -> GdsError {
+        GdsError::ValidationError {
+            message: format!(
+                "Cell '{}', element {} ({}), field '{field}': {message}",
+                self.cell_name, self.element_index, self.element_type
+            ),
+        }
+    }
+}
+
+impl CoordinateConversion for NearestCoordinateConverter<'_> {
+    #[inline]
+    fn convert_unit(&mut self, value: Unit, field: impl fmt::Display) -> Result<i32, GdsError> {
+        if let Unit::Integer(integer) = value
+            && integer.units == self.database_units
+        {
+            return Ok(integer.value);
+        }
+        let physical_value = self.physical_value(value, &field)?;
+        self.convert_physical(physical_value, field)
+    }
+
+    #[inline]
+    fn physical_value(
+        &self,
+        value: Unit,
+        field: &(impl fmt::Display + ?Sized),
+    ) -> Result<f64, GdsError> {
+        if !value.units().is_finite() || value.units() <= 0.0 {
+            return Err(self.error(
+                field,
+                &format!(
+                    "source units must be finite and positive, got {}",
+                    value.units()
+                ),
+            ));
+        }
+        let physical_value = value.absolute_value();
+        if !physical_value.is_finite() {
+            return Err(self.error(
+                field,
+                &format!("physical value {physical_value} is not finite"),
+            ));
+        }
+        Ok(physical_value)
+    }
+
+    #[inline]
+    fn convert_physical(
+        &mut self,
+        physical_value: f64,
+        field: impl fmt::Display,
+    ) -> Result<i32, GdsError> {
+        if !physical_value.is_finite() {
+            return Err(self.error(
+                &field,
+                &format!("physical value {physical_value} is not finite"),
+            ));
+        }
+        let scaled = physical_value / self.database_units;
+        if !scaled.is_finite() {
+            return Err(self.error(
+                &field,
+                &format!(
+                    "physical value {physical_value} cannot be represented using database unit {}",
+                    self.database_units
+                ),
+            ));
+        }
+        let rounded = scaled.round();
+        if rounded < f64::from(i32::MIN) || rounded > f64::from(i32::MAX) {
+            return Err(self.error(
+                &field,
+                &format!(
+                    "physical value {physical_value} rounds to {rounded}, outside the GDS i32 range"
+                ),
+            ));
+        }
+        Ok(rounded as i32)
+    }
+
+    #[inline]
+    fn checked_array_endpoint(
+        &mut self,
+        origin: i32,
+        spacing: i32,
+        count: u32,
+        physical_value: f64,
+        field: impl fmt::Display,
+    ) -> Result<i32, GdsError> {
+        if !physical_value.is_finite() {
+            return Err(self.error(
+                &field,
+                &format!("physical value {physical_value} is not finite"),
+            ));
+        }
+        let database_value = i64::from(origin) + i64::from(spacing) * i64::from(count);
+        i32::try_from(database_value).map_err(|_| {
+            self.error(
+                &field,
+                &format!("derived database value {database_value} is outside the GDS i32 range"),
+            )
+        })
+    }
+
+    #[inline]
+    fn validate_finite(&self, value: f64, field: &str) -> Result<(), GdsError> {
+        if !value.is_finite() {
+            return Err(self.error(field, &format!("value {value} is not finite")));
+        }
+        Ok(())
+    }
+
+    #[inline]
+    fn validate_positive(&self, value: f64, field: &str) -> Result<(), GdsError> {
+        self.validate_finite(value, field)?;
+        if value <= 0.0 {
+            return Err(self.error(field, &format!("value {value} must be positive")));
+        }
+        Ok(())
+    }
+
+    #[inline]
+    fn encode_gds_real8(&self, value: f64, field: &str) -> Result<[u8; 8], GdsError> {
+        eight_byte_real(value).map_err(|error| {
+            self.error(
+                field,
+                &format!("value {value} cannot be encoded as GDS REAL8: {error}"),
+            )
+        })
+    }
+
+    #[inline]
+    fn validate_closed(
+        &self,
+        first: [i32; 2],
+        last: [i32; 2],
+        field: &str,
+    ) -> Result<(), GdsError> {
+        if first != last {
+            return Err(self.error(
+                field,
+                &format!(
+                    "shape is not closed after database-unit conversion: first point {first:?}, last point {last:?}"
+                ),
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl<'a> CoordinateConverter<'a> {
+    pub(super) fn new(
+        database_units: f64,
+        policy: GdsRoundingPolicy,
+        cell_name: &'a str,
+        element_index: usize,
+        element_type: &'a str,
+    ) -> Result<Self, GdsError> {
+        validate_database_units(database_units)?;
+        Ok(Self {
+            database_units,
+            policy,
+            cell_name,
+            element_index,
+            element_type,
+            field_prefix: None,
+            collect_report: true,
+            report: GdsConversionReport::default(),
+        })
+    }
+
+    pub(super) fn with_field_prefix(mut self, field_prefix: Option<String>) -> Self {
+        self.field_prefix = field_prefix;
+        self
+    }
+
+    pub(super) const fn without_report(mut self) -> Self {
+        self.collect_report = false;
+        self
+    }
+
+    pub(super) fn convert_unit(
+        &mut self,
+        value: Unit,
+        field: impl fmt::Display,
+    ) -> Result<i32, GdsError> {
+        if let Unit::Integer(integer) = value
+            && integer.units == self.database_units
+        {
+            return Ok(integer.value);
+        }
+        if !value.units().is_finite() || value.units() <= 0.0 {
+            return Err(self.error(
+                &field,
+                &format!(
+                    "source units must be finite and positive, got {}",
+                    value.units()
+                ),
+            ));
+        }
+        let physical_value = value.absolute_value();
+        if !physical_value.is_finite() {
+            return Err(self.error(
+                &field,
+                &format!("physical value {physical_value} is not finite"),
+            ));
+        }
+        self.convert_physical(physical_value, field)
+    }
+
+    pub(super) fn physical_value(
+        &self,
+        value: Unit,
+        field: &(impl fmt::Display + ?Sized),
+    ) -> Result<f64, GdsError> {
+        if !value.units().is_finite() || value.units() <= 0.0 {
+            return Err(self.error(
+                field,
+                &format!(
+                    "source units must be finite and positive, got {}",
+                    value.units()
+                ),
+            ));
+        }
+        let physical_value = value.absolute_value();
+        if !physical_value.is_finite() {
+            return Err(self.error(
+                field,
+                &format!("physical value {physical_value} is not finite"),
+            ));
+        }
+        Ok(physical_value)
+    }
+
+    pub(super) fn convert_physical(
+        &mut self,
+        physical_value: f64,
+        field: impl fmt::Display,
+    ) -> Result<i32, GdsError> {
+        if !physical_value.is_finite() {
+            return Err(self.error(
+                &field,
+                &format!("physical value {physical_value} is not finite"),
+            ));
+        }
+
+        let scaled = physical_value / self.database_units;
+        if !scaled.is_finite() {
+            return Err(self.error(
+                &field,
+                &format!(
+                    "physical value {physical_value} cannot be represented using database unit {}",
+                    self.database_units
+                ),
+            ));
+        }
+
+        let nearest = scaled.round();
+        let rounded = match self.policy {
+            GdsRoundingPolicy::Nearest => nearest,
+            policy => {
+                let snapped = if within_one_ulp(scaled, nearest) {
+                    nearest
+                } else {
+                    scaled
+                };
+                match policy {
+                    GdsRoundingPolicy::Floor => snapped.floor(),
+                    GdsRoundingPolicy::Ceil => snapped.ceil(),
+                    GdsRoundingPolicy::ErrorIfOffGrid => {
+                        if snapped != nearest {
+                            return Err(self.error(
+                                &field,
+                                &format!(
+                                    "physical value {physical_value} is off the {} database-unit grid",
+                                    self.database_units
+                                ),
+                            ));
+                        }
+                        nearest
+                    }
+                    GdsRoundingPolicy::Nearest => nearest,
+                }
+            }
+        };
+
+        if rounded < f64::from(i32::MIN) || rounded > f64::from(i32::MAX) {
+            return Err(self.error(
+                &field,
+                &format!(
+                    "physical value {physical_value} rounds to {rounded}, outside the GDS i32 range"
+                ),
+            ));
+        }
+
+        let database_value = rounded as i32;
+        self.record_quantization(physical_value, database_value, field);
+        Ok(database_value)
+    }
+
+    pub(super) fn checked_array_endpoint(
+        &mut self,
+        origin: i32,
+        spacing: i32,
+        count: u32,
+        physical_value: f64,
+        field: impl fmt::Display,
+    ) -> Result<i32, GdsError> {
+        if !physical_value.is_finite() {
+            return Err(self.error(
+                &field,
+                &format!("physical value {physical_value} is not finite"),
+            ));
+        }
+        let database_value = i64::from(origin) + i64::from(spacing) * i64::from(count);
+        let Ok(database_value) = i32::try_from(database_value) else {
+            return Err(self.error(
+                &field,
+                &format!("derived database value {database_value} is outside the GDS i32 range"),
+            ));
+        };
+        self.record_quantization(physical_value, database_value, field);
+        Ok(database_value)
+    }
+
+    fn record_quantization(
+        &mut self,
+        physical_value: f64,
+        database_value: i32,
+        field: impl fmt::Display,
+    ) {
+        if !self.collect_report {
+            return;
+        }
+        let physical_error =
+            (physical_value - f64::from(database_value) * self.database_units).abs();
+        let scaled = physical_value / self.database_units;
+        if physical_error > 0.0 && !within_one_ulp(scaled, f64::from(database_value)) {
+            self.report.max_physical_quantization_error = self
+                .report
+                .max_physical_quantization_error
+                .max(physical_error);
+            let representative_field = if let Some(prefix) = &self.field_prefix {
+                format!("{prefix}.{field}")
+            } else {
+                field.to_string()
+            };
+            if let Some(location) = self.report.affected_locations.first_mut() {
+                location.affected_field_count += 1;
+                if physical_error > location.physical_error {
+                    location.representative_field = representative_field;
+                    location.physical_value = physical_value;
+                    location.database_value = database_value;
+                    location.physical_error = physical_error;
+                }
+            } else {
+                self.report.affected_locations.push(GdsQuantization {
+                    cell_name: self.cell_name.to_string(),
+                    element_index: self.element_index,
+                    element_type: self.element_type.to_string(),
+                    representative_field,
+                    affected_field_count: 1,
+                    physical_value,
+                    database_value,
+                    physical_error,
+                });
+            }
+        }
+    }
+
+    pub(super) fn finish(self) -> GdsConversionReport {
+        self.report
+    }
+
+    pub(super) fn validate_finite(&self, value: f64, field: &str) -> Result<(), GdsError> {
+        if !value.is_finite() {
+            return Err(self.error(field, &format!("value {value} is not finite")));
+        }
+        Ok(())
+    }
+
+    pub(super) fn validate_positive(&self, value: f64, field: &str) -> Result<(), GdsError> {
+        self.validate_finite(value, field)?;
+        if value <= 0.0 {
+            return Err(self.error(field, &format!("value {value} must be positive")));
+        }
+        Ok(())
+    }
+
+    pub(super) fn encode_gds_real8(&self, value: f64, field: &str) -> Result<[u8; 8], GdsError> {
+        eight_byte_real(value).map_err(|error| {
+            self.error(
+                field,
+                &format!("value {value} cannot be encoded as GDS REAL8: {error}"),
+            )
+        })
+    }
+
+    pub(super) fn validate_closed(
+        &self,
+        first: [i32; 2],
+        last: [i32; 2],
+        field: &str,
+    ) -> Result<(), GdsError> {
+        if first != last {
+            return Err(self.error(
+                field,
+                &format!(
+                    "shape is not closed after database-unit conversion: first point {first:?}, last point {last:?}"
+                ),
+            ));
+        }
+        Ok(())
+    }
+
+    fn error(&self, field: &(impl fmt::Display + ?Sized), message: &str) -> GdsError {
+        let field = if let Some(prefix) = &self.field_prefix {
+            format!("{prefix}.{field}")
+        } else {
+            field.to_string()
+        };
+        GdsError::ValidationError {
+            message: format!(
+                "Cell '{}', element {} ({}), field '{field}': {message}",
+                self.cell_name, self.element_index, self.element_type
+            ),
+        }
+    }
+}
+
+impl CoordinateConversion for CoordinateConverter<'_> {
+    fn convert_unit(&mut self, value: Unit, field: impl fmt::Display) -> Result<i32, GdsError> {
+        CoordinateConverter::convert_unit(self, value, field)
+    }
+
+    fn physical_value(
+        &self,
+        value: Unit,
+        field: &(impl fmt::Display + ?Sized),
+    ) -> Result<f64, GdsError> {
+        CoordinateConverter::physical_value(self, value, field)
+    }
+
+    fn convert_physical(
+        &mut self,
+        physical_value: f64,
+        field: impl fmt::Display,
+    ) -> Result<i32, GdsError> {
+        CoordinateConverter::convert_physical(self, physical_value, field)
+    }
+
+    fn checked_array_endpoint(
+        &mut self,
+        origin: i32,
+        spacing: i32,
+        count: u32,
+        physical_value: f64,
+        field: impl fmt::Display,
+    ) -> Result<i32, GdsError> {
+        CoordinateConverter::checked_array_endpoint(
+            self,
+            origin,
+            spacing,
+            count,
+            physical_value,
+            field,
+        )
+    }
+
+    fn validate_finite(&self, value: f64, field: &str) -> Result<(), GdsError> {
+        CoordinateConverter::validate_finite(self, value, field)
+    }
+
+    fn validate_positive(&self, value: f64, field: &str) -> Result<(), GdsError> {
+        CoordinateConverter::validate_positive(self, value, field)
+    }
+
+    fn encode_gds_real8(&self, value: f64, field: &str) -> Result<[u8; 8], GdsError> {
+        CoordinateConverter::encode_gds_real8(self, value, field)
+    }
+
+    fn validate_closed(
+        &self,
+        first: [i32; 2],
+        last: [i32; 2],
+        field: &str,
+    ) -> Result<(), GdsError> {
+        CoordinateConverter::validate_closed(self, first, last, field)
+    }
+}
+
+fn within_one_ulp(left: f64, right: f64) -> bool {
+    fn ordered_bits(value: f64) -> u64 {
+        let bits = value.to_bits();
+        if value.is_sign_negative() {
+            !bits
+        } else {
+            bits | (1_u64 << 63)
+        }
+    }
+
+    ordered_bits(left).abs_diff(ordered_bits(right)) <= 1
+}
+
+pub(super) fn validate_database_units(database_units: f64) -> Result<(), GdsError> {
+    if !database_units.is_finite() || database_units <= 0.0 {
+        return Err(GdsError::ValidationError {
+            message: format!("Database units must be finite and positive, got {database_units}"),
+        });
+    }
+    Ok(())
+}

--- a/crates/gdsr/src/io/write/gds_format.rs
+++ b/crates/gdsr/src/io/write/gds_format.rs
@@ -1,43 +1,61 @@
-pub fn eight_byte_real(value: f64) -> [u8; 8] {
+use std::fmt;
+
+/// Smallest positive normalized GDS REAL8 value, `16^-65`.
+pub(super) const MIN_GDS_REAL8_MAGNITUDE: f64 = f64::from_bits(763_u64 << 52);
+/// Exclusive upper magnitude bound for GDS REAL8, `16^63`.
+pub(super) const MAX_GDS_REAL8_MAGNITUDE: f64 = f64::from_bits(1275_u64 << 52);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum GdsReal8Error {
+    NonFinite,
+    MagnitudeTooSmall,
+    MagnitudeTooLarge,
+}
+
+impl fmt::Display for GdsReal8Error {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NonFinite => formatter.write_str("value must be finite"),
+            Self::MagnitudeTooSmall => write!(
+                formatter,
+                "nonzero magnitude must be at least {MIN_GDS_REAL8_MAGNITUDE}"
+            ),
+            Self::MagnitudeTooLarge => write!(
+                formatter,
+                "magnitude must be less than {MAX_GDS_REAL8_MAGNITUDE}"
+            ),
+        }
+    }
+}
+
+#[inline]
+pub(super) fn eight_byte_real(value: f64) -> Result<[u8; 8], GdsReal8Error> {
+    if !value.is_finite() {
+        return Err(GdsReal8Error::NonFinite);
+    }
     if value == 0.0 {
-        return [0x00; 8];
+        return Ok([0x00; 8]);
     }
 
-    let mut byte1: u8;
-    let mut val = value;
-
-    if val < 0.0 {
-        byte1 = 0x80;
-        val = -val;
-    } else {
-        byte1 = 0x00;
+    let magnitude = value.abs();
+    if magnitude < MIN_GDS_REAL8_MAGNITUDE {
+        return Err(GdsReal8Error::MagnitudeTooSmall);
+    }
+    if magnitude >= MAX_GDS_REAL8_MAGNITUDE {
+        return Err(GdsReal8Error::MagnitudeTooLarge);
     }
 
-    let fexp = val.log2() / 4.0;
-    let mut exponent = fexp.ceil() as i32;
-
-    if fexp == f64::from(exponent) {
-        exponent += 1;
-    }
-
-    let mantissa = (val * 16.0_f64.powi(14 - exponent)) as u64;
-    byte1 += (exponent + 64) as u8;
-
-    let byte2 = (mantissa >> 48) as u8;
-    let short3 = ((mantissa >> 32) & 0xFFFF) as u16;
-    let long4 = (mantissa & 0xFFFF_FFFF) as u32;
-
+    let bits = magnitude.to_bits();
+    let binary_exponent = ((bits >> 52) & 0x7ff) as i32 - 1023;
+    let exponent = binary_exponent.div_euclid(4) + 1;
+    let encoded_exponent = (exponent + 64) as u8;
+    let significand = (bits & ((1_u64 << 52) - 1)) | (1_u64 << 52);
+    let mantissa = significand << binary_exponent.rem_euclid(4);
+    let sign = if value.is_sign_negative() { 0x80 } else { 0 };
     let mut result = [0u8; 8];
-    result[0] = byte1;
-    result[1] = byte2;
-    result[2] = (short3 >> 8) as u8;
-    result[3] = (short3 & 0xFF) as u8;
-    result[4] = (long4 >> 24) as u8;
-    result[5] = (long4 >> 16) as u8;
-    result[6] = (long4 >> 8) as u8;
-    result[7] = (long4 & 0xFF) as u8;
-
-    result
+    result[0] = sign | encoded_exponent;
+    result[1..].copy_from_slice(&mantissa.to_be_bytes()[1..]);
+    Ok(result)
 }
 
 pub fn write_u16_array_as_big_endian(
@@ -59,7 +77,7 @@ mod tests {
     #[test]
     fn test_eight_byte_real_zero() {
         let value = 0.0;
-        let result = eight_byte_real(value);
+        let result = eight_byte_real(value).expect("zero should be representable");
 
         assert_debug_snapshot!(result, @r"
         [
@@ -78,7 +96,7 @@ mod tests {
     #[test]
     fn test_eight_byte_real_negative() {
         let value = -123.456;
-        let result = eight_byte_real(value);
+        let result = eight_byte_real(value).expect("value should be representable");
 
         assert_debug_snapshot!(result, @r"
         [
@@ -97,7 +115,7 @@ mod tests {
     #[test]
     fn test_eight_byte_real_positive() {
         let value = 123.456;
-        let result = eight_byte_real(value);
+        let result = eight_byte_real(value).expect("value should be representable");
 
         assert_debug_snapshot!(result, @r"
         [
@@ -116,7 +134,7 @@ mod tests {
     #[test]
     fn test_height_byte_real_log() {
         let value = 16.0;
-        let result = eight_byte_real(value);
+        let result = eight_byte_real(value).expect("value should be representable");
 
         assert_debug_snapshot!(result, @r"
         [
@@ -130,5 +148,15 @@ mod tests {
             0,
         ]
         ");
+    }
+
+    #[test]
+    fn eight_byte_real_checks_format_boundaries() {
+        assert!(eight_byte_real(MIN_GDS_REAL8_MAGNITUDE).is_ok());
+        assert!(eight_byte_real(f64::from_bits(MIN_GDS_REAL8_MAGNITUDE.to_bits() - 1)).is_err());
+        assert!(eight_byte_real(f64::from_bits(MAX_GDS_REAL8_MAGNITUDE.to_bits() - 1)).is_ok());
+        assert!(eight_byte_real(MAX_GDS_REAL8_MAGNITUDE).is_err());
+        assert!(eight_byte_real(f64::INFINITY).is_err());
+        assert!(eight_byte_real(f64::NAN).is_err());
     }
 }

--- a/crates/gdsr/src/io/write/mod.rs
+++ b/crates/gdsr/src/io/write/mod.rs
@@ -1,7 +1,9 @@
+mod conversion;
 mod gds_format;
 pub mod svg;
 pub mod validation;
 
+use std::fmt;
 use std::io::Write;
 
 use rayon::prelude::*;
@@ -15,6 +17,10 @@ use crate::{
     Cell, Element, GdsBox, GdsTimestampPolicy, GdsTimestamps, Instance, Library, Movable, Node,
     Path, Point, Polygon, Property, Reference, Text, Transformable,
 };
+use conversion::{
+    CoordinateConversion, CoordinateConverter, NearestCoordinateConverter, validate_database_units,
+};
+pub use conversion::{GdsConversionReport, GdsQuantization, GdsRoundingPolicy, GdsWriteOptions};
 use gds_format::{eight_byte_real, write_u16_array_as_big_endian};
 use validation::{
     validate_col_row, validate_data_type, validate_layer, validate_node_points,
@@ -122,7 +128,16 @@ pub trait GdsWriter: Sync {
 /// Default GDS writer using standard GDSII serialization.
 pub struct GdsFileWriter;
 
-impl GdsWriter for GdsFileWriter {}
+impl GdsWriter for GdsFileWriter {
+    fn write_cell_with_timestamps(
+        &self,
+        cell: &Cell,
+        db_units: f64,
+        timestamps: GdsTimestamps,
+    ) -> Result<Vec<u8>, GdsError> {
+        write_default_cell_with_timestamps(cell, db_units, timestamps)
+    }
+}
 
 /// Writes a GDS library incrementally to an output stream.
 ///
@@ -148,8 +163,9 @@ impl GdsWriter for GdsFileWriter {}
 pub struct GdsStreamWriter<W> {
     output: W,
     database_units: f64,
-    timestamp_policy: GdsTimestampPolicy,
+    options: GdsWriteOptions,
     current_timestamps: GdsTimestamps,
+    conversion_report: GdsConversionReport,
 }
 
 impl<W: Write> GdsStreamWriter<W> {
@@ -160,13 +176,30 @@ impl<W: Write> GdsStreamWriter<W> {
         user_units: f64,
         database_units: f64,
     ) -> Result<Self, GdsError> {
+        Self::new_with_options(
+            output,
+            library_name,
+            user_units,
+            database_units,
+            GdsWriteOptions::default().without_report(),
+        )
+    }
+
+    /// Starts a streaming write using explicit coordinate and timestamp options.
+    pub fn new_with_options(
+        output: W,
+        library_name: &str,
+        user_units: f64,
+        database_units: f64,
+        options: GdsWriteOptions,
+    ) -> Result<Self, GdsError> {
         Self::start(
             output,
             library_name,
             None,
             user_units,
             database_units,
-            GdsTimestampPolicy::Current,
+            options,
         )
     }
 
@@ -182,13 +215,27 @@ impl<W: Write> GdsStreamWriter<W> {
         database_units: f64,
         timestamp_policy: GdsTimestampPolicy,
     ) -> Result<Self, GdsError> {
+        let options = GdsWriteOptions::default()
+            .with_timestamp_policy(timestamp_policy)
+            .without_report();
+        Self::from_library_with_options(output, library, user_units, database_units, options)
+    }
+
+    /// Starts a streaming write from a library using explicit serialization options.
+    pub fn from_library_with_options(
+        output: W,
+        library: &Library,
+        user_units: f64,
+        database_units: f64,
+        options: GdsWriteOptions,
+    ) -> Result<Self, GdsError> {
         Self::start(
             output,
             library.name(),
             library.timestamps(),
             user_units,
             database_units,
-            timestamp_policy,
+            options,
         )
     }
 
@@ -198,11 +245,11 @@ impl<W: Write> GdsStreamWriter<W> {
         library_timestamps: Option<GdsTimestamps>,
         user_units: f64,
         database_units: f64,
-        timestamp_policy: GdsTimestampPolicy,
+        options: GdsWriteOptions,
     ) -> Result<Self, GdsError> {
         let current_timestamps = GdsTimestamps::current();
         let timestamps = resolve_timestamps(
-            timestamp_policy,
+            options.timestamp_policy(),
             library_timestamps,
             current_timestamps,
             "library",
@@ -219,25 +266,47 @@ impl<W: Write> GdsStreamWriter<W> {
         Ok(Self {
             output,
             database_units,
-            timestamp_policy,
+            options,
             current_timestamps,
+            conversion_report: GdsConversionReport::default(),
         })
     }
 
     /// Serializes and flushes one cell to the library.
+    ///
+    /// If this fails, cells written by earlier calls remain in the output. The
+    /// caller should discard the partial stream when atomic output is required.
     pub fn write_cell(&mut self, cell: &Cell) -> Result<(), GdsError> {
         let timestamps = resolve_timestamps(
-            self.timestamp_policy,
+            self.options.timestamp_policy(),
             cell.timestamps(),
             self.current_timestamps,
             "cell",
             cell.name(),
         )?;
-        let bytes =
-            GdsFileWriter.write_cell_with_timestamps(cell, self.database_units, timestamps)?;
+        if !self.options.collects_report()
+            && self.options.rounding_policy() == GdsRoundingPolicy::Nearest
+        {
+            let bytes =
+                GdsFileWriter.write_cell_with_timestamps(cell, self.database_units, timestamps)?;
+            self.output.write_all(&bytes)?;
+            self.output.flush()?;
+            return Ok(());
+        }
+        let (bytes, report) =
+            write_cell_with_options(cell, self.database_units, self.options, timestamps)?;
         self.output.write_all(&bytes)?;
         self.output.flush()?;
+        self.conversion_report.extend(report);
         Ok(())
+    }
+
+    /// Returns the conversion report accumulated by cells written so far.
+    ///
+    /// Affected locations follow cell write order. [`Self::finish_with_report`]
+    /// sorts its returned report by cell name and numeric element index.
+    pub const fn conversion_report(&self) -> &GdsConversionReport {
+        &self.conversion_report
     }
 
     /// Writes and flushes the library footer, returning the output stream.
@@ -246,18 +315,18 @@ impl<W: Write> GdsStreamWriter<W> {
         self.output.flush()?;
         Ok(self.output)
     }
+
+    /// Finishes the library and returns the output plus its conversion report.
+    pub fn finish_with_report(mut self) -> Result<(W, GdsConversionReport), GdsError> {
+        write_gds_tail_to_file(&mut self.output)?;
+        self.output.flush()?;
+        self.conversion_report.sort();
+        Ok((self.output, self.conversion_report))
+    }
 }
 
 pub fn write_u16_array(buffer: &mut impl Write, array: &[u16]) -> Result<(), GdsError> {
     Ok(write_u16_array_as_big_endian(buffer, array)?)
-}
-
-fn write_float_to_eight_byte_real_to_file(
-    buffer: &mut impl Write,
-    value: f64,
-) -> Result<(), GdsError> {
-    let value = eight_byte_real(value);
-    Ok(buffer.write_all(&value)?)
 }
 
 fn cell_head_record(timestamps: GdsTimestamps) -> [u16; 14] {
@@ -290,6 +359,19 @@ fn write_gds_head_to_file(
     timestamps: GdsTimestamps,
     buffer: &mut impl Write,
 ) -> Result<(), GdsError> {
+    fn encode_unit(value: f64, name: &str) -> Result<[u8; 8], GdsError> {
+        if !value.is_finite() || value <= 0.0 {
+            return Err(GdsError::ValidationError {
+                message: format!("{name} must be finite and positive, got {value}"),
+            });
+        }
+        eight_byte_real(value).map_err(|error| GdsError::ValidationError {
+            message: format!("{name} {value} cannot be encoded as GDS REAL8: {error}"),
+        })
+    }
+
+    let encoded_user_units = encode_unit(user_units, "User units")?;
+    let encoded_database_units = encode_unit(db_units, "Database units")?;
     let [s1, h1] = record_header(GDSRecord::Header, GDSDataType::TwoByteSignedInteger, 1);
     let [s2, h2] = record_header(GDSRecord::BgnLib, GDSDataType::TwoByteSignedInteger, 12);
     let ts = timestamps.to_record();
@@ -298,14 +380,17 @@ fn write_gds_head_to_file(
         ts[9], ts[10], ts[11],
     ];
 
-    write_u16_array(buffer, &head_start)?;
-    write_string_with_record_to_file(buffer, GDSRecord::LibName, library_name)?;
+    let mut header = Vec::with_capacity(64 + library_name.len());
+    write_u16_array(&mut header, &head_start)?;
+    write_string_with_record_to_file(&mut header, GDSRecord::LibName, library_name)?;
     write_u16_array(
-        buffer,
+        &mut header,
         &record_header(GDSRecord::Units, GDSDataType::EightByteReal, 2),
     )?;
-    write_float_to_eight_byte_real_to_file(buffer, user_units)?;
-    write_float_to_eight_byte_real_to_file(buffer, db_units)
+    header.extend_from_slice(&encoded_user_units);
+    header.extend_from_slice(&encoded_database_units);
+    buffer.write_all(&header)?;
+    Ok(())
 }
 
 fn write_gds_tail_to_file(buffer: &mut impl Write) -> Result<(), GdsError> {
@@ -318,8 +403,22 @@ fn write_gds_tail_to_file(buffer: &mut impl Write) -> Result<(), GdsError> {
 fn write_points_to_file(
     buffer: &mut impl Write,
     points: &[Point],
-    database_units: f64,
+    converter: &mut impl CoordinateConversion,
+    field: &str,
+    require_closed: bool,
 ) -> Result<(), GdsError> {
+    struct PointField<'a> {
+        field: &'a str,
+        index: usize,
+        axis: char,
+    }
+
+    impl fmt::Display for PointField<'_> {
+        fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(formatter, "{}[{}].{}", self.field, self.index, self.axis)
+        }
+    }
+
     validate_point_limit(points, "XY record")?;
 
     let record_size = GDSDataType::FourByteSignedInteger.record_size(points.len() as u16 * 2);
@@ -330,18 +429,76 @@ fn write_points_to_file(
 
     write_u16_array(buffer, &xy_header_buffer)?;
 
-    for point in points {
-        let point = point.to_integer_unit();
-        let x_real = point.x().absolute_value();
-        let y_real = point.y().absolute_value();
-
-        let scaled_x = (x_real / database_units).round() as i32;
-        let scaled_y = (y_real / database_units).round() as i32;
-
-        buffer.write_all(&scaled_x.to_be_bytes())?;
-        buffer.write_all(&scaled_y.to_be_bytes())?;
+    if require_closed {
+        let mut first = None;
+        let mut last = None;
+        for (index, point) in points.iter().enumerate() {
+            let scaled_x = converter.convert_unit(
+                point.x(),
+                PointField {
+                    field,
+                    index,
+                    axis: 'x',
+                },
+            )?;
+            let scaled_y = converter.convert_unit(
+                point.y(),
+                PointField {
+                    field,
+                    index,
+                    axis: 'y',
+                },
+            )?;
+            first.get_or_insert([scaled_x, scaled_y]);
+            last = Some([scaled_x, scaled_y]);
+            buffer.write_all(&scaled_x.to_be_bytes())?;
+            buffer.write_all(&scaled_y.to_be_bytes())?;
+        }
+        if let (Some(first), Some(last)) = (first, last) {
+            converter.validate_closed(first, last, field)?;
+        }
+    } else {
+        for (index, point) in points.iter().enumerate() {
+            let scaled_x = converter.convert_unit(
+                point.x(),
+                PointField {
+                    field,
+                    index,
+                    axis: 'x',
+                },
+            )?;
+            let scaled_y = converter.convert_unit(
+                point.y(),
+                PointField {
+                    field,
+                    index,
+                    axis: 'y',
+                },
+            )?;
+            buffer.write_all(&scaled_x.to_be_bytes())?;
+            buffer.write_all(&scaled_y.to_be_bytes())?;
+        }
     }
 
+    Ok(())
+}
+
+fn write_database_points_to_file(
+    buffer: &mut impl Write,
+    points: &[[i32; 2]],
+) -> Result<(), GdsError> {
+    let record_size = GDSDataType::FourByteSignedInteger.record_size(points.len() as u16 * 2);
+    write_u16_array(
+        buffer,
+        &[
+            record_size,
+            record_head(GDSRecord::XY, GDSDataType::FourByteSignedInteger),
+        ],
+    )?;
+    for [x, y] in points {
+        buffer.write_all(&x.to_be_bytes())?;
+        buffer.write_all(&y.to_be_bytes())?;
+    }
     Ok(())
 }
 
@@ -399,7 +556,21 @@ fn write_transformation_to_file(
     angle: f64,
     magnification: f64,
     x_reflection: bool,
+    converter: &impl CoordinateConversion,
 ) -> Result<(), GdsError> {
+    let encoded_magnification = if magnification == 1.0 {
+        None
+    } else {
+        if magnification <= 0.0 {
+            converter.validate_positive(magnification, "magnification")?;
+        }
+        Some(converter.encode_gds_real8(magnification, "magnification")?)
+    };
+    let encoded_angle = if angle == 0.0 {
+        None
+    } else {
+        Some(converter.encode_gds_real8(angle, "angle")?)
+    };
     let transform_applied = angle != 0.0 || magnification != 1.0 || x_reflection;
     if transform_applied {
         let buffer_flags = [
@@ -410,22 +581,22 @@ fn write_transformation_to_file(
 
         write_u16_array(buffer, &buffer_flags)?;
 
-        if magnification != 1.0 {
+        if let Some(encoded_magnification) = encoded_magnification {
             let buffer_mag = [
                 GDSDataType::EightByteReal.record_size(1),
                 record_head(GDSRecord::Mag, GDSDataType::EightByteReal),
             ];
             write_u16_array(buffer, &buffer_mag)?;
-            write_float_to_eight_byte_real_to_file(buffer, magnification)?;
+            buffer.write_all(&encoded_magnification)?;
         }
 
-        if angle != 0.0 {
+        if let Some(encoded_angle) = encoded_angle {
             let buffer_rot = [
                 GDSDataType::EightByteReal.record_size(1),
                 record_head(GDSRecord::Angle, GDSDataType::EightByteReal),
             ];
             write_u16_array(buffer, &buffer_rot)?;
-            write_float_to_eight_byte_real_to_file(buffer, angle)?;
+            buffer.write_all(&encoded_angle)?;
         }
     }
 
@@ -443,6 +614,62 @@ fn element_head(
     let [s2, h2] = record_header(GDSRecord::Layer, GDSDataType::TwoByteSignedInteger, 1);
     let [s3, h3] = record_header(type_record, GDSDataType::TwoByteSignedInteger, 1);
     [s1, h1, s2, h2, layer, s3, h3, type_value]
+}
+
+/// Serializes a library with the built-in writer and returns its conversion report.
+///
+/// Custom [`GdsWriter`] overrides are intentionally not used by this API.
+pub fn write_library_with_options(
+    library: &Library,
+    user_units: f64,
+    db_units: f64,
+    options: GdsWriteOptions,
+) -> Result<(Vec<u8>, GdsConversionReport), GdsError> {
+    let current_timestamps = GdsTimestamps::current();
+    let library_timestamps = resolve_timestamps(
+        options.timestamp_policy(),
+        library.timestamps(),
+        current_timestamps,
+        "library",
+        library.name(),
+    )?;
+    let mut buffer = Vec::new();
+    write_gds_head_to_file(
+        library.name(),
+        user_units,
+        db_units,
+        library_timestamps,
+        &mut buffer,
+    )?;
+
+    let mut cells: Vec<&Cell> = library.cells().values().collect();
+    cells.sort_unstable_by(|left, right| left.name().cmp(right.name()));
+    let cells = cells
+        .par_iter()
+        .map(|cell| {
+            let timestamps = resolve_timestamps(
+                options.timestamp_policy(),
+                cell.timestamps(),
+                current_timestamps,
+                "cell",
+                cell.name(),
+            )?;
+            write_cell_with_options(cell, db_units, options, timestamps)
+        })
+        .collect::<Vec<_>>();
+
+    let mut report = GdsConversionReport::default();
+    for cell in cells {
+        let (bytes, cell_report) = cell?;
+        buffer.extend_from_slice(&bytes);
+        if options.collects_report() {
+            report.extend(cell_report);
+        }
+    }
+
+    write_gds_tail_to_file(&mut buffer)?;
+    report.sort();
+    Ok((buffer, report))
 }
 
 /// Serializes an entire library to GDS bytes.
@@ -489,7 +716,7 @@ pub fn write_library_with_timestamp_policy(
     let mut cells: Vec<&Cell> = library.cells().values().collect();
     cells.sort_unstable_by(|left, right| left.name().cmp(right.name()));
 
-    for buf in cells
+    let cells = cells
         .par_iter()
         .map(|cell| {
             let timestamps = resolve_timestamps(
@@ -501,8 +728,9 @@ pub fn write_library_with_timestamp_policy(
             )?;
             writer.write_cell_with_timestamps(cell, db_units, timestamps)
         })
-        .collect::<Result<Vec<_>, GdsError>>()?
-    {
+        .collect::<Vec<_>>();
+    for cell in cells {
+        let buf = cell?;
         buffer.extend_from_slice(&buf);
     }
 
@@ -545,18 +773,20 @@ pub fn write_cell_with_timestamps(
     db_units: f64,
     timestamps: GdsTimestamps,
 ) -> Result<Vec<u8>, GdsError> {
+    validate_database_units(db_units)?;
     validate_structure_name(cell.name())?;
 
     let mut buffer = Vec::new();
     write_u16_array(&mut buffer, &cell_head_record(timestamps))?;
     write_string_with_record_to_file(&mut buffer, GDSRecord::StrName, cell.name())?;
 
-    for buf in cell
+    let elements = cell
         .elements()
         .par_iter()
         .map(|element| writer.write_element(element, db_units))
-        .collect::<Result<Vec<_>, GdsError>>()?
-    {
+        .collect::<Vec<_>>();
+    for element in elements {
+        let buf = element?;
         buffer.extend_from_slice(&buf);
     }
 
@@ -566,6 +796,115 @@ pub fn write_cell_with_timestamps(
     )?;
 
     Ok(buffer)
+}
+
+fn write_default_cell_with_timestamps(
+    cell: &Cell,
+    db_units: f64,
+    timestamps: GdsTimestamps,
+) -> Result<Vec<u8>, GdsError> {
+    validate_database_units(db_units)?;
+    validate_structure_name(cell.name())?;
+
+    let mut buffer = Vec::new();
+    write_u16_array(&mut buffer, &cell_head_record(timestamps))?;
+    write_string_with_record_to_file(&mut buffer, GDSRecord::StrName, cell.name())?;
+
+    let elements = cell
+        .elements()
+        .par_iter()
+        .enumerate()
+        .map(|(element_index, element)| {
+            write_default_element(element, db_units, cell.name(), element_index)
+        })
+        .collect::<Vec<_>>();
+    for element in elements {
+        let bytes = element?;
+        buffer.extend_from_slice(&bytes);
+    }
+
+    write_u16_array(
+        &mut buffer,
+        &record_header(GDSRecord::EndStr, GDSDataType::NoData, 1),
+    )?;
+
+    Ok(buffer)
+}
+
+fn write_default_element(
+    element: &Element,
+    db_units: f64,
+    cell_name: &str,
+    element_index: usize,
+) -> Result<Vec<u8>, GdsError> {
+    let mut converter = NearestCoordinateConverter::new_validated(
+        db_units,
+        cell_name,
+        element_index,
+        element_type(element),
+    );
+    match element {
+        Element::Polygon(polygon) => write_polygon_with_converter(polygon, &mut converter),
+        Element::Path(path) => write_path_with_converter(path, &mut converter),
+        Element::Text(text) => write_text_with_converter(text, &mut converter),
+        Element::Reference(reference) => {
+            if let Instance::Cell(referenced_cell_name) = reference.instance() {
+                write_reference_cell(reference, referenced_cell_name, &mut converter)
+            } else {
+                write_reference_with_options(
+                    reference,
+                    db_units,
+                    GdsWriteOptions::default().without_report(),
+                    cell_name,
+                    element_index,
+                    None,
+                )
+                .map(|(bytes, _)| bytes)
+            }
+        }
+        Element::Box(gds_box) => write_box_with_converter(gds_box, &mut converter),
+        Element::Node(node) => write_node_with_converter(node, &mut converter),
+    }
+}
+
+fn write_cell_with_options(
+    cell: &Cell,
+    db_units: f64,
+    options: GdsWriteOptions,
+    timestamps: GdsTimestamps,
+) -> Result<(Vec<u8>, GdsConversionReport), GdsError> {
+    validate_database_units(db_units)?;
+    validate_structure_name(cell.name())?;
+
+    let mut buffer = Vec::new();
+    write_u16_array(&mut buffer, &cell_head_record(timestamps))?;
+    write_string_with_record_to_file(&mut buffer, GDSRecord::StrName, cell.name())?;
+
+    let elements = cell
+        .elements()
+        .par_iter()
+        .enumerate()
+        .map(|(element_index, element)| {
+            write_element_with_options(element, db_units, options, cell.name(), element_index)
+        })
+        .collect::<Vec<_>>();
+
+    let mut report = GdsConversionReport::default();
+    for element in elements {
+        let (bytes, element_report) = element?;
+        buffer.extend_from_slice(&bytes);
+        if options.collects_report() {
+            report.extend(element_report);
+        }
+    }
+
+    write_u16_array(
+        &mut buffer,
+        &record_header(GDSRecord::EndStr, GDSDataType::NoData, 1),
+    )?;
+
+    report.sort();
+    Ok((buffer, report))
 }
 
 fn resolve_timestamps(
@@ -586,8 +925,89 @@ fn resolve_timestamps(
     }
 }
 
+fn element_type(element: &Element) -> &'static str {
+    match element {
+        Element::Polygon(_) => "polygon",
+        Element::Path(_) => "path",
+        Element::Text(_) => "text",
+        Element::Reference(_) => "reference",
+        Element::Box(_) => "box",
+        Element::Node(_) => "node",
+    }
+}
+
+fn write_element_with_options(
+    element: &Element,
+    db_units: f64,
+    options: GdsWriteOptions,
+    cell_name: &str,
+    element_index: usize,
+) -> Result<(Vec<u8>, GdsConversionReport), GdsError> {
+    write_element_with_field_prefix(element, db_units, options, cell_name, element_index, None)
+}
+
+fn write_element_with_field_prefix(
+    element: &Element,
+    db_units: f64,
+    options: GdsWriteOptions,
+    cell_name: &str,
+    element_index: usize,
+    field_prefix: Option<String>,
+) -> Result<(Vec<u8>, GdsConversionReport), GdsError> {
+    if let Element::Reference(reference) = element {
+        return write_reference_with_options(
+            reference,
+            db_units,
+            options,
+            cell_name,
+            element_index,
+            field_prefix,
+        );
+    }
+
+    let reported_element_type = if field_prefix.is_some() {
+        "reference"
+    } else {
+        element_type(element)
+    };
+    let converter = CoordinateConverter::new(
+        db_units,
+        options.rounding_policy(),
+        cell_name,
+        element_index,
+        reported_element_type,
+    )?
+    .with_field_prefix(field_prefix);
+    let mut converter = if options.collects_report() {
+        converter
+    } else {
+        converter.without_report()
+    };
+    let bytes = match element {
+        Element::Polygon(polygon) => write_polygon_with_converter(polygon, &mut converter),
+        Element::Path(path) => write_path_with_converter(path, &mut converter),
+        Element::Text(text) => write_text_with_converter(text, &mut converter),
+        Element::Reference(_) => {
+            return Err(GdsError::ValidationError {
+                message: "Reference dispatch failed".to_string(),
+            });
+        }
+        Element::Box(gds_box) => write_box_with_converter(gds_box, &mut converter),
+        Element::Node(node) => write_node_with_converter(node, &mut converter),
+    }?;
+    Ok((bytes, converter.finish()))
+}
+
 /// Serializes a polygon to GDS bytes.
 pub fn write_polygon(polygon: &Polygon, db_units: f64) -> Result<Vec<u8>, GdsError> {
+    let mut converter = NearestCoordinateConverter::new(db_units, "polygon")?;
+    write_polygon_with_converter(polygon, &mut converter)
+}
+
+fn write_polygon_with_converter(
+    polygon: &Polygon,
+    converter: &mut impl CoordinateConversion,
+) -> Result<Vec<u8>, GdsError> {
     validate_polygon_points(polygon.points())?;
     validate_layer(polygon.layer())?;
     validate_data_type(polygon.data_type())?;
@@ -601,7 +1021,7 @@ pub fn write_polygon(polygon: &Polygon, db_units: f64) -> Result<Vec<u8>, GdsErr
         polygon.data_type().value(),
     );
     write_u16_array(&mut buffer, &head)?;
-    write_points_to_file(&mut buffer, polygon.points(), db_units)?;
+    write_points_to_file(&mut buffer, polygon.points(), converter, "point", true)?;
     write_element_tail_to_file(&mut buffer, polygon.properties())?;
 
     Ok(buffer)
@@ -609,6 +1029,14 @@ pub fn write_polygon(polygon: &Polygon, db_units: f64) -> Result<Vec<u8>, GdsErr
 
 /// Serializes a path to GDS bytes.
 pub fn write_path(path: &Path, db_units: f64) -> Result<Vec<u8>, GdsError> {
+    let mut converter = NearestCoordinateConverter::new(db_units, "path")?;
+    write_path_with_converter(path, &mut converter)
+}
+
+fn write_path_with_converter(
+    path: &Path,
+    converter: &mut impl CoordinateConversion,
+) -> Result<Vec<u8>, GdsError> {
     validate_path_points(path.points())?;
     validate_layer(path.layer())?;
     validate_data_type(path.data_type())?;
@@ -629,24 +1057,21 @@ pub fn write_path(path: &Path, db_units: f64) -> Result<Vec<u8>, GdsError> {
     }
 
     if let Some(width) = path.width() {
-        let scaled_width = width.scale_to(db_units);
-        let width_value = scaled_width.as_integer_unit().value;
+        let width_value = converter.convert_unit(width, "width")?;
         write_i32_record(&mut buffer, GDSRecord::Width, width_value)?;
     }
 
     if let Some(begin_ext) = path.begin_extension() {
-        let scaled = begin_ext.scale_to(db_units);
-        let value = scaled.as_integer_unit().value;
+        let value = converter.convert_unit(begin_ext, "begin_extension")?;
         write_i32_record(&mut buffer, GDSRecord::BgnExtn, value)?;
     }
 
     if let Some(end_ext) = path.end_extension() {
-        let scaled = end_ext.scale_to(db_units);
-        let value = scaled.as_integer_unit().value;
+        let value = converter.convert_unit(end_ext, "end_extension")?;
         write_i32_record(&mut buffer, GDSRecord::EndExtn, value)?;
     }
 
-    write_points_to_file(&mut buffer, path.points(), db_units)?;
+    write_points_to_file(&mut buffer, path.points(), converter, "point", false)?;
     write_element_tail_to_file(&mut buffer, path.properties())?;
 
     Ok(buffer)
@@ -654,8 +1079,17 @@ pub fn write_path(path: &Path, db_units: f64) -> Result<Vec<u8>, GdsError> {
 
 /// Serializes a text element to GDS bytes.
 pub fn write_text(text: &Text, db_units: f64) -> Result<Vec<u8>, GdsError> {
+    let mut converter = NearestCoordinateConverter::new(db_units, "text")?;
+    write_text_with_converter(text, &mut converter)
+}
+
+fn write_text_with_converter(
+    text: &Text,
+    converter: &mut impl CoordinateConversion,
+) -> Result<Vec<u8>, GdsError> {
     validate_layer(text.layer())?;
     validate_string_length(text.text())?;
+    let angle = text.angle().to_degrees().value();
 
     let mut buffer = Vec::new();
 
@@ -686,11 +1120,12 @@ pub fn write_text(text: &Text, db_units: f64) -> Result<Vec<u8>, GdsError> {
     )?;
     write_transformation_to_file(
         &mut buffer,
-        text.angle().to_degrees().value(),
+        angle,
         text.magnification(),
         text.x_reflection(),
+        converter,
     )?;
-    write_points_to_file(&mut buffer, &[*text.origin()], db_units)?;
+    write_points_to_file(&mut buffer, &[*text.origin()], converter, "origin", false)?;
     write_string_with_record_to_file(&mut buffer, GDSRecord::String, text.text())?;
     write_element_tail_to_file(&mut buffer, text.properties())?;
 
@@ -701,32 +1136,104 @@ pub fn write_text(text: &Text, db_units: f64) -> Result<Vec<u8>, GdsError> {
 ///
 /// Properties on inline references are appended to each expanded element.
 pub fn write_reference(reference: &Reference, db_units: f64) -> Result<Vec<u8>, GdsError> {
+    if let Instance::Cell(referenced_cell_name) = reference.instance() {
+        let mut converter = NearestCoordinateConverter::new(db_units, "reference")?;
+        return write_reference_cell(reference, referenced_cell_name, &mut converter);
+    }
+    write_reference_with_options(
+        reference,
+        db_units,
+        GdsWriteOptions::default().without_report(),
+        "<standalone>",
+        0,
+        None,
+    )
+    .map(|(bytes, _)| bytes)
+}
+
+fn write_reference_with_options(
+    reference: &Reference,
+    db_units: f64,
+    options: GdsWriteOptions,
+    cell_name: &str,
+    element_index: usize,
+    field_prefix: Option<String>,
+) -> Result<(Vec<u8>, GdsConversionReport), GdsError> {
     match reference.instance() {
-        Instance::Cell(cell_name) => write_reference_cell(reference, db_units, cell_name),
-        Instance::Element(element) => {
-            write_reference_element(reference, db_units, element.as_ref().as_ref())
+        Instance::Cell(referenced_cell_name) => {
+            let converter = CoordinateConverter::new(
+                db_units,
+                options.rounding_policy(),
+                cell_name,
+                element_index,
+                "reference",
+            )?
+            .with_field_prefix(field_prefix);
+            let mut converter = if options.collects_report() {
+                converter
+            } else {
+                converter.without_report()
+            };
+            let bytes = write_reference_cell(reference, referenced_cell_name, &mut converter)?;
+            Ok((bytes, converter.finish()))
         }
+        Instance::Element(element) => write_reference_element(
+            reference,
+            element.as_ref().as_ref(),
+            db_units,
+            options,
+            cell_name,
+            element_index,
+            field_prefix.as_deref(),
+        ),
     }
 }
 
 fn write_reference_element(
     reference: &Reference,
-    db_units: f64,
     element: &Element,
-) -> Result<Vec<u8>, GdsError> {
-    let grid = reference.grid();
+    db_units: f64,
+    options: GdsWriteOptions,
+    cell_name: &str,
+    element_index: usize,
+    field_prefix: Option<&str>,
+) -> Result<(Vec<u8>, GdsConversionReport), GdsError> {
+    let source_grid = reference.grid();
     let properties = reference.properties();
+
+    let grid_converter = CoordinateConverter::new(
+        db_units,
+        options.rounding_policy(),
+        cell_name,
+        element_index,
+        "reference",
+    )?
+    .with_field_prefix(field_prefix.map(str::to_owned));
+    grid_converter.validate_finite(source_grid.angle().value(), "angle")?;
+    grid_converter.validate_positive(source_grid.magnification(), "magnification")?;
+    grid_converter.physical_value(source_grid.origin().x(), "origin.x")?;
+    grid_converter.physical_value(source_grid.origin().y(), "origin.y")?;
+    if let Some(spacing) = source_grid.spacing_x() {
+        grid_converter.physical_value(spacing.x(), "spacing_x.x")?;
+        grid_converter.physical_value(spacing.y(), "spacing_x.y")?;
+    }
+    if let Some(spacing) = source_grid.spacing_y() {
+        grid_converter.physical_value(spacing.x(), "spacing_y.x")?;
+        grid_converter.physical_value(spacing.y(), "spacing_y.y")?;
+    }
+
+    let grid = source_grid.clone().to_float_unit();
     let spacing_x = grid.spacing_x().unwrap_or_default();
     let spacing_y = grid.spacing_y().unwrap_or_default();
-
     let mut buf = Vec::new();
+    let mut report = grid_converter.finish();
     for column_index in 0..grid.columns() {
         for row_index in 0..grid.rows() {
             let offset = (spacing_x * column_index) + (spacing_y * row_index);
             let rotated_offset = offset.rotate_around_point(grid.angle(), &Point::default());
-            let final_position = grid.origin() + rotated_offset;
+            let final_position = grid.origin().to_float_unit() + rotated_offset.to_float_unit();
 
-            let mut new_element = element.clone();
+            let mut new_element = element.clone().to_float_unit();
             if grid.x_reflection() {
                 new_element = new_element.reflect(crate::Radians::new(0.0), Point::default());
             }
@@ -737,16 +1244,30 @@ fn write_reference_element(
                 new_element.properties_mut().extend_from_slice(properties);
             }
 
-            buf.extend_from_slice(&GdsFileWriter.write_element(&new_element, db_units)?);
+            let expansion_prefix = if let Some(prefix) = &field_prefix {
+                format!("{prefix}.inline[{column_index},{row_index}]")
+            } else {
+                format!("inline[{column_index},{row_index}]")
+            };
+            let (bytes, element_report) = write_element_with_field_prefix(
+                &new_element,
+                db_units,
+                options,
+                cell_name,
+                element_index,
+                Some(expansion_prefix),
+            )?;
+            buf.extend_from_slice(&bytes);
+            report.extend(element_report);
         }
     }
-    Ok(buf)
+    Ok((buf, report))
 }
 
 fn write_reference_cell(
     reference: &Reference,
-    db_units: f64,
     cell_name: &str,
+    converter: &mut impl CoordinateConversion,
 ) -> Result<Vec<u8>, GdsError> {
     let grid = reference.grid();
     validate_structure_name(cell_name)?;
@@ -779,31 +1300,86 @@ fn write_reference_cell(
         grid.angle().to_degrees().value(),
         grid.magnification(),
         grid.x_reflection(),
+        converter,
     )?;
 
     if is_single_instance {
-        write_points_to_file(&mut buffer, &[grid.origin()], db_units)?;
+        write_points_to_file(&mut buffer, &[grid.origin()], converter, "origin", false)?;
     } else {
+        let grid = grid.clone().to_float_unit();
         let [size, head] = record_header(GDSRecord::ColRow, GDSDataType::TwoByteSignedInteger, 2);
         write_u16_array(
             &mut buffer,
             &[size, head, grid.columns() as u16, grid.rows() as u16],
         )?;
 
-        let origin = grid
-            .origin()
-            .rotate_around_point(grid.angle(), &grid.origin());
+        let origin = grid.origin();
+        let spacing_x = grid.spacing_x().unwrap_or_default();
+        let spacing_y = grid.spacing_y().unwrap_or_default();
+        let origin_x = converter.physical_value(origin.x(), "origin.x")?;
+        let origin_y = converter.physical_value(origin.y(), "origin.y")?;
+        let origin_database_x = converter.convert_physical(origin_x, "origin.x")?;
+        let origin_database_y = converter.convert_physical(origin_y, "origin.y")?;
 
-        let point2 = grid
-            .spacing_x()
-            .map(|sx| (origin + sx * grid.columns()).rotate_around_point(grid.angle(), &origin))
-            .unwrap_or(origin);
-        let point3 = grid
-            .spacing_y()
-            .map(|sy| (origin + sy * grid.rows()).rotate_around_point(grid.angle(), &origin))
-            .unwrap_or(origin);
+        let spacing_x_x = converter.physical_value(spacing_x.x(), "spacing_x.x")?;
+        let spacing_x_y = converter.physical_value(spacing_x.y(), "spacing_x.y")?;
+        let spacing_y_x = converter.physical_value(spacing_y.x(), "spacing_y.x")?;
+        let spacing_y_y = converter.physical_value(spacing_y.y(), "spacing_y.y")?;
+        let (sin, cos) = grid.angle().value().sin_cos();
+        let rotated_spacing_x_x = spacing_x_x.mul_add(cos, -(spacing_x_y * sin));
+        let rotated_spacing_x_y = spacing_x_x.mul_add(sin, spacing_x_y * cos);
+        let rotated_spacing_y_x = spacing_y_x.mul_add(cos, -(spacing_y_y * sin));
+        let rotated_spacing_y_y = spacing_y_x.mul_add(sin, spacing_y_y * cos);
+        let spacing_database_x_x =
+            converter.convert_physical(rotated_spacing_x_x, "spacing_x.rotated_x")?;
+        let spacing_database_x_y =
+            converter.convert_physical(rotated_spacing_x_y, "spacing_x.rotated_y")?;
+        let spacing_database_y_x =
+            converter.convert_physical(rotated_spacing_y_x, "spacing_y.rotated_x")?;
+        let spacing_database_y_y =
+            converter.convert_physical(rotated_spacing_y_y, "spacing_y.rotated_y")?;
 
-        write_points_to_file(&mut buffer, &[origin, point2, point3], db_units)?;
+        let point2_physical_x = rotated_spacing_x_x.mul_add(f64::from(grid.columns()), origin_x);
+        let point2_physical_y = rotated_spacing_x_y.mul_add(f64::from(grid.columns()), origin_y);
+        let point3_physical_x = rotated_spacing_y_x.mul_add(f64::from(grid.rows()), origin_x);
+        let point3_physical_y = rotated_spacing_y_y.mul_add(f64::from(grid.rows()), origin_y);
+        let point2_database_x = converter.checked_array_endpoint(
+            origin_database_x,
+            spacing_database_x_x,
+            grid.columns(),
+            point2_physical_x,
+            "aref_endpoint[1].x",
+        )?;
+        let point2_database_y = converter.checked_array_endpoint(
+            origin_database_y,
+            spacing_database_x_y,
+            grid.columns(),
+            point2_physical_y,
+            "aref_endpoint[1].y",
+        )?;
+        let point3_database_x = converter.checked_array_endpoint(
+            origin_database_x,
+            spacing_database_y_x,
+            grid.rows(),
+            point3_physical_x,
+            "aref_endpoint[2].x",
+        )?;
+        let point3_database_y = converter.checked_array_endpoint(
+            origin_database_y,
+            spacing_database_y_y,
+            grid.rows(),
+            point3_physical_y,
+            "aref_endpoint[2].y",
+        )?;
+
+        write_database_points_to_file(
+            &mut buffer,
+            &[
+                [origin_database_x, origin_database_y],
+                [point2_database_x, point2_database_y],
+                [point3_database_x, point3_database_y],
+            ],
+        )?;
     }
 
     write_element_tail_to_file(&mut buffer, reference.properties())?;
@@ -813,6 +1389,14 @@ fn write_reference_cell(
 
 /// Serializes a box to GDS bytes.
 pub fn write_box(gds_box: &GdsBox, db_units: f64) -> Result<Vec<u8>, GdsError> {
+    let mut converter = NearestCoordinateConverter::new(db_units, "box")?;
+    write_box_with_converter(gds_box, &mut converter)
+}
+
+fn write_box_with_converter(
+    gds_box: &GdsBox,
+    converter: &mut impl CoordinateConversion,
+) -> Result<Vec<u8>, GdsError> {
     validate_layer(gds_box.layer())?;
     validate_data_type(gds_box.box_type())?;
 
@@ -826,7 +1410,7 @@ pub fn write_box(gds_box: &GdsBox, db_units: f64) -> Result<Vec<u8>, GdsError> {
     );
     write_u16_array(&mut buffer, &head)?;
     let points = gds_box.points();
-    write_points_to_file(&mut buffer, &points, db_units)?;
+    write_points_to_file(&mut buffer, &points, converter, "point", true)?;
     write_element_tail_to_file(&mut buffer, gds_box.properties())?;
 
     Ok(buffer)
@@ -834,6 +1418,14 @@ pub fn write_box(gds_box: &GdsBox, db_units: f64) -> Result<Vec<u8>, GdsError> {
 
 /// Serializes a node to GDS bytes.
 pub fn write_node(node: &Node, db_units: f64) -> Result<Vec<u8>, GdsError> {
+    let mut converter = NearestCoordinateConverter::new(db_units, "node")?;
+    write_node_with_converter(node, &mut converter)
+}
+
+fn write_node_with_converter(
+    node: &Node,
+    converter: &mut impl CoordinateConversion,
+) -> Result<Vec<u8>, GdsError> {
     validate_node_points(node.points())?;
     validate_layer(node.layer())?;
     validate_data_type(node.node_type())?;
@@ -847,7 +1439,7 @@ pub fn write_node(node: &Node, db_units: f64) -> Result<Vec<u8>, GdsError> {
         node.node_type().value(),
     );
     write_u16_array(&mut buffer, &head)?;
-    write_points_to_file(&mut buffer, node.points(), db_units)?;
+    write_points_to_file(&mut buffer, node.points(), converter, "point", false)?;
     write_element_tail_to_file(&mut buffer, node.properties())?;
 
     Ok(buffer)
@@ -864,9 +1456,10 @@ mod tests {
     use crate::config::gds_file_types::GDSRecordData;
     use crate::elements::node::MAX_NODE_POINTS;
     use crate::io::read::RecordReader;
+    use crate::io::write::gds_format::{MAX_GDS_REAL8_MAGNITUDE, MIN_GDS_REAL8_MAGNITUDE};
     use crate::{
         DEFAULT_INTEGER_UNITS, DataType, GdsTimestampPolicy, GdsTimestamps, Grid, Layer, Library,
-        Property,
+        Property, Unit,
     };
 
     use super::validation::MAX_POINTS;
@@ -1090,7 +1683,15 @@ mod tests {
         );
 
         let mut bytes = Vec::new();
-        let error = write_points_to_file(&mut bytes, path.points(), DEFAULT_INTEGER_UNITS)
+        let mut converter = CoordinateConverter::new(
+            DEFAULT_INTEGER_UNITS,
+            GdsRoundingPolicy::Nearest,
+            "<standalone>",
+            0,
+            "path",
+        )
+        .expect("converter should be created");
+        let error = write_points_to_file(&mut bytes, path.points(), &mut converter, "point", false)
             .expect_err("oversized XY record should be rejected");
 
         assert!(bytes.is_empty());
@@ -1100,6 +1701,956 @@ mod tests {
                 "Validation error: XY record has {} points, which exceeds the maximum of {MAX_POINTS}",
                 MAX_POINTS + 1
             )
+        );
+    }
+
+    fn library_with_node(point: Point) -> Library {
+        let mut library = Library::new("conversion");
+        let mut cell = Cell::new("top");
+        cell.add(Node::new([point], Layer::new(1), DataType::new(0)));
+        library.add_cell(cell);
+        library
+    }
+
+    fn zero_timestamp_options(rounding_policy: GdsRoundingPolicy) -> GdsWriteOptions {
+        GdsWriteOptions::new(rounding_policy).with_timestamp_policy(GdsTimestampPolicy::Zero)
+    }
+
+    fn record_i32(bytes: &[u8], wanted: GDSRecord) -> Vec<i32> {
+        RecordReader::new(BufReader::new(bytes))
+            .find_map(
+                |record| match record.expect("written record should be readable") {
+                    (record, GDSRecordData::I32(values)) if record == wanted => Some(values),
+                    _ => None,
+                },
+            )
+            .expect("requested record should be present")
+    }
+
+    fn records_i32(bytes: &[u8], wanted: GDSRecord) -> Vec<Vec<i32>> {
+        RecordReader::new(BufReader::new(bytes))
+            .filter_map(
+                |record| match record.expect("written record should be readable") {
+                    (record, GDSRecordData::I32(values)) if record == wanted => Some(values),
+                    _ => None,
+                },
+            )
+            .collect()
+    }
+
+    fn record_f64(bytes: &[u8], wanted: GDSRecord) -> Vec<f64> {
+        RecordReader::new(BufReader::new(bytes))
+            .find_map(
+                |record| match record.expect("written record should be readable") {
+                    (record, GDSRecordData::F64(values)) if record == wanted => Some(values),
+                    _ => None,
+                },
+            )
+            .expect("requested record should be present")
+    }
+
+    #[test]
+    fn float_coordinates_are_scaled_before_rounding() {
+        let library = library_with_node(Point::float(0.4, -0.4, 1e-9));
+        let (bytes, report) = library
+            .to_bytes_with_options(
+                1e-6,
+                1e-10,
+                zero_timestamp_options(GdsRoundingPolicy::Nearest),
+            )
+            .expect("coordinate should be writable");
+
+        assert_eq!(record_i32(&bytes, GDSRecord::XY), [4, -4]);
+        assert!(report.affected_locations().is_empty());
+    }
+
+    #[test]
+    fn rounding_policies_are_deterministic_for_negative_half_grid_values() {
+        let library = library_with_node(Point::float(0.5, -0.5, 1.0));
+        for (policy, expected) in [
+            (GdsRoundingPolicy::Nearest, [1, -1]),
+            (GdsRoundingPolicy::Floor, [0, -1]),
+            (GdsRoundingPolicy::Ceil, [1, 0]),
+        ] {
+            let (bytes, report) = library
+                .to_bytes_with_options(1.0, 1.0, zero_timestamp_options(policy))
+                .expect("half-grid coordinate should be writable");
+
+            assert_eq!(record_i32(&bytes, GDSRecord::XY), expected);
+            assert_eq!(report.max_physical_quantization_error(), 0.5);
+            assert_eq!(report.affected_locations().len(), 1);
+            assert_eq!(report.affected_locations()[0].field(), "point[0].x");
+            assert_eq!(report.affected_locations()[0].affected_field_count(), 2);
+        }
+    }
+
+    #[test]
+    fn tiny_off_grid_values_follow_every_rounding_policy() {
+        let library = library_with_node(Point::float(1e-16, -1e-16, 1.0));
+        for (policy, expected) in [
+            (GdsRoundingPolicy::Nearest, [0, 0]),
+            (GdsRoundingPolicy::Floor, [0, -1]),
+            (GdsRoundingPolicy::Ceil, [1, 0]),
+        ] {
+            let (bytes, report) = library
+                .to_bytes_with_options(1.0, 1.0, zero_timestamp_options(policy))
+                .expect("tiny off-grid values should use the selected policy");
+
+            assert_eq!(record_i32(&bytes, GDSRecord::XY), expected);
+            assert_eq!(report.affected_locations()[0].affected_field_count(), 2);
+            assert!(report.max_physical_quantization_error() > 0.0);
+        }
+
+        let error = library
+            .to_bytes_with_options(
+                1.0,
+                1.0,
+                zero_timestamp_options(GdsRoundingPolicy::ErrorIfOffGrid),
+            )
+            .expect_err("tiny off-grid value should not be treated as zero");
+        assert!(error.to_string().contains("field 'point[0].x'"));
+        assert!(error.to_string().contains("off the 1 database-unit grid"));
+    }
+
+    #[test]
+    fn meaningful_i32_boundary_offset_follows_every_rounding_policy() {
+        let maximum = f64::from(i32::MAX);
+        let ulp = f64::from_bits(maximum.to_bits() + 1) - maximum;
+        let off_grid = maximum + 4.0 * ulp;
+        let library = library_with_node(Point::float(off_grid, 0.0, 1.0));
+
+        for policy in [GdsRoundingPolicy::Nearest, GdsRoundingPolicy::Floor] {
+            let (bytes, report) = library
+                .to_bytes_with_options(1.0, 1.0, zero_timestamp_options(policy))
+                .expect("in-range rounded boundary value should be writable");
+            assert_eq!(record_i32(&bytes, GDSRecord::XY), [i32::MAX, 0]);
+            assert_eq!(report.affected_locations().len(), 1);
+        }
+
+        let ceil_error = library
+            .to_bytes_with_options(1.0, 1.0, zero_timestamp_options(GdsRoundingPolicy::Ceil))
+            .expect_err("ceil should cross the i32 boundary");
+        assert!(ceil_error.to_string().contains("outside the GDS i32 range"));
+
+        let exact_error = library
+            .to_bytes_with_options(
+                1.0,
+                1.0,
+                zero_timestamp_options(GdsRoundingPolicy::ErrorIfOffGrid),
+            )
+            .expect_err("meaningful boundary offset should remain off-grid");
+        assert!(
+            exact_error
+                .to_string()
+                .contains("off the 1 database-unit grid")
+        );
+    }
+
+    #[test]
+    fn every_policy_snaps_near_integer_scaled_values() {
+        let library = library_with_node(Point::float(
+            2.999_999_999_999_999_6,
+            -2.999_999_999_999_999_6,
+            1.0,
+        ));
+        for policy in [
+            GdsRoundingPolicy::Nearest,
+            GdsRoundingPolicy::Floor,
+            GdsRoundingPolicy::Ceil,
+            GdsRoundingPolicy::ErrorIfOffGrid,
+        ] {
+            let (bytes, report) = library
+                .to_bytes_with_options(1.0, 1.0, zero_timestamp_options(policy))
+                .expect("near-grid value should be writable");
+            assert_eq!(record_i32(&bytes, GDSRecord::XY), [3, -3]);
+            assert!(report.affected_locations().is_empty());
+        }
+    }
+
+    #[test]
+    fn error_if_off_grid_accepts_ulp_residuals_and_rejects_real_offsets() {
+        let exact = library_with_node(Point::float(0.3, -0.3, 1.0));
+        let (bytes, _) = exact
+            .to_bytes_with_options(
+                1.0,
+                0.1,
+                zero_timestamp_options(GdsRoundingPolicy::ErrorIfOffGrid),
+            )
+            .expect("decimal grid value should survive binary representation");
+        assert_eq!(record_i32(&bytes, GDSRecord::XY), [3, -3]);
+
+        let off_grid = library_with_node(Point::float(0.31, 0.0, 1.0));
+        let error = off_grid
+            .to_bytes_with_options(
+                1.0,
+                0.1,
+                zero_timestamp_options(GdsRoundingPolicy::ErrorIfOffGrid),
+            )
+            .expect_err("off-grid value should be rejected");
+        insta::assert_snapshot!(
+            error.to_string(),
+            @"Validation error: Cell 'top', element 0 (node), field 'point[0].x': physical value 0.31 is off the 0.1 database-unit grid"
+        );
+    }
+
+    #[test]
+    fn invalid_units_and_coordinate_values_are_rejected() {
+        let library = library_with_node(Point::integer(0, 0, 1.0));
+        for database_units in [0.0, -1.0, f64::INFINITY, f64::NAN] {
+            let error = library
+                .to_bytes_with_options(
+                    1.0,
+                    database_units,
+                    zero_timestamp_options(GdsRoundingPolicy::Nearest),
+                )
+                .expect_err("invalid database units should be rejected");
+            assert!(error.to_string().contains("finite and positive"));
+        }
+        for user_units in [0.0, -1.0, f64::INFINITY, f64::NAN] {
+            let error = library
+                .to_bytes_with_options(
+                    user_units,
+                    1.0,
+                    zero_timestamp_options(GdsRoundingPolicy::Nearest),
+                )
+                .expect_err("invalid user units should be rejected");
+            assert!(error.to_string().contains("finite and positive"));
+        }
+
+        let nonfinite = library_with_node(Point::float(f64::NAN, 0.0, 1.0));
+        let error = nonfinite
+            .to_bytes_with_options(1.0, 1.0, zero_timestamp_options(GdsRoundingPolicy::Nearest))
+            .expect_err("nonfinite coordinate should be rejected");
+        assert!(error.to_string().contains("field 'point[0].x'"));
+        assert!(error.to_string().contains("not finite"));
+
+        for source_units in [0.0, -1.0, f64::INFINITY, f64::NAN] {
+            let invalid_source = library_with_node(Point::integer(1, 0, source_units));
+            let error = invalid_source
+                .to_bytes_with_options(1.0, 1.0, zero_timestamp_options(GdsRoundingPolicy::Nearest))
+                .expect_err("invalid source units should be rejected");
+            assert!(
+                error
+                    .to_string()
+                    .contains("source units must be finite and positive")
+            );
+        }
+    }
+
+    #[test]
+    fn real8_header_boundaries_are_checked_and_round_trip() {
+        let maximum_inside = f64::from_bits(MAX_GDS_REAL8_MAGNITUDE.to_bits().saturating_sub(1));
+        let library = Library::new("real8");
+        let (bytes, _) = library
+            .to_bytes_with_options(
+                MIN_GDS_REAL8_MAGNITUDE,
+                maximum_inside,
+                zero_timestamp_options(GdsRoundingPolicy::Nearest),
+            )
+            .expect("representable REAL8 boundaries should be writable");
+        assert_eq!(
+            record_f64(&bytes, GDSRecord::Units),
+            [MIN_GDS_REAL8_MAGNITUDE, maximum_inside]
+        );
+
+        let below_minimum = f64::from_bits(MIN_GDS_REAL8_MAGNITUDE.to_bits().saturating_sub(1));
+        for (user_units, database_units, field) in [
+            (below_minimum, 1.0, "User units"),
+            (1.0, MAX_GDS_REAL8_MAGNITUDE, "Database units"),
+        ] {
+            let error = library
+                .to_bytes_with_options(
+                    user_units,
+                    database_units,
+                    zero_timestamp_options(GdsRoundingPolicy::Nearest),
+                )
+                .expect_err("unrepresentable header unit should be rejected");
+            assert!(error.to_string().contains(field));
+            assert!(error.to_string().contains("GDS REAL8"));
+        }
+    }
+
+    #[test]
+    fn real8_transform_boundaries_are_checked_with_element_context() {
+        let maximum_inside = f64::from_bits(MAX_GDS_REAL8_MAGNITUDE.to_bits().saturating_sub(1));
+        for magnification in [MIN_GDS_REAL8_MAGNITUDE, maximum_inside] {
+            let reference =
+                Reference::new("leaf").with_grid(Grid::default().with_magnification(magnification));
+            let mut library = Library::new("real8");
+            library.add_cell(Cell::new("leaf"));
+            let mut top = Cell::new("top");
+            top.add(reference);
+            library.add_cell(top);
+
+            let (bytes, _) = library
+                .to_bytes_with_options(1.0, 1.0, zero_timestamp_options(GdsRoundingPolicy::Nearest))
+                .expect("representable transform should be writable");
+            assert_eq!(record_f64(&bytes, GDSRecord::Mag), [magnification]);
+        }
+
+        for (grid, field) in [
+            (
+                Grid::default().with_magnification(MAX_GDS_REAL8_MAGNITUDE),
+                "magnification",
+            ),
+            (
+                Grid::default().with_angle(crate::Radians::new(MAX_GDS_REAL8_MAGNITUDE)),
+                "angle",
+            ),
+            (
+                Grid::default().with_angle(crate::Radians::new(f64::MAX)),
+                "angle",
+            ),
+        ] {
+            let reference = Reference::new("leaf").with_grid(grid);
+            let mut library = Library::new("real8");
+            library.add_cell(Cell::new("leaf"));
+            let mut top = Cell::new("top");
+            top.add(reference);
+            library.add_cell(top);
+
+            let error = library
+                .to_bytes_with_options(1.0, 1.0, zero_timestamp_options(GdsRoundingPolicy::Nearest))
+                .expect_err("unrepresentable transform should be rejected");
+            assert!(
+                error
+                    .to_string()
+                    .contains(&format!("element 0 (reference), field '{field}'"))
+            );
+        }
+    }
+
+    #[test]
+    fn coordinate_overflow_is_rejected_before_casting() {
+        for value in [f64::from(i32::MAX) + 1.0, f64::from(i32::MIN) - 1.0] {
+            let library = library_with_node(Point::float(value, 0.0, 1.0));
+            let error = library
+                .to_bytes_with_options(1.0, 1.0, zero_timestamp_options(GdsRoundingPolicy::Nearest))
+                .expect_err("out-of-range coordinate should be rejected");
+            assert!(error.to_string().contains("outside the GDS i32 range"));
+            assert!(error.to_string().contains("Cell 'top', element 0 (node)"));
+        }
+    }
+
+    #[test]
+    fn exact_i32_coordinate_boundaries_are_accepted() {
+        let library = library_with_node(Point::integer(i32::MIN, i32::MAX, 1.0));
+        let (bytes, report) = library
+            .to_bytes_with_options(
+                1.0,
+                1.0,
+                zero_timestamp_options(GdsRoundingPolicy::ErrorIfOffGrid),
+            )
+            .expect("exact i32 boundaries should be writable");
+        assert_eq!(record_i32(&bytes, GDSRecord::XY), [i32::MIN, i32::MAX]);
+        assert!(report.affected_locations().is_empty());
+    }
+
+    #[test]
+    fn path_scalar_overflow_and_nonfinite_values_are_rejected() {
+        for (width, begin_extension, expected_field) in [
+            (
+                Some(Unit::float(f64::from(i32::MAX) + 1.0, 1.0)),
+                None,
+                "width",
+            ),
+            (
+                None,
+                Some(Unit::float(f64::INFINITY, 1.0)),
+                "begin_extension",
+            ),
+        ] {
+            let path = Path::new(
+                [Point::float(0.0, 0.0, 1.0), Point::float(1.0, 0.0, 1.0)],
+                Layer::new(1),
+                DataType::new(0),
+                None,
+                width,
+                begin_extension,
+                None,
+            );
+            let mut library = Library::new("conversion");
+            let mut cell = Cell::new("top");
+            cell.add(path);
+            library.add_cell(cell);
+
+            let error = library
+                .to_bytes_with_options(1.0, 1.0, zero_timestamp_options(GdsRoundingPolicy::Nearest))
+                .expect_err("invalid path scalar should be rejected");
+            assert!(
+                error
+                    .to_string()
+                    .contains(&format!("field '{expected_field}'"))
+            );
+        }
+    }
+
+    #[test]
+    fn polygon_must_remain_closed_after_conversion() {
+        let polygon = Polygon::new(
+            [
+                Point::float(0.0, 0.0, 1.0),
+                Point::float(1e-16, 0.0, 1.0),
+                Point::float(0.0, 1e-16, 1.0),
+                Point::float(5e-16, 0.0, 1.0),
+            ],
+            Layer::new(1),
+            DataType::new(0),
+        );
+        let mut library = Library::new("conversion");
+        let mut cell = Cell::new("top");
+        cell.add(polygon);
+        library.add_cell(cell);
+
+        let error = library
+            .to_bytes_with_options(
+                1.0,
+                1e-16,
+                zero_timestamp_options(GdsRoundingPolicy::Nearest),
+            )
+            .expect_err("quantized open polygon should be rejected");
+        assert!(
+            error
+                .to_string()
+                .contains("not closed after database-unit conversion")
+        );
+    }
+
+    #[test]
+    fn transform_values_must_be_finite_and_magnification_positive() {
+        for grid in [
+            Grid::default().with_magnification(0.0),
+            Grid::default().with_magnification(f64::NAN),
+            Grid::default().with_angle(crate::Radians::new(f64::INFINITY)),
+        ] {
+            let reference = Reference::new("leaf").with_grid(grid);
+            let mut library = Library::new("conversion");
+            library.add_cell(Cell::new("leaf"));
+            let mut top = Cell::new("top");
+            top.add(reference);
+            library.add_cell(top);
+
+            let error = library
+                .to_bytes_with_options(1.0, 1.0, zero_timestamp_options(GdsRoundingPolicy::Nearest))
+                .expect_err("invalid transform should be rejected");
+            assert!(
+                error.to_string().contains("magnification") || error.to_string().contains("angle")
+            );
+        }
+    }
+
+    #[test]
+    fn parallel_conversion_returns_the_first_element_error() {
+        let mut library = Library::new("conversion");
+        let mut cell = Cell::new("top");
+        cell.add(Node::new(
+            [Point::float(f64::INFINITY, 0.0, 1.0)],
+            Layer::new(1),
+            DataType::new(0),
+        ));
+        cell.add(Node::new(
+            [Point::float(f64::NEG_INFINITY, 0.0, 1.0)],
+            Layer::new(1),
+            DataType::new(0),
+        ));
+        library.add_cell(cell);
+
+        for thread_count in [1, 4] {
+            let pool = ThreadPoolBuilder::new()
+                .num_threads(thread_count)
+                .build()
+                .expect("test thread pool should build");
+            let error = pool
+                .install(|| {
+                    library.to_bytes_with_options(
+                        1.0,
+                        1.0,
+                        zero_timestamp_options(GdsRoundingPolicy::Nearest),
+                    )
+                })
+                .expect_err("invalid coordinate should be rejected");
+            assert!(error.to_string().contains("element 0 (node)"));
+        }
+    }
+
+    #[test]
+    fn default_parallel_writer_always_returns_the_lowest_element_error() {
+        let mut slow_points = points_with_count(MAX_POINTS);
+        *slow_points
+            .last_mut()
+            .expect("maximum-length path should contain points") =
+            Point::float(f64::INFINITY, 0.0, DEFAULT_INTEGER_UNITS);
+        let slow_invalid = Path::new(
+            slow_points,
+            Layer::new(1),
+            DataType::new(0),
+            None,
+            None,
+            None,
+            None,
+        );
+        let fast_invalid = Node::new(
+            [Point::float(f64::NEG_INFINITY, 0.0, DEFAULT_INTEGER_UNITS)],
+            Layer::new(1),
+            DataType::new(0),
+        );
+        let mut cell = Cell::new("top");
+        cell.add(slow_invalid);
+        cell.add(fast_invalid);
+        let mut library = Library::new("conversion");
+        library.add_cell(cell);
+        let pool = ThreadPoolBuilder::new()
+            .num_threads(4)
+            .build()
+            .expect("test thread pool should build");
+
+        for _ in 0..100 {
+            let error = pool
+                .install(|| {
+                    library.write_with_timestamp_policy(
+                        &GdsFileWriter,
+                        DEFAULT_INTEGER_UNITS,
+                        DEFAULT_INTEGER_UNITS,
+                        GdsTimestampPolicy::Zero,
+                    )
+                })
+                .expect_err("invalid coordinate should be rejected");
+            assert!(error.to_string().contains("element 0 (path)"));
+            assert!(
+                error
+                    .to_string()
+                    .contains(&format!("point[{}].x", MAX_POINTS - 1))
+            );
+        }
+    }
+
+    #[test]
+    fn report_order_is_cell_then_numeric_element_index() {
+        let mut library = Library::new("conversion");
+        for name in ["z", "a"] {
+            let mut cell = Cell::new(name);
+            cell.add(Node::new(
+                [Point::float(0.5, 0.0, 1.0)],
+                Layer::new(1),
+                DataType::new(0),
+            ));
+            cell.add(Node::new(
+                [Point::float(1.5, 0.0, 1.0)],
+                Layer::new(1),
+                DataType::new(0),
+            ));
+            library.add_cell(cell);
+        }
+
+        let (_, report) = library
+            .to_bytes_with_options(1.0, 1.0, zero_timestamp_options(GdsRoundingPolicy::Nearest))
+            .expect("library should be writable");
+        assert_eq!(
+            report
+                .affected_locations()
+                .iter()
+                .map(|location| (location.cell_name(), location.element_index()))
+                .collect::<Vec<_>>(),
+            [("a", 0), ("a", 1), ("z", 0), ("z", 1)]
+        );
+    }
+
+    #[test]
+    fn width_and_extensions_use_the_selected_rounding_policy() {
+        let path = Path::new(
+            [Point::float(0.0, 0.0, 1.0), Point::float(1.0, 0.0, 1.0)],
+            Layer::new(1),
+            DataType::new(0),
+            None,
+            Some(Unit::float(0.5, 1.0)),
+            Some(Unit::float(-0.5, 1.0)),
+            Some(Unit::float(1.5, 1.0)),
+        );
+        let mut library = Library::new("conversion");
+        let mut cell = Cell::new("top");
+        cell.add(path);
+        library.add_cell(cell);
+
+        let (bytes, report) = library
+            .to_bytes_with_options(1.0, 1.0, zero_timestamp_options(GdsRoundingPolicy::Nearest))
+            .expect("path fields should be writable");
+
+        assert_eq!(record_i32(&bytes, GDSRecord::Width), [1]);
+        assert_eq!(record_i32(&bytes, GDSRecord::BgnExtn), [-1]);
+        assert_eq!(record_i32(&bytes, GDSRecord::EndExtn), [2]);
+        assert_eq!(report.affected_locations()[0].affected_field_count(), 3);
+        assert_eq!(report.affected_locations()[0].field(), "width");
+    }
+
+    #[test]
+    fn aref_spacing_and_derived_endpoints_are_checked() {
+        let reference = Reference::new("leaf").with_grid(
+            Grid::default()
+                .with_columns(2)
+                .with_spacing_x(Some(Point::float(0.5, 0.0, 1.0))),
+        );
+        let mut library = Library::new("conversion");
+        library.add_cell(Cell::new("leaf"));
+        let mut top = Cell::new("top");
+        top.add(reference);
+        library.add_cell(top);
+
+        let (bytes, report) = library
+            .to_bytes_with_options(1.0, 1.0, zero_timestamp_options(GdsRoundingPolicy::Nearest))
+            .expect("array reference should be writable");
+        assert_eq!(record_i32(&bytes, GDSRecord::XY), [0, 0, 2, 0, 0, 0]);
+        assert_eq!(report.max_physical_quantization_error(), 1.0);
+        assert_eq!(report.affected_locations()[0].field(), "aref_endpoint[1].x");
+        assert_eq!(report.affected_locations()[0].affected_field_count(), 2);
+
+        let overflow =
+            Reference::new("leaf").with_grid(Grid::default().with_columns(2).with_spacing_x(Some(
+                Point::float(f64::from(i32::MAX) / 2.0 + 1.0, 0.0, 1.0),
+            )));
+        let mut top = Cell::new("top");
+        top.add(overflow);
+        let mut library = Library::new("overflow");
+        library.add_cell(Cell::new("leaf"));
+        library.add_cell(top);
+        let error = library
+            .to_bytes_with_options(1.0, 1.0, zero_timestamp_options(GdsRoundingPolicy::Nearest))
+            .expect_err("derived AREF endpoint overflow should be rejected");
+        assert!(error.to_string().contains("aref_endpoint[1].x"));
+        assert!(error.to_string().contains("outside the GDS i32 range"));
+    }
+
+    #[test]
+    fn array_endpoint_rejects_nonfinite_accumulated_physical_value() {
+        let finite_spacing = f64::MAX / 2.0;
+        let count = u32::MAX;
+        assert!(finite_spacing.is_finite());
+        let accumulated = finite_spacing * f64::from(count);
+        assert!(!accumulated.is_finite());
+
+        let mut converter =
+            CoordinateConverter::new(1.0, GdsRoundingPolicy::Nearest, "top", 0, "reference")
+                .expect("converter should be created");
+        let error = converter
+            .checked_array_endpoint(0, 0, count, accumulated, "aref_endpoint[1].x")
+            .expect_err("nonfinite accumulated physical endpoint should be rejected");
+        assert!(error.to_string().contains("aref_endpoint[1].x"));
+        assert!(
+            error
+                .to_string()
+                .contains("physical value inf is not finite")
+        );
+        assert!(converter.finish().affected_locations().is_empty());
+    }
+
+    #[test]
+    fn rotated_aref_snaps_per_instance_spacing_before_full_count_endpoint() {
+        let reference = Reference::new("leaf").with_grid(
+            Grid::default()
+                .with_origin(Point::integer(10, 20, 1.0))
+                .with_columns(2)
+                .with_spacing_x(Some(Point::float(0.5, 0.0, 1.0)))
+                .with_angle(crate::Radians::new(std::f64::consts::FRAC_PI_2)),
+        );
+        let mut library = Library::new("conversion");
+        library.add_cell(Cell::new("leaf"));
+        let mut top = Cell::new("top");
+        top.add(reference);
+        library.add_cell(top);
+
+        let (bytes, report) = library
+            .to_bytes_with_options(1.0, 1.0, zero_timestamp_options(GdsRoundingPolicy::Nearest))
+            .expect("rotated array should be writable");
+        assert_eq!(record_i32(&bytes, GDSRecord::XY), [10, 20, 10, 22, 10, 20]);
+        assert_eq!(report.max_physical_quantization_error(), 1.0);
+        assert_eq!(report.affected_locations()[0].field(), "aref_endpoint[1].y");
+    }
+
+    #[test]
+    fn inline_reference_conversion_cannot_saturate_before_validation() {
+        let node = Node::new(
+            [Point::integer(i32::MAX, 0, 1.0)],
+            Layer::new(1),
+            DataType::new(0),
+        );
+        let reference =
+            Reference::new(Element::from(node)).with_grid(Grid::default().with_magnification(2.0));
+        let mut library = Library::new("conversion");
+        let mut cell = Cell::new("top");
+        cell.add(reference);
+        library.add_cell(cell);
+
+        let error = library
+            .to_bytes_with_options(1.0, 1.0, zero_timestamp_options(GdsRoundingPolicy::Nearest))
+            .expect_err("expanded coordinate overflow should be rejected");
+        assert!(error.to_string().contains("element 0 (reference)"));
+        assert!(error.to_string().contains("inline[0,0].point[0].x"));
+    }
+
+    #[test]
+    fn inline_reference_applies_policy_only_to_cancelled_emitted_coordinates() {
+        let node = Node::new(
+            [Point::float(0.75, 0.0, 1.0)],
+            Layer::new(1),
+            DataType::new(0),
+        );
+        let reference = Reference::new(Element::from(node))
+            .with_grid(Grid::default().with_origin(Point::float(0.25, 0.0, 1.0)));
+        let mut library = Library::new("conversion");
+        let mut cell = Cell::new("top");
+        cell.add(reference);
+        library.add_cell(cell);
+
+        let (bytes, report) = library
+            .to_bytes_with_options(
+                1.0,
+                1.0,
+                zero_timestamp_options(GdsRoundingPolicy::ErrorIfOffGrid),
+            )
+            .expect("off-grid inputs that cancel to an exact emitted point should be writable");
+        assert_eq!(record_i32(&bytes, GDSRecord::XY), [1, 0]);
+        assert!(report.affected_locations().is_empty());
+    }
+
+    #[test]
+    fn inline_reference_rounds_only_rotated_emitted_spacing() {
+        let node = Node::new(
+            [Point::float(0.0, 0.0, 1.0)],
+            Layer::new(1),
+            DataType::new(0),
+        );
+        let reference = Reference::new(Element::from(node)).with_grid(
+            Grid::default()
+                .with_columns(2)
+                .with_spacing_x(Some(Point::float(0.0, std::f64::consts::SQRT_2, 1.0)))
+                .with_angle(crate::Radians::new(std::f64::consts::FRAC_PI_4)),
+        );
+        let mut library = Library::new("conversion");
+        let mut cell = Cell::new("top");
+        cell.add(reference);
+        library.add_cell(cell);
+
+        let (bytes, report) = library
+            .to_bytes_with_options(
+                1.0,
+                1.0,
+                zero_timestamp_options(GdsRoundingPolicy::ErrorIfOffGrid),
+            )
+            .expect("rotated spacing that emits exact points should be writable");
+        assert_eq!(
+            records_i32(&bytes, GDSRecord::XY),
+            [vec![0, 0], vec![-1, 1]]
+        );
+        assert!(report.affected_locations().is_empty());
+    }
+
+    #[test]
+    fn inline_reference_validates_unemitted_source_units() {
+        let node = Node::new(
+            [Point::float(0.0, 0.0, 1.0)],
+            Layer::new(1),
+            DataType::new(0),
+        );
+        let reference = Reference::new(Element::from(node))
+            .with_grid(Grid::default().with_origin(Point::integer(1, 0, 0.0)));
+        let mut library = Library::new("conversion");
+        let mut cell = Cell::new("top");
+        cell.add(reference);
+        library.add_cell(cell);
+
+        let error = library
+            .to_bytes_with_options(1.0, 1.0, zero_timestamp_options(GdsRoundingPolicy::Nearest))
+            .expect_err("invalid raw inline grid units should be rejected");
+        assert!(error.to_string().contains("field 'origin.x'"));
+        assert!(
+            error
+                .to_string()
+                .contains("source units must be finite and positive")
+        );
+    }
+
+    #[test]
+    fn nested_inline_reference_errors_keep_every_expansion_index() {
+        let node = Node::new(
+            [Point::integer(i32::MAX, 0, 1.0)],
+            Layer::new(1),
+            DataType::new(0),
+        );
+        let inner =
+            Reference::new(Element::from(node)).with_grid(Grid::default().with_magnification(2.0));
+        let outer = Reference::new(Element::from(inner));
+        let mut library = Library::new("conversion");
+        let mut cell = Cell::new("top");
+        cell.add(outer);
+        library.add_cell(cell);
+
+        let error = library
+            .to_bytes_with_options(1.0, 1.0, zero_timestamp_options(GdsRoundingPolicy::Nearest))
+            .expect_err("nested expanded overflow should be rejected");
+        assert!(
+            error
+                .to_string()
+                .contains("inline[0,0].inline[0,0].point[0].x")
+        );
+    }
+
+    #[test]
+    fn streaming_and_in_memory_options_share_conversion_results() {
+        let library = library_with_node(Point::float(0.5, -0.5, 1.0));
+        for policy in [GdsRoundingPolicy::Floor, GdsRoundingPolicy::Ceil] {
+            let options = zero_timestamp_options(policy);
+            let (expected_bytes, expected_report) = library
+                .to_bytes_with_options(1.0, 1.0, options)
+                .expect("in-memory write should succeed");
+            let mut streamed_bytes = Vec::new();
+            let streamed_report = library
+                .write_to_with_options(&mut streamed_bytes, 1.0, 1.0, options)
+                .expect("stream write should succeed");
+
+            assert_eq!(streamed_bytes, expected_bytes);
+            assert_eq!(streamed_report, expected_report);
+        }
+
+        let options = zero_timestamp_options(GdsRoundingPolicy::ErrorIfOffGrid);
+        let expected_error = library
+            .to_bytes_with_options(1.0, 1.0, options)
+            .expect_err("in-memory write should reject off-grid coordinates");
+        let streamed_error = library
+            .write_to_with_options(Vec::new(), 1.0, 1.0, options)
+            .expect_err("stream write should reject off-grid coordinates");
+        assert_eq!(streamed_error.to_string(), expected_error.to_string());
+    }
+
+    #[test]
+    fn failed_stream_cell_does_not_change_accumulated_report() {
+        let options = zero_timestamp_options(GdsRoundingPolicy::Nearest);
+        let mut writer = GdsStreamWriter::new_with_options(Vec::new(), "stream", 1.0, 1.0, options)
+            .expect("stream should start");
+        let mut valid = Cell::new("valid");
+        valid.add(Node::new(
+            [Point::float(0.5, 0.0, 1.0)],
+            Layer::new(1),
+            DataType::new(0),
+        ));
+        writer.write_cell(&valid).expect("valid cell should write");
+        let report_before_error = writer.conversion_report().clone();
+
+        let mut invalid = Cell::new("invalid");
+        invalid.add(Node::new(
+            [Point::float(f64::INFINITY, 0.0, 1.0)],
+            Layer::new(1),
+            DataType::new(0),
+        ));
+        writer
+            .write_cell(&invalid)
+            .expect_err("invalid cell should fail");
+
+        assert_eq!(writer.conversion_report(), &report_before_error);
+    }
+
+    #[test]
+    fn live_stream_report_uses_write_order_and_finished_report_is_sorted() {
+        let options = zero_timestamp_options(GdsRoundingPolicy::Nearest);
+        let mut writer = GdsStreamWriter::new_with_options(Vec::new(), "stream", 1.0, 1.0, options)
+            .expect("stream should start");
+        for name in ["z", "a"] {
+            let mut cell = Cell::new(name);
+            cell.add(Node::new(
+                [Point::float(0.5, 0.0, 1.0)],
+                Layer::new(1),
+                DataType::new(0),
+            ));
+            writer.write_cell(&cell).expect("cell should write");
+        }
+        assert_eq!(
+            writer
+                .conversion_report()
+                .affected_locations()
+                .iter()
+                .map(GdsQuantization::cell_name)
+                .collect::<Vec<_>>(),
+            ["z", "a"]
+        );
+
+        let (_, report) = writer.finish_with_report().expect("stream should finish");
+        assert_eq!(
+            report
+                .affected_locations()
+                .iter()
+                .map(GdsQuantization::cell_name)
+                .collect::<Vec<_>>(),
+            ["a", "z"]
+        );
+    }
+
+    #[test]
+    fn properties_survive_quantized_writes_at_attribute_boundary() {
+        let mut node = Node::new(
+            [Point::float(0.5, 0.0, 1.0)],
+            Layer::new(1),
+            DataType::new(0),
+        );
+        node.properties_mut()
+            .push(Property::new(u16::MAX, "boundary"));
+        let mut library = Library::new("conversion");
+        let mut cell = Cell::new("top");
+        cell.add(node);
+        library.add_cell(cell);
+
+        let (bytes, _) = library
+            .to_bytes_with_options(1.0, 1.0, zero_timestamp_options(GdsRoundingPolicy::Nearest))
+            .expect("property boundary should remain writable");
+        let records = RecordReader::new(BufReader::new(bytes.as_slice()))
+            .collect::<Result<Vec<_>, _>>()
+            .expect("records should parse");
+        assert!(records.iter().any(|(record, data)| matches!(
+            (record, data),
+            (GDSRecord::PropAttr, GDSRecordData::I16(values)) if values == &[-1]
+        )));
+    }
+
+    #[test]
+    fn arbitrary_float_bits_never_panic_during_conversion() {
+        let mut bits = 0_u64;
+        for _ in 0..1024 {
+            bits = bits
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            for policy in [
+                GdsRoundingPolicy::Nearest,
+                GdsRoundingPolicy::Floor,
+                GdsRoundingPolicy::Ceil,
+                GdsRoundingPolicy::ErrorIfOffGrid,
+            ] {
+                let mut converter = CoordinateConverter::new(1e-9, policy, "bits", 0, "node")
+                    .expect("database units should be valid");
+                let _result = converter.convert_physical(f64::from_bits(bits), "point[0].x");
+            }
+        }
+    }
+
+    #[test]
+    fn default_writer_preserves_context_for_later_inline_reference_errors() {
+        let mut cell = Cell::new("top");
+        cell.add(Node::new(
+            [Point::integer(0, 0, 1.0)],
+            Layer::new(1),
+            DataType::new(0),
+        ));
+        cell.add(Reference::new(Element::from(Node::new(
+            [Point::float(f64::INFINITY, 0.0, 1.0)],
+            Layer::new(1),
+            DataType::new(0),
+        ))));
+        let mut library = Library::new("conversion");
+        library.add_cell(cell);
+
+        let error = library
+            .write_with_timestamp_policy(&GdsFileWriter, 1.0, 1.0, GdsTimestampPolicy::Zero)
+            .expect_err("invalid inline coordinate should be rejected");
+        assert!(
+            error
+                .to_string()
+                .contains("Cell 'top', element 1 (reference), field 'inline[0,0].point[0].x'")
         );
     }
 
@@ -1385,6 +2936,23 @@ mod tests {
         assert_eq!(library.name(), "streamed");
         assert!(library.get_cell("first").is_some());
         assert!(library.get_cell("second").is_some());
+    }
+
+    #[test]
+    fn invalid_library_name_does_not_write_a_partial_stream_header() {
+        let mut output = Vec::new();
+        let library_name = "x".repeat(usize::from(u16::MAX));
+        let error = GdsStreamWriter::new(
+            &mut output,
+            &library_name,
+            DEFAULT_INTEGER_UNITS,
+            DEFAULT_INTEGER_UNITS,
+        )
+        .err()
+        .expect("oversized library name should be rejected");
+
+        assert!(matches!(error, GdsError::ValidationError { .. }));
+        assert!(output.is_empty());
     }
 
     #[test]

--- a/crates/gdsr/src/lib.rs
+++ b/crates/gdsr/src/lib.rs
@@ -34,7 +34,10 @@ pub use error::GdsError;
 pub use flatten::FlattenOptions;
 pub use grid::Grid;
 pub use io::write::svg::cell_to_svg;
-pub use io::write::{GdsFileWriter, GdsStreamWriter, GdsWriter};
+pub use io::write::{
+    GdsConversionReport, GdsFileWriter, GdsQuantization, GdsRoundingPolicy, GdsStreamWriter,
+    GdsWriteOptions, GdsWriter,
+};
 pub use library::{
     CellConflictStrategy, CellPruneError, CellPruneMode, CellPruneReport, DanglingCellReference,
     Library, LibraryMergeError,

--- a/crates/gdsr/src/library.rs
+++ b/crates/gdsr/src/library.rs
@@ -8,9 +8,12 @@ use crate::design_rules::{self, DesignRuleOptions, DesignRuleReport};
 use crate::error::GdsError;
 use crate::io::read::{from_gds_reader, from_gds_reader_filtered};
 use crate::io::write::validation::MAX_STRUCTURE_NAME_LENGTH;
-use crate::io::write::{GdsFileWriter, GdsStreamWriter, GdsWriter};
+use crate::io::write::{GdsFileWriter, GdsStreamWriter, GdsWriter, write_library_with_options};
 use crate::types::LayerMapping;
-use crate::{DataType, Element, GdsTimestampPolicy, GdsTimestamps, Instance, Layer};
+use crate::{
+    DataType, Element, GdsConversionReport, GdsTimestampPolicy, GdsTimestamps, GdsWriteOptions,
+    Instance, Layer,
+};
 
 /// A dangling reference: a cell contains a reference to a target that doesn't exist.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -350,6 +353,18 @@ impl Library {
         self.to_bytes_with_timestamp_policy(user_units, database_units, GdsTimestampPolicy::Current)
     }
 
+    /// Serializes with explicit coordinate and timestamp options.
+    ///
+    /// Returns the bytes and all nonzero database-grid quantization effects.
+    pub fn to_bytes_with_options(
+        &self,
+        user_units: f64,
+        database_units: f64,
+        options: GdsWriteOptions,
+    ) -> Result<(Vec<u8>, GdsConversionReport), GdsError> {
+        write_library_with_options(self, user_units, database_units, options)
+    }
+
     /// Serialize the library with the default GDS writer and an explicit timestamp policy.
     pub fn to_bytes_with_timestamp_policy(
         &self,
@@ -378,6 +393,29 @@ impl Library {
             database_units,
             GdsTimestampPolicy::Current,
         )
+    }
+
+    /// Serializes to `output` with explicit options and returns the conversion report.
+    pub fn write_to_with_options<W: Write>(
+        &self,
+        output: W,
+        user_units: f64,
+        database_units: f64,
+        options: GdsWriteOptions,
+    ) -> Result<GdsConversionReport, GdsError> {
+        let mut writer = GdsStreamWriter::from_library_with_options(
+            output,
+            self,
+            user_units,
+            database_units,
+            options,
+        )?;
+        let mut cells: Vec<&Cell> = self.cells.values().collect();
+        cells.sort_unstable_by(|left, right| left.name().cmp(right.name()));
+        for cell in cells {
+            writer.write_cell(cell)?;
+        }
+        writer.finish_with_report().map(|(_, report)| report)
     }
 
     /// Serialize the library to `output` using an explicit timestamp policy.
@@ -424,6 +462,21 @@ impl Library {
             database_units,
             GdsTimestampPolicy::Current,
         )
+    }
+
+    /// Writes a GDS file with explicit options and returns the conversion report.
+    pub fn write_file_with_options<P: AsRef<std::path::Path>>(
+        &self,
+        file_name: P,
+        user_units: f64,
+        database_units: f64,
+        options: GdsWriteOptions,
+    ) -> Result<GdsConversionReport, GdsError> {
+        let (bytes, report) = self.to_bytes_with_options(user_units, database_units, options)?;
+        let mut file = File::create(file_name)?;
+        file.write_all(&bytes)?;
+        file.flush()?;
+        Ok(report)
     }
 
     /// Writes the library to a GDS file using an explicit timestamp policy.

--- a/docs/units.md
+++ b/docs/units.md
@@ -92,3 +92,52 @@ But `1e-6` is greater than `1e-9`, which is the units we are using for our `Poin
 
 When we set database units, this is setting the minimal value that we can see in our GDSII,
 since all values are less than that, all values in the polygon will be scaled to 0.
+
+## Checked database-grid conversion
+
+All built-in writers validate physical values before converting them to GDSII's signed
+32-bit database coordinates. User units, database units, source unit scales, coordinates,
+path widths and extensions, reference spacing, and derived array endpoints must be finite
+and representable. User units, database units, source unit scales, and magnifications must
+also be positive. Header units, magnifications, and angles must fit GDSII's REAL8 range.
+
+Existing write methods use checked nearest rounding. Half-grid values round away from zero.
+Use `GdsWriteOptions` when another policy or a conversion report is needed:
+
+```rs
+use gdsr::{GdsRoundingPolicy, GdsWriteOptions};
+
+# fn write(library: &gdsr::Library) -> Result<(), gdsr::GdsError> {
+let options = GdsWriteOptions::new(GdsRoundingPolicy::ErrorIfOffGrid);
+let (bytes, report) = library.to_bytes_with_options(1e-6, 1e-9, options)?;
+
+println!("{} bytes", bytes.len());
+println!(
+    "maximum physical error: {} m",
+    report.max_physical_quantization_error()
+);
+# Ok(())
+# }
+```
+
+The policies are `Nearest`, `Floor`, `Ceil`, and `ErrorIfOffGrid`. Floor and ceil use
+their mathematical meanings for negative values. Values within one ULP of an integer
+database coordinate are treated as exact under every policy;
+this prevents one-ULP binary floating-point representation noise from moving exact
+physical grid values. Genuine small offsets remain subject to the selected policy.
+`ErrorIfOffGrid` rejects them.
+
+Array-reference spacing is rounded after rotation and before multiplication by the
+column or row count, keeping each repeated instance on the selected grid. This can
+accumulate displacement at the far endpoint; the report includes that physical error.
+
+Reports contain one entry per affected parent element, sorted by cell name and numeric
+element index. Each entry gives the field with the largest error, affected-field count,
+source physical value, written database value, and physical error. Exact conversions
+are omitted.
+
+Streaming writers use the same conversion path. A live stream report follows cell write
+order; `finish_with_report` sorts its returned report by cell name and numeric element
+index. A later `write_cell` error does not undo cells already flushed to the output;
+discard that partial stream or write to a temporary destination when atomic output is
+required.


### PR DESCRIPTION
## Summary

Add explicit nearest, floor, ceil, and error-if-off-grid write policies with contextual validation and deterministic quantization reports. Centralize coordinate and REAL8 checks across library, stream, and file writers while preserving faster legacy nearest writes. Closes #306.

## Test Plan

Full nextest, strict workspace Clippy, pre-commit hooks, doctests, and same-machine Criterion comparisons.