### PR TITLE
Deny rustdoc warnings in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,9 @@ jobs:
       - name: Build docs
         run: uv run --isolated --with-requirements docs/requirements.txt zensical build
 
+      - name: Check Rust docs
+        run: RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps
+
   cargo-test:
     name: "cargo test (${{ matrix.os }})"
 

--- a/crates/gdsr/src/library.rs
+++ b/crates/gdsr/src/library.rs
@@ -589,7 +589,7 @@ impl Library {
     /// Returns all dangling cell references in the library.
     ///
     /// A dangling cell reference is a `Reference` whose resolved cell name
-    /// (via [`Reference::referenced_cell_name`]) does not match any cell in the library.
+    /// (via [`crate::Reference::referenced_cell_name`]) does not match any cell in the library.
     /// This recursively resolves through inline element wrappers.
     pub fn dangling_cell_references(&self) -> Vec<DanglingCellReference> {
         let mut dangling = Vec::new();


### PR DESCRIPTION
## Summary

Fix the public intra-doc link for dangling references and run the full workspace rustdoc build with warnings denied in CI. This prevents broken links from regressing. Closes #398.

## Test Plan

ci