### PR TITLE
Add hierarchy-aware bounds API

### DIFF
--- a/crates/gdsr-benchmark/benches/io.rs
+++ b/crates/gdsr-benchmark/benches/io.rs
@@ -257,6 +257,52 @@ fn hierarchy_library() -> Library {
     library
 }
 
+fn shared_reference_bounds_library(reference_count: i32) -> Library {
+    let mut library = Library::new("bench_shared_bounds");
+    let mut leaf = Cell::new("leaf");
+    leaf.add(Polygon::new(
+        [point(0, 0), point(100, 0), point(100, 100), point(0, 100)],
+        Layer::new(1),
+        DataType::new(0),
+    ));
+    library.add_cell(leaf);
+
+    let mut top = Cell::new("top");
+    for index in 0..reference_count {
+        top.add(
+            Reference::new("leaf").with_grid(
+                Grid::default()
+                    .with_origin(point(index * 10, index % 100))
+                    .with_columns(1_024)
+                    .with_rows(1_024)
+                    .with_spacing_x(Some(point(200, 25)))
+                    .with_spacing_y(Some(point(-50, 175))),
+            ),
+        );
+    }
+    library.add_cell(top);
+    library
+}
+
+fn deep_hierarchy_bounds_library(depth: usize) -> Library {
+    let mut library = Library::new("bench_deep_bounds");
+    let leaf_name = format!("cell_{depth:05}");
+    let mut leaf = Cell::new(&leaf_name);
+    leaf.add(Polygon::new(
+        [point(0, 0), point(100, 0), point(100, 100), point(0, 100)],
+        Layer::new(1),
+        DataType::new(0),
+    ));
+    library.add_cell(leaf);
+
+    for index in (0..depth).rev() {
+        let mut cell = Cell::new(&format!("cell_{index:05}"));
+        cell.add(Reference::new(format!("cell_{:05}", index + 1)));
+        library.add_cell(cell);
+    }
+    library
+}
+
 fn fixtures() -> [Fixture; 3] {
     [
         Fixture::new("mixed_10k", mixed_library(10_000)),
@@ -417,6 +463,30 @@ fn bench_write_file(c: &mut Criterion, fixture: &Fixture) {
     group.finish();
 }
 
+fn bench_hierarchy_bounds(c: &mut Criterion) {
+    let shared = shared_reference_bounds_library(50_000);
+    let deep = deep_hierarchy_bounds_library(10_000);
+    let mut group = c.benchmark_group("hierarchy_bounds");
+    group.bench_function("shared_child_50k_arefs", |bencher| {
+        bencher.iter(|| {
+            black_box(
+                shared
+                    .hierarchy_bounds(black_box("top"))
+                    .expect("benchmark hierarchy should resolve"),
+            )
+        });
+    });
+    group.bench_function("deep_chain_10k", |bencher| {
+        bencher.iter(|| {
+            black_box(
+                deep.hierarchy_bounds(black_box("cell_00000"))
+                    .expect("benchmark hierarchy should resolve"),
+            )
+        });
+    });
+    group.finish();
+}
+
 fn bench_io(c: &mut Criterion) {
     let fixtures = fixtures();
     let mixed_50k = &fixtures[1];
@@ -429,6 +499,7 @@ fn bench_io(c: &mut Criterion) {
     bench_write_bytes_with_options(c);
     bench_write_stream(c, hierarchy_10k);
     bench_write_file(c, mixed_50k);
+    bench_hierarchy_bounds(c);
 }
 
 criterion_group!(benches, bench_io);

--- a/crates/gdsr-viewer/src/bevy_scene.rs
+++ b/crates/gdsr-viewer/src/bevy_scene.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::sync::Arc;
 
 use bevy::math::{DAffine2, DMat2, DVec2};
-use gdsr::{DataType, Element, Grid, Layer, Library, Point};
+use gdsr::{DataType, Element, Grid, Instance, Layer, Library, Point};
 
 use crate::drawable::{Drawable, WorldBBox, cell_world_bboxes, should_collapse_reference};
 
@@ -56,14 +56,63 @@ enum PreparedSource {
     Geometry(usize),
     Text(PreparedText),
     Node(PreparedNode),
-    Reference(Box<PreparedReference>),
 }
 
 struct PreparedReference {
-    grid: Grid,
+    grids: Vec<Grid>,
     source: PreparedSource,
     source_bbox: Option<WorldBBox>,
+    suffix_bounds: Vec<Option<WorldBBox>>,
+    suffix_grid_counts: Vec<u64>,
     label: Option<Arc<str>>,
+}
+
+struct GridTraversalFrame {
+    grid_index: usize,
+    transform: DAffine2,
+    column: u32,
+    row: u32,
+    entered: bool,
+}
+
+struct ReferenceTraversal<'a> {
+    reference: &'a PreparedReference,
+    parent_transform: DAffine2,
+    depth: u32,
+    stack: Vec<GridTraversalFrame>,
+}
+
+enum PlanAction<'a> {
+    Cell {
+        cell_name: String,
+        transform: DAffine2,
+        depth: u32,
+    },
+    CellReferences {
+        cell_name: String,
+        transform: DAffine2,
+        depth: u32,
+        next_reference: usize,
+        world_bbox: Option<WorldBBox>,
+    },
+    Reference(ReferenceTraversal<'a>),
+}
+
+struct CellComplexityFrame {
+    cell_name: String,
+    depth: u32,
+    next_reference: usize,
+    count: u64,
+    pending_multiplier: Option<u64>,
+}
+
+enum ReferenceDrawUnits<'a> {
+    Ready(u64),
+    Cell {
+        cell_name: &'a str,
+        depth: u32,
+        multiplier: u64,
+    },
 }
 
 struct PreparedCell {
@@ -288,55 +337,65 @@ impl PreparedLibrary {
         reference: &gdsr::Reference,
         cell_bboxes: &HashMap<String, Option<WorldBBox>>,
     ) -> Result<PreparedReference, SceneBuildError> {
-        let (source, source_bbox, label) = if let Some(cell_name) = reference.instance().as_cell() {
-            (
-                PreparedSource::Cell(cell_name.clone()),
-                cell_bboxes.get(cell_name).copied().flatten(),
-                Some(Arc::<str>::from(cell_name.as_str())),
-            )
-        } else if let Some(element) = reference.instance().as_element() {
-            let element = element.as_ref().as_ref();
-            match element {
-                Element::Reference(inner) => {
-                    let inner = self.prepare_reference(inner, cell_bboxes)?;
-                    let bbox = inner
-                        .source_bbox
-                        .and_then(|bbox| reference_bbox(&inner.grid, bbox));
-                    (PreparedSource::Reference(Box::new(inner)), bbox, None)
+        let mut current = reference;
+        let mut grids = Vec::new();
+        let (source, source_bbox, cell_label) = loop {
+            grids.push(current.grid().clone());
+            match current.instance() {
+                Instance::Cell(cell_name) => {
+                    break (
+                        PreparedSource::Cell(cell_name.clone()),
+                        cell_bboxes.get(cell_name).copied().flatten(),
+                        Some(Arc::<str>::from(cell_name.as_str())),
+                    );
                 }
-                Element::Text(text) => (
-                    PreparedSource::Text(prepare_text(text)),
-                    element.world_bbox(),
-                    None,
-                ),
-                Element::Node(node) => (
-                    PreparedSource::Node(prepare_node(node)),
-                    element.world_bbox(),
-                    None,
-                ),
-                _ => {
-                    let layer = element_layer(element);
-                    let geometry_id = self.prepare_inline_geometry(element, layer)?;
-                    (
-                        PreparedSource::Geometry(geometry_id),
-                        element.world_bbox(),
-                        None,
-                    )
+                Instance::Element(element) => {
+                    let element = element.as_ref().as_ref();
+                    match element {
+                        Element::Reference(reference) => current = reference,
+                        Element::Text(text) => {
+                            break (
+                                PreparedSource::Text(prepare_text(text)),
+                                element.world_bbox(),
+                                None,
+                            );
+                        }
+                        Element::Node(node) => {
+                            break (
+                                PreparedSource::Node(prepare_node(node)),
+                                element.world_bbox(),
+                                None,
+                            );
+                        }
+                        _ => {
+                            let layer = element_layer(element);
+                            let geometry_id = self.prepare_inline_geometry(element, layer)?;
+                            break (
+                                PreparedSource::Geometry(geometry_id),
+                                element.world_bbox(),
+                                None,
+                            );
+                        }
+                    }
                 }
             }
-        } else {
-            return Ok(PreparedReference {
-                grid: reference.grid().clone(),
-                source: PreparedSource::Cell(String::new()),
-                source_bbox: None,
-                label: None,
-            });
         };
+        let label = (grids.len() == 1).then_some(cell_label).flatten();
+        let mut suffix_bounds = vec![source_bbox; grids.len() + 1];
+        let mut suffix_grid_counts = vec![1_u64; grids.len() + 1];
+        for grid_index in (0..grids.len()).rev() {
+            suffix_bounds[grid_index] = suffix_bounds[grid_index + 1]
+                .and_then(|bounds| reference_bbox(&grids[grid_index], bounds));
+            suffix_grid_counts[grid_index] =
+                grid_count(&grids[grid_index]).saturating_mul(suffix_grid_counts[grid_index + 1]);
+        }
 
         Ok(PreparedReference {
-            grid: reference.grid().clone(),
+            grids,
             source,
             source_bbox,
+            suffix_bounds,
+            suffix_grid_counts,
             label,
         })
     }
@@ -392,7 +451,7 @@ impl PreparedLibrary {
                 planner.add_load(bbox, Some(Arc::<str>::from(cell_name)));
             }
         } else {
-            planner.visit_cell(cell_name, DAffine2::IDENTITY, options.depth);
+            planner.visit_iteratively(cell_name, options.depth);
         }
         planner.plan
     }
@@ -421,8 +480,48 @@ struct Planner<'a> {
     cell_stack: HashSet<String>,
 }
 
-impl Planner<'_> {
-    fn visit_cell(&mut self, cell_name: &str, transform: DAffine2, depth: u32) {
+impl<'a> Planner<'a> {
+    fn visit_iteratively(&mut self, cell_name: &str, depth: u32) {
+        let mut actions = vec![PlanAction::Cell {
+            cell_name: cell_name.to_string(),
+            transform: DAffine2::IDENTITY,
+            depth,
+        }];
+        while let Some(action) = actions.pop() {
+            match action {
+                PlanAction::Cell {
+                    cell_name,
+                    transform,
+                    depth,
+                } => self.visit_cell(&cell_name, transform, depth, &mut actions),
+                PlanAction::CellReferences {
+                    cell_name,
+                    transform,
+                    depth,
+                    next_reference,
+                    world_bbox,
+                } => self.visit_cell_references(
+                    &cell_name,
+                    transform,
+                    depth,
+                    next_reference,
+                    world_bbox,
+                    &mut actions,
+                ),
+                PlanAction::Reference(traversal) => {
+                    self.visit_reference(traversal, &mut actions);
+                }
+            }
+        }
+    }
+
+    fn visit_cell(
+        &mut self,
+        cell_name: &str,
+        transform: DAffine2,
+        depth: u32,
+        actions: &mut Vec<PlanAction<'a>>,
+    ) {
         let Some(cell) = self.library.cells.get(cell_name) else {
             return;
         };
@@ -479,121 +578,203 @@ impl Planner<'_> {
                 return;
             }
         }
-        for reference in &cell.references {
-            if self.detail_budget_exhausted() {
-                if let Some(bbox) = world_bbox {
-                    self.add_load(bbox, Some(Arc::<str>::from(cell_name)));
-                }
-                self.cell_stack.remove(cell_name);
-                return;
+        actions.push(PlanAction::CellReferences {
+            cell_name: cell_name.to_string(),
+            transform,
+            depth,
+            next_reference: 0,
+            world_bbox,
+        });
+    }
+
+    fn visit_cell_references(
+        &mut self,
+        cell_name: &str,
+        transform: DAffine2,
+        depth: u32,
+        next_reference: usize,
+        world_bbox: Option<WorldBBox>,
+        actions: &mut Vec<PlanAction<'a>>,
+    ) {
+        let Some(cell) = self.library.cells.get(cell_name) else {
+            self.cell_stack.remove(cell_name);
+            return;
+        };
+        let Some(reference) = cell.references.get(next_reference) else {
+            self.cell_stack.remove(cell_name);
+            return;
+        };
+        if self.detail_budget_exhausted() {
+            if let Some(bbox) = world_bbox {
+                self.add_load(bbox, Some(Arc::<str>::from(cell_name)));
             }
-            self.visit_reference(reference, transform, depth);
+            self.cell_stack.remove(cell_name);
+            return;
         }
 
-        self.cell_stack.remove(cell_name);
+        actions.push(PlanAction::CellReferences {
+            cell_name: cell_name.to_string(),
+            transform,
+            depth,
+            next_reference: next_reference + 1,
+            world_bbox,
+        });
+        actions.push(PlanAction::Reference(ReferenceTraversal {
+            reference,
+            parent_transform: transform,
+            depth,
+            stack: vec![GridTraversalFrame {
+                grid_index: 0,
+                transform,
+                column: 0,
+                row: 0,
+                entered: false,
+            }],
+        }));
     }
 
     fn visit_reference(
         &mut self,
-        reference: &PreparedReference,
-        parent_transform: DAffine2,
-        depth: u32,
+        mut traversal: ReferenceTraversal<'a>,
+        actions: &mut Vec<PlanAction<'a>>,
     ) {
-        let Some(source_bbox) = reference.source_bbox else {
-            return;
-        };
-        let Some(local_bbox) = reference_bbox(&reference.grid, source_bbox) else {
-            return;
-        };
-        let world_bbox = transform_bbox(parent_transform, local_bbox);
-        if !world_bbox.overlaps(self.options.visible) {
-            self.plan.stats.culled_references += 1;
-            return;
-        }
-        if self.plan.stats.detail_cells >= MAX_DETAIL_CELLS {
-            self.add_load(world_bbox, reference.label.clone());
-            return;
-        }
-        if self.detail_budget_exhausted() {
-            self.add_load(world_bbox, reference.label.clone());
+        let reference = traversal.reference;
+        if reference.source_bbox.is_none() {
             return;
         }
 
-        let grid_count = grid_count(&reference.grid);
-        let draw_units = self.reference_draw_units(reference, depth);
-        let source_is_degenerate =
-            source_bbox.min_x == source_bbox.max_x || source_bbox.min_y == source_bbox.max_y;
-        let (width_px, height_px) =
-            reference_screen_size(world_bbox, self.options.zoom, source_is_degenerate);
-        if should_collapse_reference(width_px, height_px, grid_count, draw_units, depth, false) {
-            self.add_load(world_bbox, reference.label.clone());
-            return;
-        }
-
-        let source_units = draw_units.checked_div(grid_count).unwrap_or(1).max(1);
-        for column in 0..reference.grid.columns() {
-            for row in 0..reference.grid.rows() {
-                if self.detail_budget_exhausted() {
-                    self.add_load(world_bbox, reference.label.clone());
-                    return;
+        while let Some(frame) = traversal.stack.last_mut() {
+            let Some(grid) = reference.grids.get(frame.grid_index) else {
+                traversal.stack.pop();
+                continue;
+            };
+            let level_depth = u32::try_from(frame.grid_index)
+                .map_or(0, |grid_index| traversal.depth.saturating_sub(grid_index));
+            let Some(source_bbox) = reference.suffix_bounds[frame.grid_index + 1] else {
+                traversal.stack.pop();
+                continue;
+            };
+            let Some(local_bbox) = reference.suffix_bounds[frame.grid_index] else {
+                traversal.stack.pop();
+                continue;
+            };
+            let world_bbox = transform_bbox(frame.transform, local_bbox);
+            if self.detail_budget_exhausted() {
+                if let Some(top_bbox) = reference.suffix_bounds[0] {
+                    self.add_load(
+                        transform_bbox(traversal.parent_transform, top_bbox),
+                        reference.label.clone(),
+                    );
                 }
-                let member_transform =
-                    parent_transform * grid_member_transform(&reference.grid, column, row);
-                let member_bbox = transform_bbox(member_transform, source_bbox);
-                if !member_bbox.overlaps(self.options.visible) {
+                return;
+            }
+            if !frame.entered {
+                if !world_bbox.overlaps(self.options.visible) {
                     self.plan.stats.culled_references += 1;
+                    traversal.stack.pop();
                     continue;
                 }
-                let (member_width, member_height) =
-                    reference_screen_size(member_bbox, self.options.zoom, source_is_degenerate);
-                if !member_width.is_finite()
-                    || !member_height.is_finite()
-                    || (member_width < 1.0 && member_height < 1.0)
-                {
-                    self.plan.stats.skipped_subpixel_references += 1;
+                if self.plan.stats.detail_cells >= MAX_DETAIL_CELLS {
+                    self.add_load(world_bbox, reference.label.clone());
+                    traversal.stack.pop();
                     continue;
                 }
+
+                let grid_count = grid_count(grid);
+                let draw_units =
+                    self.reference_draw_units_from(reference, frame.grid_index, level_depth);
+                let source_is_degenerate = source_bbox.min_x == source_bbox.max_x
+                    || source_bbox.min_y == source_bbox.max_y;
+                let (width_px, height_px) =
+                    reference_screen_size(world_bbox, self.options.zoom, source_is_degenerate);
                 if should_collapse_reference(
-                    member_width,
-                    member_height,
-                    1,
-                    source_units,
-                    depth,
+                    width_px,
+                    height_px,
+                    grid_count,
+                    draw_units,
+                    level_depth,
                     false,
                 ) {
-                    self.add_load(member_bbox, reference.label.clone());
-                } else {
-                    if !self.visit_source(
-                        &reference.source,
-                        member_transform,
-                        depth.saturating_sub(1),
-                    ) {
-                        self.add_load(member_bbox, reference.label.clone());
+                    self.add_load(world_bbox, reference.label.clone());
+                    traversal.stack.pop();
+                    continue;
+                }
+                frame.entered = true;
+            }
+            if grid.columns() == 0 || grid.rows() == 0 || frame.column >= grid.columns() {
+                traversal.stack.pop();
+                continue;
+            }
+
+            let column = frame.column;
+            let row = frame.row;
+            if frame.row + 1 < grid.rows() {
+                frame.row += 1;
+            } else {
+                frame.row = 0;
+                frame.column += 1;
+            }
+            let next_grid_index = frame.grid_index + 1;
+            let member_transform = frame.transform * grid_member_transform(grid, column, row);
+            let member_bbox = transform_bbox(member_transform, source_bbox);
+            if !member_bbox.overlaps(self.options.visible) {
+                self.plan.stats.culled_references += 1;
+                continue;
+            }
+            let source_is_degenerate =
+                source_bbox.min_x == source_bbox.max_x || source_bbox.min_y == source_bbox.max_y;
+            let (member_width, member_height) =
+                reference_screen_size(member_bbox, self.options.zoom, source_is_degenerate);
+            if !member_width.is_finite()
+                || !member_height.is_finite()
+                || (member_width < 1.0 && member_height < 1.0)
+            {
+                self.plan.stats.skipped_subpixel_references += 1;
+                continue;
+            }
+            let grid_count = grid_count(grid);
+            let draw_units =
+                self.reference_draw_units_from(reference, frame.grid_index, level_depth);
+            let source_units = draw_units.checked_div(grid_count).unwrap_or(1).max(1);
+            if should_collapse_reference(
+                member_width,
+                member_height,
+                1,
+                source_units,
+                level_depth,
+                false,
+            ) {
+                self.add_load(member_bbox, reference.label.clone());
+            } else if next_grid_index < reference.grids.len() {
+                traversal.stack.push(GridTraversalFrame {
+                    grid_index: next_grid_index,
+                    transform: member_transform,
+                    column: 0,
+                    row: 0,
+                    entered: false,
+                });
+            } else {
+                match &reference.source {
+                    PreparedSource::Cell(cell_name) => {
+                        actions.push(PlanAction::Reference(traversal));
+                        actions.push(PlanAction::Cell {
+                            cell_name: cell_name.clone(),
+                            transform: member_transform,
+                            depth: level_depth.saturating_sub(1),
+                        });
                         return;
                     }
+                    PreparedSource::Geometry(geometry_id) => {
+                        self.push_geometry(*geometry_id, member_transform);
+                    }
+                    PreparedSource::Text(text) => self.push_text(text, member_transform),
+                    PreparedSource::Node(node) => {
+                        if !self.push_node(node, member_transform) {
+                            self.add_load(member_bbox, reference.label.clone());
+                            return;
+                        }
+                    }
                 }
-            }
-        }
-    }
-
-    fn visit_source(&mut self, source: &PreparedSource, transform: DAffine2, depth: u32) -> bool {
-        match source {
-            PreparedSource::Cell(cell_name) => {
-                self.visit_cell(cell_name, transform, depth);
-                true
-            }
-            PreparedSource::Geometry(geometry_id) => {
-                self.push_geometry(*geometry_id, transform);
-                true
-            }
-            PreparedSource::Text(text) => {
-                self.push_text(text, transform);
-                true
-            }
-            PreparedSource::Node(node) => self.push_node(node, transform),
-            PreparedSource::Reference(reference) => {
-                self.visit_reference(reference, transform, depth);
-                true
             }
         }
     }
@@ -682,24 +863,62 @@ impl Planner<'_> {
         }
     }
 
-    fn reference_draw_units(&mut self, reference: &PreparedReference, depth: u32) -> u64 {
-        let count = grid_count(&reference.grid);
-        if count == 0 {
-            return 0;
+    fn reference_draw_units_from(
+        &mut self,
+        reference: &PreparedReference,
+        start_grid: usize,
+        depth: u32,
+    ) -> u64 {
+        match Self::reference_draw_units_parts(reference, start_grid, depth) {
+            ReferenceDrawUnits::Ready(count) => count,
+            ReferenceDrawUnits::Cell {
+                cell_name,
+                depth,
+                multiplier,
+            } => multiplier.saturating_mul(self.cell_draw_units(cell_name, depth).max(1)),
         }
-        let source_count = if depth <= 1 {
-            1
-        } else {
-            self.source_draw_units(&reference.source, depth - 1)
-        };
-        count.saturating_mul(source_count.max(1))
     }
 
-    fn source_draw_units(&mut self, source: &PreparedSource, depth: u32) -> u64 {
-        match source {
-            PreparedSource::Cell(cell_name) => self.cell_draw_units(cell_name, depth),
-            PreparedSource::Reference(reference) => self.reference_draw_units(reference, depth),
-            PreparedSource::Geometry(_) | PreparedSource::Text(_) | PreparedSource::Node(_) => 1,
+    fn reference_draw_units_parts(
+        reference: &PreparedReference,
+        start_grid: usize,
+        depth: u32,
+    ) -> ReferenceDrawUnits<'_> {
+        let remaining_grids = reference.grids.len().saturating_sub(start_grid);
+        if let Ok(grid_depth) = u32::try_from(remaining_grids)
+            && depth > grid_depth
+        {
+            let multiplier = reference.suffix_grid_counts[start_grid];
+            return match &reference.source {
+                PreparedSource::Cell(cell_name) => ReferenceDrawUnits::Cell {
+                    cell_name,
+                    depth: depth.saturating_sub(grid_depth),
+                    multiplier,
+                },
+                PreparedSource::Geometry(_) | PreparedSource::Text(_) | PreparedSource::Node(_) => {
+                    ReferenceDrawUnits::Ready(multiplier)
+                }
+            };
+        }
+
+        let mut count = 1_u64;
+        let mut remaining_depth = depth;
+        for grid in reference.grids.iter().skip(start_grid) {
+            count = count.saturating_mul(grid_count(grid));
+            if count == 0 || remaining_depth <= 1 {
+                return ReferenceDrawUnits::Ready(count);
+            }
+            remaining_depth -= 1;
+        }
+        match &reference.source {
+            PreparedSource::Cell(cell_name) => ReferenceDrawUnits::Cell {
+                cell_name,
+                depth: remaining_depth,
+                multiplier: count,
+            },
+            PreparedSource::Geometry(_) | PreparedSource::Text(_) | PreparedSource::Node(_) => {
+                ReferenceDrawUnits::Ready(count)
+            }
         }
     }
 
@@ -708,18 +927,90 @@ impl Planner<'_> {
         if let Some(&count) = self.complexity_cache.get(&key) {
             return count;
         }
-        if depth == 0 || !self.complexity_stack.insert(cell_name.to_string()) {
+        if depth == 0 || self.complexity_stack.contains(cell_name) {
             return 1;
         }
-        let count = self.library.cells.get(cell_name).map_or(1, |cell| {
-            let direct = cell.direct_draw_units;
-            cell.references.iter().fold(direct, |count, reference| {
-                count.saturating_add(self.reference_draw_units(reference, depth))
-            })
-        });
-        self.complexity_stack.remove(cell_name);
-        self.complexity_cache.insert(key, count);
-        count
+        self.complexity_stack.insert(cell_name.to_string());
+        let mut frames = vec![CellComplexityFrame {
+            cell_name: cell_name.to_string(),
+            depth,
+            next_reference: 0,
+            count: self
+                .library
+                .cells
+                .get(cell_name)
+                .map_or(1, |cell| cell.direct_draw_units),
+            pending_multiplier: None,
+        }];
+        let mut completed: Option<u64> = None;
+
+        loop {
+            if let Some(child_count) = completed.take()
+                && let Some(frame) = frames.last_mut()
+                && let Some(multiplier) = frame.pending_multiplier.take()
+            {
+                frame.count = frame
+                    .count
+                    .saturating_add(multiplier.saturating_mul(child_count.max(1)));
+            }
+
+            let Some(frame) = frames.last_mut() else {
+                return 1;
+            };
+            let reference = self
+                .library
+                .cells
+                .get(&frame.cell_name)
+                .and_then(|cell| cell.references.get(frame.next_reference));
+            let Some(reference) = reference else {
+                let Some(frame) = frames.pop() else {
+                    return 1;
+                };
+                self.complexity_stack.remove(&frame.cell_name);
+                self.complexity_cache
+                    .insert((frame.cell_name, frame.depth), frame.count);
+                if frames.is_empty() {
+                    return frame.count;
+                }
+                completed = Some(frame.count);
+                continue;
+            };
+            frame.next_reference += 1;
+
+            match Self::reference_draw_units_parts(reference, 0, frame.depth) {
+                ReferenceDrawUnits::Ready(count) => {
+                    frame.count = frame.count.saturating_add(count);
+                }
+                ReferenceDrawUnits::Cell {
+                    cell_name,
+                    depth,
+                    multiplier,
+                } => {
+                    let child_key = (cell_name.to_string(), depth);
+                    if let Some(&count) = self.complexity_cache.get(&child_key) {
+                        frame.count = frame
+                            .count
+                            .saturating_add(multiplier.saturating_mul(count.max(1)));
+                    } else if depth == 0 || self.complexity_stack.contains(cell_name) {
+                        frame.count = frame.count.saturating_add(multiplier);
+                    } else {
+                        frame.pending_multiplier = Some(multiplier);
+                        self.complexity_stack.insert(cell_name.to_string());
+                        frames.push(CellComplexityFrame {
+                            cell_name: cell_name.to_string(),
+                            depth,
+                            next_reference: 0,
+                            count: self
+                                .library
+                                .cells
+                                .get(cell_name)
+                                .map_or(1, |cell| cell.direct_draw_units),
+                            pending_multiplier: None,
+                        });
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -840,8 +1131,8 @@ fn point_in_bbox(point: DVec2, bbox: &WorldBBox) -> bool {
 mod tests {
     use super::*;
     use gdsr::{
-        Cell, DataType, HorizontalPresentation, Layer, Polygon, Radians, Reference, Text,
-        VerticalPresentation,
+        Cell, DataType, HorizontalPresentation, Layer, Path, Polygon, Radians, Reference, Text,
+        Unit, VerticalPresentation,
     };
 
     fn point(x: i32, y: i32) -> Point {
@@ -1088,6 +1379,69 @@ mod tests {
     }
 
     #[test]
+    fn cyclic_parent_bounds_do_not_cull_reachable_geometry() {
+        let mut a = Cell::new("a");
+        a.add(square_at(0, 0, 1, 1));
+        a.add(Reference::new("b"));
+        let mut b = Cell::new("b");
+        b.add(square_at(100, 0, 1, 2));
+        b.add(Reference::new("a"));
+        let mut top = Cell::new("top");
+        top.add(Reference::new("a"));
+        let mut library = Library::new("test");
+        library.add_cell(top);
+        library.add_cell(b);
+        library.add_cell(a);
+        let prepared = PreparedLibrary::build(&library, "top").expect("scene should prepare");
+        let visible = WorldBBox::new(99.0e-9, -1.0e-9, 102.0e-9, 2.0e-9);
+
+        let plan = prepared.plan(
+            "top",
+            &SceneOptions {
+                visible: &visible,
+                zoom: 1.0e12,
+                depth: 4,
+                hidden_layers: &HashSet::new(),
+            },
+        );
+
+        assert_eq!(plan.geometry_instances.len(), 1);
+        let geometry = &prepared.geometries[plan.geometry_instances[0].geometry_id];
+        assert_eq!(geometry.layer, (Layer::new(2), DataType::new(0)));
+    }
+
+    #[test]
+    fn signed_inline_path_bounds_do_not_cull_visible_geometry() {
+        let path = Path::new(
+            [Point::float(0.0, 0.0, 1.0), Point::float(10.0, 0.0, 1.0)],
+            Layer::new(1),
+            DataType::new(0),
+            None,
+            Some(Unit::float(-4.0, 1.0)),
+            Some(Unit::float(-100.0, 1.0)),
+            Some(Unit::float(-100.0, 1.0)),
+        );
+        let mut top = Cell::new("top");
+        top.add(Reference::new(Element::Path(path)));
+        let mut library = Library::new("test");
+        library.add_cell(top);
+        let prepared = PreparedLibrary::build(&library, "top").expect("scene should prepare");
+        let visible = WorldBBox::new(4.0, 1.0, 6.0, 2.0);
+
+        let plan = prepared.plan(
+            "top",
+            &SceneOptions {
+                visible: &visible,
+                zoom: 100.0,
+                depth: 2,
+                hidden_layers: &HashSet::new(),
+            },
+        );
+
+        assert_eq!(plan.geometry_instances.len(), 1);
+    }
+
+    #[test]
     fn dense_subpixel_geometry_uses_one_proxy() {
         let mut cell = Cell::new("top");
         for _ in 0..DENSE_BATCH_MIN_ELEMENTS {
@@ -1165,6 +1519,63 @@ mod tests {
 
         assert_eq!(plan.geometry_instances.len(), MAX_SCENE_OBJECTS);
         assert_eq!(plan.load_proxies.len(), 1);
+    }
+
+    #[test]
+    fn ten_thousand_inline_references_prepare_and_plan_iteratively() {
+        let mut reference = Reference::new(Element::Polygon(square(100, 1)));
+        for _ in 1..10_000 {
+            reference = Reference::new(Element::Reference(reference));
+        }
+        let mut top = Cell::new("top");
+        top.add(reference);
+        let mut library = Library::new("test");
+        library.add_cell(top);
+
+        let prepared = PreparedLibrary::build(&library, "top").expect("scene should prepare");
+        let top = prepared.cells.get("top").expect("top should be prepared");
+        assert_eq!(top.references[0].grids.len(), 10_000);
+        let plan = prepared.plan(
+            "top",
+            &SceneOptions {
+                visible: &visible(),
+                zoom: 1.0e12,
+                depth: 10_001,
+                hidden_layers: &HashSet::new(),
+            },
+        );
+        assert_eq!(plan.geometry_instances.len(), 1);
+    }
+
+    #[test]
+    fn ten_thousand_named_cells_prepare_and_plan_iteratively() {
+        const DEPTH: usize = 10_000;
+        let mut library = Library::new("test");
+        let leaf_name = format!("cell_{:05}", DEPTH - 1);
+        let mut leaf = Cell::new(&leaf_name);
+        leaf.add(square(100, 1));
+        library.add_cell(leaf);
+        for index in (0..DEPTH - 1).rev() {
+            let cell_name = format!("cell_{index:05}");
+            let mut cell = Cell::new(&cell_name);
+            cell.add(Reference::new(format!("cell_{:05}", index + 1)));
+            library.add_cell(cell);
+        }
+
+        let prepared =
+            PreparedLibrary::build(&library, "cell_00000").expect("scene should prepare");
+        let plan = prepared.plan(
+            "cell_00000",
+            &SceneOptions {
+                visible: &visible(),
+                zoom: 1.0e12,
+                depth: u32::try_from(DEPTH + 1).expect("depth should fit"),
+                hidden_layers: &HashSet::new(),
+            },
+        );
+
+        assert_eq!(plan.geometry_instances.len(), 1);
+        assert_eq!(plan.stats.detail_cells, DEPTH);
     }
 
     #[test]

--- a/crates/gdsr-viewer/src/drawable.rs
+++ b/crates/gdsr-viewer/src/drawable.rs
@@ -2,155 +2,34 @@ use std::collections::{HashMap, HashSet};
 
 use egui::epaint;
 use egui::{Color32, FontId, Mesh, Pos2, Rect, Shape, Stroke, StrokeKind};
-use gdsr::{DataType, Dimensions, Element, Layer, Library, Point};
+use gdsr::{DataType, Dimensions, Element, Layer, Library};
 
 use crate::state::LayerState;
 use crate::viewport::Viewport;
 
 /// World-space axis-aligned bounding box with named fields.
-#[derive(Clone, Copy, Debug)]
-pub struct WorldBBox {
-    pub min_x: f64,
-    pub min_y: f64,
-    pub max_x: f64,
-    pub max_y: f64,
-}
-
-impl WorldBBox {
-    pub fn new(min_x: f64, min_y: f64, max_x: f64, max_y: f64) -> Self {
-        Self {
-            min_x,
-            min_y,
-            max_x,
-            max_y,
-        }
-    }
-
-    pub fn overlaps(&self, other: &Self) -> bool {
-        self.max_x >= other.min_x
-            && self.min_x <= other.max_x
-            && self.max_y >= other.min_y
-            && self.min_y <= other.max_y
-    }
-
-    pub fn merge(&self, other: &Self) -> Self {
-        Self {
-            min_x: self.min_x.min(other.min_x),
-            min_y: self.min_y.min(other.min_y),
-            max_x: self.max_x.max(other.max_x),
-            max_y: self.max_y.max(other.max_y),
-        }
-    }
-}
+pub type WorldBBox = gdsr::WorldBounds;
 
 pub fn cell_world_bbox(cell_name: &str, library: &Library) -> Option<WorldBBox> {
-    let mut visiting = HashSet::new();
-    let mut cache = HashMap::new();
-    named_cell_world_bbox(cell_name, library, &mut visiting, &mut cache)
+    library.hierarchy_bounds(cell_name).ok()?.root_bounds()
 }
 
 pub fn cell_world_bboxes(library: &Library, root_cell: &str) -> HashMap<String, Option<WorldBBox>> {
-    let mut visiting = HashSet::new();
-    let mut cache = HashMap::new();
-    named_cell_world_bbox(root_cell, library, &mut visiting, &mut cache);
-    cache
-}
-
-fn named_cell_world_bbox(
-    cell_name: &str,
-    library: &Library,
-    visiting: &mut HashSet<String>,
-    cache: &mut HashMap<String, Option<WorldBBox>>,
-) -> Option<WorldBBox> {
-    if let Some(bbox) = cache.get(cell_name) {
-        return *bbox;
-    }
-    if !visiting.insert(cell_name.to_owned()) {
-        return None;
-    }
-
-    let Some(cell) = library.get_cell(cell_name) else {
-        visiting.remove(cell_name);
-        cache.insert(cell_name.to_owned(), None);
-        return None;
+    let Ok(report) = library.hierarchy_bounds(root_cell) else {
+        return HashMap::new();
     };
-    let mut result = None;
-    for element in cell.iter_elements() {
-        if let Some(bbox) = element_world_bbox(element, library, visiting, cache) {
-            merge_bbox(&mut result, bbox);
-        }
-    }
-
-    visiting.remove(cell_name);
-    cache.insert(cell_name.to_owned(), result);
-    result
-}
-
-fn element_world_bbox(
-    element: &Element,
-    library: &Library,
-    visiting: &mut HashSet<String>,
-    cache: &mut HashMap<String, Option<WorldBBox>>,
-) -> Option<WorldBBox> {
-    match element {
-        Element::Reference(reference) => reference_world_bbox(reference, library, visiting, cache),
-        _ => element.world_bbox(),
-    }
-}
-
-fn reference_world_bbox(
-    reference: &gdsr::Reference,
-    library: &Library,
-    visiting: &mut HashSet<String>,
-    cache: &mut HashMap<String, Option<WorldBBox>>,
-) -> Option<WorldBBox> {
-    let source_bbox = if let Some(cell_name) = reference.instance().as_cell() {
-        named_cell_world_bbox(cell_name, library, visiting, cache)?
-    } else {
-        let element = reference.instance().as_element()?;
-        element_world_bbox(element.as_ref().as_ref(), library, visiting, cache)?
-    };
-
-    reference_bbox_from_source_bbox(reference, source_bbox)
+    report
+        .cell_bounds()
+        .iter()
+        .map(|(cell_name, bounds)| (cell_name.clone(), *bounds))
+        .collect()
 }
 
 fn reference_bbox_from_source_bbox(
     reference: &gdsr::Reference,
     source_bbox: WorldBBox,
 ) -> Option<WorldBBox> {
-    let grid = reference.grid();
-    if grid.columns() == 0 || grid.rows() == 0 {
-        return None;
-    }
-
-    let mut result = None;
-    let bbox_element = Element::Polygon(bbox_polygon(source_bbox));
-    let spacing_x = grid.spacing_x().unwrap_or_default();
-    let spacing_y = grid.spacing_y().unwrap_or_default();
-
-    for column_index in [0, grid.columns() - 1] {
-        for row_index in [0, grid.rows() - 1] {
-            let offset = (spacing_x * column_index) + (spacing_y * row_index);
-            let rotated_offset = offset.rotate_around_point(grid.angle(), &Point::default());
-            let final_position = grid.origin() + rotated_offset;
-            let single_grid = grid
-                .clone()
-                .with_columns(1)
-                .with_rows(1)
-                .with_spacing_x(None)
-                .with_spacing_y(None)
-                .with_origin(final_position);
-            let single_reference = reference.clone().with_grid(single_grid);
-
-            for element in single_reference.get_elements_in_grid(&bbox_element) {
-                if let Some(bbox) = element.world_bbox() {
-                    merge_bbox(&mut result, bbox);
-                }
-            }
-        }
-    }
-
-    result
+    source_bbox.transformed_by_grid(reference.grid())
 }
 
 pub fn reference_grid_count(reference: &gdsr::Reference) -> u64 {
@@ -175,37 +54,62 @@ pub fn reference_instance_bbox(
     library: Option<&Library>,
     cell_bbox_cache: &mut HashMap<String, Option<WorldBBox>>,
 ) -> Option<WorldBBox> {
-    if reference.instance().as_cell().is_some() {
-        let lib = library?;
-        let mut visiting = HashSet::new();
-        reference_world_bbox(reference, lib, &mut visiting, cell_bbox_cache)
-    } else if let Some(element) = reference.instance().as_element() {
-        let source_bbox = element.as_ref().as_ref().world_bbox()?;
-        reference_bbox_from_source_bbox(reference, source_bbox)
-    } else {
-        None
+    if let Some(cell_name) = reference.instance().as_cell() {
+        let source_bbox = named_cell_bbox(cell_name, library?, cell_bbox_cache)?;
+        return reference_bbox_from_source_bbox(reference, source_bbox);
     }
+    let element = reference.instance().as_element()?;
+    if let Element::Reference(nested) = element.as_ref().as_ref() {
+        return inline_reference_instance_bbox(reference.grid(), nested, library, cell_bbox_cache);
+    }
+    reference_bbox_from_source_bbox(reference, element.as_ref().as_ref().world_bbox()?)
 }
 
-fn bbox_polygon(bbox: WorldBBox) -> gdsr::Polygon {
-    gdsr::Polygon::new(
-        [
-            gdsr::Point::float(bbox.min_x, bbox.min_y, 1.0),
-            gdsr::Point::float(bbox.max_x, bbox.min_y, 1.0),
-            gdsr::Point::float(bbox.max_x, bbox.max_y, 1.0),
-            gdsr::Point::float(bbox.min_x, bbox.max_y, 1.0),
-            gdsr::Point::float(bbox.min_x, bbox.min_y, 1.0),
-        ],
-        Layer::new(0),
-        DataType::new(0),
-    )
+fn named_cell_bbox(
+    cell_name: &str,
+    library: &Library,
+    cell_bbox_cache: &mut HashMap<String, Option<WorldBBox>>,
+) -> Option<WorldBBox> {
+    if let Some(cached) = cell_bbox_cache.get(cell_name) {
+        return *cached;
+    }
+    let report = library.hierarchy_bounds(cell_name).ok()?;
+    let root_bounds = report.root_bounds();
+    cell_bbox_cache.extend(
+        report
+            .cell_bounds()
+            .iter()
+            .map(|(name, bounds)| (name.clone(), *bounds)),
+    );
+    root_bounds
 }
 
-fn merge_bbox(result: &mut Option<WorldBBox>, bbox: WorldBBox) {
-    *result = Some(match result {
-        Some(acc) => acc.merge(&bbox),
-        None => bbox,
-    });
+fn inline_reference_instance_bbox(
+    outer_grid: &gdsr::Grid,
+    reference: &gdsr::Reference,
+    library: Option<&Library>,
+    cell_bbox_cache: &mut HashMap<String, Option<WorldBBox>>,
+) -> Option<WorldBBox> {
+    let mut current = reference;
+    let mut grids = vec![outer_grid];
+    let source_bbox = loop {
+        grids.push(current.grid());
+        if let Some(cell_name) = current.instance().as_cell() {
+            break named_cell_bbox(cell_name, library?, cell_bbox_cache)?;
+        }
+        let element = current.instance().as_element()?;
+        if let Element::Reference(reference) = element.as_ref().as_ref() {
+            current = reference;
+        } else {
+            break element.as_ref().as_ref().world_bbox()?;
+        }
+    };
+
+    let mut bounds = Some(source_bbox);
+    for grid in grids.into_iter().rev() {
+        bounds = bounds.and_then(|bounds| bounds.transformed_by_grid(grid));
+    }
+    bounds
 }
 
 /// Bundles the rendering context passed to every `Drawable::draw` call.
@@ -579,19 +483,32 @@ impl Drawable for gdsr::Path {
     }
 
     fn world_bbox(&self) -> Option<WorldBBox> {
-        let (min_pt, max_pt) = self.bounding_box();
+        let mut points = self.points().iter();
+        let first = points.next()?;
+        let first_x = first.x().absolute_value();
+        let first_y = first.y().absolute_value();
+        let mut bounds = WorldBBox::new(first_x, first_y, first_x, first_y);
+        for point in points {
+            let x = point.x().absolute_value();
+            let y = point.y().absolute_value();
+            bounds = bounds.merge(&WorldBBox::new(x, y, x, y));
+        }
         let half_width = self
             .width()
-            .map(|w| w.absolute_value() / 2.0)
+            .map(|w| w.absolute_value().abs() / 2.0)
             .unwrap_or(0.0);
-        let begin_ext = self.begin_extension().map_or(0.0, |u| u.absolute_value());
-        let end_ext = self.end_extension().map_or(0.0, |u| u.absolute_value());
+        let begin_ext = self
+            .begin_extension()
+            .map_or(0.0, |u| u.absolute_value().max(0.0));
+        let end_ext = self
+            .end_extension()
+            .map_or(0.0, |u| u.absolute_value().max(0.0));
         let pad = half_width + begin_ext.max(end_ext);
         Some(WorldBBox::new(
-            min_pt.x().absolute_value() - pad,
-            min_pt.y().absolute_value() - pad,
-            max_pt.x().absolute_value() + pad,
-            max_pt.y().absolute_value() + pad,
+            bounds.min_x - pad,
+            bounds.min_y - pad,
+            bounds.max_x + pad,
+            bounds.max_y + pad,
         ))
     }
 
@@ -602,15 +519,19 @@ impl Drawable for gdsr::Path {
         }
         let half_width = self
             .width()
-            .map(|w| w.absolute_value() / 2.0)
+            .map(|w| w.absolute_value().abs() / 2.0)
             .unwrap_or(0.0);
         let min_tolerance = 3.0 / zoom;
         let tolerance = half_width.max(min_tolerance);
         let tol_sq = tolerance * tolerance;
 
         let path_type = self.path_type().unwrap_or_default();
-        let begin_ext = self.begin_extension().map_or(0.0, |u| u.absolute_value());
-        let end_ext = self.end_extension().map_or(0.0, |u| u.absolute_value());
+        let begin_ext = self
+            .begin_extension()
+            .map_or(0.0, |u| u.absolute_value().max(0.0));
+        let end_ext = self
+            .end_extension()
+            .map_or(0.0, |u| u.absolute_value().max(0.0));
 
         let mut segments: Vec<(f64, f64, f64, f64)> = pts
             .windows(2)
@@ -1024,6 +945,23 @@ fn reference_draw_units(reference: &gdsr::Reference, ctx: &mut DrawContext) -> u
     )
 }
 
+struct CellDrawUnitsFrame {
+    cell_name: String,
+    depth: u32,
+    next_element: usize,
+    count: u64,
+    pending_multiplier: Option<u64>,
+}
+
+enum ReferenceDrawUnits<'a> {
+    Ready(u64),
+    Cell {
+        cell_name: &'a str,
+        depth: u32,
+        multiplier: u64,
+    },
+}
+
 pub fn reference_draw_units_for_depth(
     reference: &gdsr::Reference,
     library: Option<&Library>,
@@ -1031,30 +969,52 @@ pub fn reference_draw_units_for_depth(
     cache: &mut HashMap<(String, u32), u64>,
     visiting: &mut HashSet<String>,
 ) -> u64 {
-    let grid_count = reference_grid_count(reference);
-    if grid_count == 0 {
-        return 0;
+    match reference_draw_units_parts(reference, depth) {
+        ReferenceDrawUnits::Ready(count) => count,
+        ReferenceDrawUnits::Cell {
+            cell_name,
+            depth,
+            multiplier,
+        } => multiplier.saturating_mul(
+            library
+                .and_then(|lib| cell_draw_units(cell_name, lib, depth, cache, visiting))
+                .unwrap_or(1),
+        ),
     }
+}
 
-    let source_count = if depth <= 1 {
-        1
-    } else if let Some(cell_name) = reference.instance().as_cell() {
-        library
-            .and_then(|lib| cell_draw_units(cell_name, lib, depth - 1, cache, visiting))
-            .unwrap_or(1)
-    } else if let Some(element) = reference.instance().as_element() {
-        element_draw_units(
-            element.as_ref().as_ref(),
-            library,
-            depth - 1,
-            cache,
-            visiting,
-        )
-    } else {
-        1
-    };
+fn reference_draw_units_parts(
+    reference: &gdsr::Reference,
+    mut depth: u32,
+) -> ReferenceDrawUnits<'_> {
+    let mut reference = reference;
+    let mut count = 1_u64;
+    loop {
+        let grid_count = reference_grid_count(reference);
+        if grid_count == 0 {
+            return ReferenceDrawUnits::Ready(0);
+        }
+        count = count.saturating_mul(grid_count);
+        if depth <= 1 {
+            return ReferenceDrawUnits::Ready(count);
+        }
+        depth -= 1;
 
-    grid_count.saturating_mul(source_count)
+        if let Some(cell_name) = reference.instance().as_cell() {
+            return ReferenceDrawUnits::Cell {
+                cell_name,
+                depth,
+                multiplier: count,
+            };
+        }
+        let Some(element) = reference.instance().as_element() else {
+            return ReferenceDrawUnits::Ready(count);
+        };
+        let Element::Reference(inner) = element.as_ref().as_ref() else {
+            return ReferenceDrawUnits::Ready(count);
+        };
+        reference = inner;
+    }
 }
 
 fn cell_draw_units(
@@ -1068,40 +1028,77 @@ fn cell_draw_units(
     if let Some(count) = cache.get(&key) {
         return Some(*count);
     }
-    let cell = library.get_cell(cell_name)?;
+    library.get_cell(cell_name)?;
     if !visiting.insert(cell_name.to_owned()) {
         return Some(1);
     }
 
-    let mut count = 0_u64;
-    for element in cell.iter_elements() {
-        count = count.saturating_add(element_draw_units(
-            element,
-            Some(library),
-            depth,
-            cache,
-            visiting,
-        ));
-    }
-    visiting.remove(cell_name);
-
-    let count = count.max(1);
-    cache.insert(key, count);
-    Some(count)
-}
-
-fn element_draw_units(
-    element: &Element,
-    library: Option<&Library>,
-    depth: u32,
-    cache: &mut HashMap<(String, u32), u64>,
-    visiting: &mut HashSet<String>,
-) -> u64 {
-    match element {
-        Element::Reference(reference) => {
-            reference_draw_units_for_depth(reference, library, depth, cache, visiting)
+    let mut frames = vec![CellDrawUnitsFrame {
+        cell_name: cell_name.to_string(),
+        depth,
+        next_element: 0,
+        count: 0,
+        pending_multiplier: None,
+    }];
+    let mut completed: Option<u64> = None;
+    loop {
+        if let Some(child_count) = completed.take()
+            && let Some(frame) = frames.last_mut()
+            && let Some(multiplier) = frame.pending_multiplier.take()
+        {
+            frame.count = frame
+                .count
+                .saturating_add(multiplier.saturating_mul(child_count));
         }
-        _ => 1,
+
+        let frame = frames.last_mut()?;
+        let element = library
+            .get_cell(&frame.cell_name)
+            .and_then(|cell| cell.elements().get(frame.next_element));
+        let Some(element) = element else {
+            let frame = frames.pop()?;
+            let count = frame.count.max(1);
+            visiting.remove(&frame.cell_name);
+            cache.insert((frame.cell_name, frame.depth), count);
+            if frames.is_empty() {
+                return Some(count);
+            }
+            completed = Some(count);
+            continue;
+        };
+        frame.next_element += 1;
+
+        let Element::Reference(reference) = element else {
+            frame.count = frame.count.saturating_add(1);
+            continue;
+        };
+        match reference_draw_units_parts(reference, frame.depth) {
+            ReferenceDrawUnits::Ready(count) => {
+                frame.count = frame.count.saturating_add(count);
+            }
+            ReferenceDrawUnits::Cell {
+                cell_name,
+                depth,
+                multiplier,
+            } => {
+                let child_key = (cell_name.to_string(), depth);
+                if let Some(&count) = cache.get(&child_key) {
+                    frame.count = frame.count.saturating_add(multiplier.saturating_mul(count));
+                } else if visiting.contains(cell_name) || library.get_cell(cell_name).is_none() {
+                    frame.count = frame.count.saturating_add(multiplier);
+                } else {
+                    frame.pending_multiplier = Some(multiplier);
+                    visiting.insert(cell_name.to_string());
+                    frames.push(CellDrawUnitsFrame {
+                        cell_name: cell_name.to_string(),
+                        depth,
+                        next_element: 0,
+                        count: 0,
+                        pending_multiplier: None,
+                    });
+                }
+            }
+        }
     }
 }
 
@@ -1188,69 +1185,118 @@ fn draw_ref_bbox(reference: &gdsr::Reference, bbox: WorldBBox, ctx: &mut DrawCon
     }
 }
 
+enum ReferenceDrawAction {
+    Element(Element, u32),
+    LeaveCell(String),
+}
+
+fn draw_reference_iteratively(reference: &gdsr::Reference, ctx: &mut DrawContext) {
+    let previous_depth = ctx.reference_depth;
+    let previous_stack_len = ctx.reference_stack.len();
+    let mut active_cells: HashSet<String> = ctx.reference_stack.iter().cloned().collect();
+    let mut pending = vec![ReferenceDrawAction::Element(
+        Element::Reference(reference.clone()),
+        previous_depth,
+    )];
+
+    while let Some(action) = pending.pop() {
+        let (element, depth) = match action {
+            ReferenceDrawAction::Element(element, depth) => (element, depth),
+            ReferenceDrawAction::LeaveCell(cell_name) => {
+                active_cells.remove(&cell_name);
+                ctx.reference_stack.pop();
+                continue;
+            }
+        };
+        ctx.reference_depth = depth;
+        let Element::Reference(reference) = element else {
+            element.draw(ctx);
+            continue;
+        };
+        let Some(bbox) = reference_instance_bbox(&reference, ctx.library, ctx.cell_bbox_cache)
+        else {
+            continue;
+        };
+        if !bbox.overlaps(ctx.visible) {
+            continue;
+        }
+        if should_draw_reference_bbox(&reference, bbox, ctx) {
+            draw_ref_bbox(&reference, bbox, ctx);
+            continue;
+        }
+
+        let child_depth = depth.saturating_sub(1);
+        if let Some(element) = reference.instance().as_element() {
+            pending.extend(
+                reference
+                    .get_elements_in_grid(element)
+                    .into_iter()
+                    .rev()
+                    .map(|element| ReferenceDrawAction::Element(element, child_depth)),
+            );
+        } else if let Some(cell_name) = reference.instance().as_cell() {
+            if !active_cells.insert(cell_name.clone()) {
+                draw_ref_bbox(&reference, bbox, ctx);
+                continue;
+            }
+            ctx.reference_stack.push(cell_name.clone());
+            pending.push(ReferenceDrawAction::LeaveCell(cell_name.clone()));
+            if let Some(cell) = ctx.library.and_then(|library| library.get_cell(cell_name)) {
+                let mut elements = Vec::new();
+                for element in cell.iter_elements() {
+                    elements.extend(reference.get_elements_in_grid(element));
+                }
+                pending.extend(
+                    elements
+                        .into_iter()
+                        .rev()
+                        .map(|element| ReferenceDrawAction::Element(element, child_depth)),
+                );
+            }
+        }
+    }
+
+    ctx.reference_stack.truncate(previous_stack_len);
+    ctx.reference_depth = previous_depth;
+}
+
 impl Drawable for gdsr::Reference {
     fn layer_keys(&self) -> Vec<(Layer, DataType)> {
-        match self.instance().as_element() {
-            Some(element) => element.layer_keys(),
-            None => vec![],
+        let mut reference = self;
+        loop {
+            let Some(element) = reference.instance().as_element() else {
+                return Vec::new();
+            };
+            match element.as_ref().as_ref() {
+                Element::Reference(inner) => reference = inner,
+                element => return element.layer_keys(),
+            }
         }
     }
 
     fn world_bbox(&self) -> Option<WorldBBox> {
-        let element = self.instance().as_element()?;
-        reference_bbox_from_source_bbox(self, element.as_ref().as_ref().world_bbox()?)
+        reference_instance_bbox(self, None, &mut HashMap::new())
     }
 
     fn hit_test(&self, wx: f64, wy: f64, zoom: f64) -> bool {
-        if let Some(element) = self.instance().as_element() {
-            for el in self.get_elements_in_grid(element) {
-                if el.hit_test(wx, wy, zoom) {
-                    return true;
+        let Some(element) = self.instance().as_element() else {
+            return false;
+        };
+        let mut pending = self.get_elements_in_grid(element);
+        while let Some(element) = pending.pop() {
+            if let Element::Reference(reference) = element {
+                if let Some(inner) = reference.instance().as_element() {
+                    pending.extend(reference.get_elements_in_grid(inner));
                 }
+            } else if element.hit_test(wx, wy, zoom) {
+                return true;
             }
         }
         false
     }
 
     fn draw(&self, ctx: &mut DrawContext) {
-        let Some(bbox) = reference_instance_bbox(self, ctx.library, ctx.cell_bbox_cache) else {
-            return;
-        };
-        if !bbox.overlaps(ctx.visible) {
-            return;
-        }
-        if should_draw_reference_bbox(self, bbox, ctx) {
-            draw_ref_bbox(self, bbox, ctx);
-            return;
-        }
-
-        let previous_depth = ctx.reference_depth;
-        ctx.reference_depth = ctx.reference_depth.saturating_sub(1);
-
-        if let Some(element) = self.instance().as_element() {
-            for el in self.get_elements_in_grid(element) {
-                el.draw(ctx);
-            }
-        } else if let Some(cell_name) = self.instance().as_cell() {
-            if ctx.reference_stack.iter().any(|name| name == cell_name) {
-                draw_ref_bbox(self, bbox, ctx);
-                ctx.reference_depth = previous_depth;
-                return;
-            }
-            ctx.reference_stack.push(cell_name.clone());
-            if let Some(lib) = ctx.library {
-                if let Some(cell) = lib.get_cell(cell_name) {
-                    for element in cell.iter_elements() {
-                        for el in self.get_elements_in_grid(element) {
-                            el.draw(ctx);
-                        }
-                    }
-                }
-            }
-            ctx.reference_stack.pop();
-        }
-
-        ctx.reference_depth = previous_depth;
+        draw_reference_iteratively(self, ctx);
     }
 }
 
@@ -1350,6 +1396,21 @@ mod tests {
 
     const SCALE: f64 = 1e-9;
     const ZOOM: f64 = 1e9;
+
+    fn deeply_named_library(depth: usize) -> Library {
+        let mut library = Library::new("deep");
+        let leaf_name = format!("cell_{:05}", depth - 1);
+        let mut leaf = gdsr::Cell::new(&leaf_name);
+        leaf.add(polygon(vec![(0, 0), (100, 0), (100, 100)], 3, 1));
+        library.add_cell(leaf);
+        for index in (0..depth - 1).rev() {
+            let cell_name = format!("cell_{index:05}");
+            let mut cell = gdsr::Cell::new(&cell_name);
+            cell.add(gdsr::Reference::new(format!("cell_{:05}", index + 1)));
+            library.add_cell(cell);
+        }
+        library
+    }
 
     #[test]
     fn polygon_hit_inside() {
@@ -1691,6 +1752,184 @@ mod tests {
         library.add_cell(b);
 
         assert!(cell_world_bbox("a", &library).is_none());
+    }
+
+    #[test]
+    fn cyclic_cell_world_bbox_matches_conservative_core_report() {
+        let mut a = gdsr::Cell::new("a");
+        a.add(polygon(vec![(0, 0), (1, 0), (1, 1), (0, 1)], 1, 0));
+        a.add(gdsr::Reference::new("b"));
+        let mut b = gdsr::Cell::new("b");
+        b.add(polygon(vec![(100, 0), (101, 0), (101, 1), (100, 1)], 2, 0));
+        b.add(gdsr::Reference::new("a"));
+        let mut top = gdsr::Cell::new("top");
+        top.add(gdsr::Reference::new("a"));
+        let mut library = gdsr::Library::new("lib");
+        library.add_cell(top);
+        library.add_cell(b);
+        library.add_cell(a);
+
+        let viewer_bounds =
+            cell_world_bbox("top", &library).expect("viewer should retain geometry");
+        let core_bounds = library
+            .hierarchy_bounds("top")
+            .expect("core should report cyclic bounds")
+            .root_bounds();
+
+        assert_eq!(Some(viewer_bounds), core_bounds);
+        assert_eq!(
+            viewer_bounds,
+            WorldBBox::new(0.0, 0.0, 101.0 * SCALE, SCALE)
+        );
+    }
+
+    #[test]
+    fn signed_path_world_bbox_matches_core_conservative_bounds() {
+        let path = gdsr::Path::new(
+            [
+                gdsr::Point::float(0.0, 0.0, 1.0),
+                gdsr::Point::float(10.0, 0.0, 1.0),
+            ],
+            Layer::new(1),
+            DataType::new(0),
+            None,
+            Some(gdsr::Unit::float(-4.0, 1.0)),
+            Some(gdsr::Unit::float(-100.0, 1.0)),
+            Some(gdsr::Unit::float(-100.0, 1.0)),
+        );
+        let viewer_bounds = path.world_bbox().expect("path should have bounds");
+        let mut top = gdsr::Cell::new("top");
+        top.add(path);
+        let mut library = gdsr::Library::new("lib");
+        library.add_cell(top);
+        let core_bounds = library
+            .hierarchy_bounds("top")
+            .expect("core should report path bounds")
+            .root_bounds();
+
+        assert_eq!(Some(viewer_bounds), core_bounds);
+        assert_eq!(viewer_bounds, WorldBBox::new(-2.0, -2.0, 12.0, 2.0));
+    }
+
+    #[test]
+    fn cell_world_bbox_matches_partial_core_report() {
+        let mut top = gdsr::Cell::new("top");
+        top.add(polygon(vec![(10, 20), (110, 20), (110, 220)], 1, 0));
+        top.add(gdsr::Reference::new("missing"));
+        let mut library = gdsr::Library::new("lib");
+        library.add_cell(top);
+
+        let viewer_bounds = cell_world_bbox("top", &library).expect("valid geometry should remain");
+        let core_report = library
+            .hierarchy_bounds("top")
+            .expect("known root should produce a report");
+        assert_eq!(Some(viewer_bounds), core_report.root_bounds());
+        assert_eq!(core_report.diagnostics().len(), 1);
+    }
+
+    #[test]
+    fn reference_instance_bbox_resolves_inline_named_reference_chain() {
+        let mut leaf = gdsr::Cell::new("leaf");
+        leaf.add(polygon(vec![(10, 20), (110, 20), (110, 220)], 1, 0));
+        let nested = gdsr::Reference::new("leaf")
+            .with_grid(gdsr::Grid::default().with_origin(gdsr::Point::default_integer(100, 200)));
+        let reference = gdsr::Reference::new(nested)
+            .with_grid(gdsr::Grid::default().with_origin(gdsr::Point::default_integer(300, 400)));
+        let mut library = gdsr::Library::new("lib");
+        library.add_cell(leaf);
+
+        let bbox = reference_instance_bbox(&reference, Some(&library), &mut HashMap::new())
+            .expect("inline named hierarchy should resolve");
+        assert!((bbox.min_x - 410.0 * SCALE).abs() < 1e-15);
+        assert!((bbox.min_y - 620.0 * SCALE).abs() < 1e-15);
+        assert!((bbox.max_x - 510.0 * SCALE).abs() < 1e-15);
+        assert!((bbox.max_y - 820.0 * SCALE).abs() < 1e-15);
+    }
+
+    #[test]
+    fn reference_world_bbox_handles_ten_thousand_inline_references() {
+        let polygon = gdsr::Polygon::new(
+            [
+                gdsr::Point::default_integer(0, 0),
+                gdsr::Point::default_integer(100, 0),
+                gdsr::Point::default_integer(100, 100),
+            ],
+            Layer::new(1),
+            DataType::new(0),
+        );
+        let mut reference = gdsr::Reference::new(polygon);
+        for _ in 1..10_000 {
+            reference = gdsr::Reference::new(reference);
+        }
+
+        let bbox = reference
+            .world_bbox()
+            .expect("inline bounds should resolve");
+        assert!((bbox.min_x - 0.0).abs() < 1e-15);
+        assert!((bbox.max_x - 100.0 * SCALE).abs() < 1e-15);
+    }
+
+    #[test]
+    fn deep_inline_layer_keys_and_hit_test_are_iterative() {
+        let polygon = gdsr::Polygon::new(
+            [
+                gdsr::Point::default_integer(0, 0),
+                gdsr::Point::default_integer(100, 0),
+                gdsr::Point::default_integer(100, 100),
+            ],
+            Layer::new(3),
+            DataType::new(1),
+        );
+        let mut reference = gdsr::Reference::new(polygon);
+        for _ in 1..10_000 {
+            reference = gdsr::Reference::new(reference);
+        }
+
+        assert_eq!(
+            reference.layer_keys(),
+            vec![(Layer::new(3), DataType::new(1))]
+        );
+        assert!(reference.hit_test(50.0 * SCALE, 50.0 * SCALE, ZOOM));
+    }
+
+    #[test]
+    fn deep_named_world_bbox_complexity_and_draw_are_iterative() {
+        const DEPTH: usize = 10_000;
+        let library = deeply_named_library(DEPTH);
+        let bbox =
+            cell_world_bbox("cell_00000", &library).expect("named hierarchy should have bounds");
+        assert!((bbox.max_x - 100.0 * SCALE).abs() < 1e-15);
+
+        let reference = gdsr::Reference::new("cell_00000");
+        let mut cache = HashMap::new();
+        let mut visiting = HashSet::new();
+        assert_eq!(
+            reference_draw_units_for_depth(
+                &reference,
+                Some(&library),
+                u32::try_from(DEPTH + 1).expect("depth should fit"),
+                &mut cache,
+                &mut visiting,
+            ),
+            1,
+        );
+
+        let egui_context = egui::Context::default();
+        let painter = egui_context.layer_painter(egui::LayerId::background());
+        let viewport = Viewport {
+            zoom: 1.0e12,
+            ..Viewport::default()
+        };
+        let rect = Rect::from_min_size(Pos2::ZERO, egui::Vec2::splat(1_000.0));
+        draw_highlight(
+            &Element::Reference(reference),
+            &viewport,
+            &painter,
+            rect,
+            &mut LayerState::default(),
+            Some(&library),
+            &mut HashMap::new(),
+        );
     }
 
     #[test]

--- a/crates/gdsr/src/elements/gds_box.rs
+++ b/crates/gdsr/src/elements/gds_box.rs
@@ -158,6 +158,7 @@ impl Dimensions for GdsBox {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{Transformation, Unit};
 
     fn p(x: i32, y: i32) -> Point {
         Point::integer(x, y, 1e-9)
@@ -170,6 +171,42 @@ mod tests {
         assert_eq!(gds_box.top_right(), p(10, 10));
         assert_eq!(gds_box.layer(), Layer::new(1));
         assert_eq!(gds_box.box_type(), DataType::new(0));
+    }
+
+    #[test]
+    fn heterogeneous_axis_units_survive_creation_transform_and_round_trip() {
+        let first = Point::new(Unit::float(4.0, 1e-9), Unit::float(-2.0, 1e-6));
+        let second = Point::new(Unit::float(-1.0, 1e-9), Unit::float(3.0, 1e-6));
+        let expected_min = Point::new(Unit::float(-1.0, 1e-9), Unit::float(-2.0, 1e-6));
+        let expected_max = Point::new(Unit::float(4.0, 1e-9), Unit::float(3.0, 1e-6));
+
+        let gds_box = GdsBox::new(first, second, Layer::new(1), DataType::new(0));
+        assert_eq!(gds_box.bottom_left(), expected_min);
+        assert_eq!(gds_box.top_right(), expected_max);
+
+        let transformed = gds_box.clone().transform(Transformation::default());
+        assert_eq!(transformed.bottom_left(), expected_min);
+        assert_eq!(transformed.top_right(), expected_max);
+
+        let round_trip = gds_box.to_integer_unit().to_float_unit();
+        assert_eq!(round_trip.bottom_left(), expected_min);
+        assert_eq!(round_trip.top_right(), expected_max);
+    }
+
+    #[test]
+    fn mixed_resolution_integer_units_survive_creation_and_transform() {
+        let coarse = Point::new(Unit::integer(1, 1.0), Unit::integer(1, 1.0));
+        let fine = Point::new(Unit::integer(1, 0.1), Unit::integer(2, 0.1));
+        let expected_min = Point::new(Unit::float(0.1, 1.0), Unit::float(0.2, 1.0));
+        let expected_max = Point::new(Unit::float(1.0, 1.0), Unit::float(1.0, 1.0));
+
+        let gds_box = GdsBox::new(coarse, fine, Layer::new(1), DataType::new(0));
+        assert_eq!(gds_box.bottom_left(), expected_min);
+        assert_eq!(gds_box.top_right(), expected_max);
+
+        let transformed = gds_box.transform(Transformation::default());
+        assert_eq!(transformed.bottom_left(), expected_min);
+        assert_eq!(transformed.top_right(), expected_max);
     }
 
     #[test]

--- a/crates/gdsr/src/elements/path.rs
+++ b/crates/gdsr/src/elements/path.rs
@@ -169,14 +169,18 @@ impl Path {
             return None;
         }
 
-        let half_width = width.absolute_value() / 2.0;
+        let half_width = width.absolute_value().abs() / 2.0;
         if half_width <= 0.0 {
             return None;
         }
 
         let path_type = self.r#type.unwrap_or_default();
-        let begin_ext = self.begin_extension.map_or(0.0, |u| u.absolute_value());
-        let end_ext = self.end_extension.map_or(0.0, |u| u.absolute_value());
+        let begin_ext = self
+            .begin_extension
+            .map_or(0.0, |u| u.absolute_value().max(0.0));
+        let end_ext = self
+            .end_extension
+            .map_or(0.0, |u| u.absolute_value().max(0.0));
 
         let units = self.points[0].units().0;
         let centerline: Vec<(f64, f64)> = self

--- a/crates/gdsr/src/elements/reference.rs
+++ b/crates/gdsr/src/elements/reference.rs
@@ -1,5 +1,5 @@
-use std::sync::Arc;
 use std::sync::mpsc;
+use std::sync::{Arc, OnceLock};
 
 use crate::elements::Element;
 use crate::elements::property::PropertyStore;
@@ -41,6 +41,44 @@ impl Default for Instance {
     }
 }
 
+impl Drop for Instance {
+    fn drop(&mut self) {
+        let Self::Element(element) = self else {
+            return;
+        };
+        if !matches!(element.as_ref().as_ref(), Element::Reference(_)) {
+            return;
+        }
+
+        let mut pending = Some(std::mem::replace(element, instance_drop_sentinel()));
+        while let Some(element) = pending {
+            let Ok(mut element) = Arc::try_unwrap(element) else {
+                break;
+            };
+            let Element::Reference(reference) = element.as_mut() else {
+                break;
+            };
+            pending = match &mut reference.instance {
+                Self::Element(inner)
+                    if matches!(inner.as_ref().as_ref(), Element::Reference(_)) =>
+                {
+                    Some(std::mem::replace(inner, instance_drop_sentinel()))
+                }
+                Self::Cell(_) | Self::Element(_) => None,
+            };
+        }
+    }
+}
+
+#[expect(
+    clippy::redundant_allocation,
+    reason = "sentinel must match Instance::Element's existing Arc<Box<Element>> representation"
+)]
+fn instance_drop_sentinel() -> Arc<Box<Element>> {
+    static SENTINEL: OnceLock<Arc<Box<Element>>> = OnceLock::new();
+    Arc::clone(SENTINEL.get_or_init(|| Arc::new(Box::new(Element::Node(crate::Node::default())))))
+}
+
 impl std::fmt::Display for Instance {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
@@ -77,6 +115,11 @@ pub struct Reference {
     pub(crate) properties: PropertyStore,
 }
 
+enum FlattenAction {
+    Reference(Reference, usize),
+    Emit(Element),
+}
+
 impl Reference {
     /// Creates a new reference to the given instance with a default grid.
     pub fn new(instance: impl Into<Instance>) -> Self {
@@ -97,16 +140,18 @@ impl Reference {
         &self.grid
     }
 
-    /// Returns the name of the referenced cell, recursively resolving through inline element
-    /// wrappers. Returns `None` if the reference chain ends at a non-reference element.
+    /// Returns the name of the referenced cell after resolving nested inline element wrappers.
+    /// Returns `None` if the reference chain ends at a non-reference element.
     pub fn referenced_cell_name(&self) -> Option<&str> {
-        match &self.instance {
-            Instance::Cell(name) => Some(name),
-            Instance::Element(element) => {
-                if let Element::Reference(inner) = element.as_ref().as_ref() {
-                    inner.referenced_cell_name()
-                } else {
-                    None
+        let mut reference = self;
+        loop {
+            match &reference.instance {
+                Instance::Cell(name) => return Some(name),
+                Instance::Element(element) => {
+                    let Element::Reference(inner) = element.as_ref().as_ref() else {
+                        return None;
+                    };
+                    reference = inner;
                 }
             }
         }
@@ -115,9 +160,19 @@ impl Reference {
     /// Remaps layers on the inline element, if this reference holds one.
     /// Cell references are unaffected.
     pub fn remap_layers(&mut self, mapping: &crate::LayerMapping) {
-        if let Instance::Element(arc_elem) = &mut self.instance {
-            let elem = Arc::make_mut(arc_elem);
-            elem.remap_layers(mapping);
+        let mut reference = self;
+        loop {
+            let Instance::Element(element) = &mut reference.instance else {
+                return;
+            };
+            let element = Arc::make_mut(element);
+            match element.as_mut() {
+                Element::Reference(inner) => reference = inner,
+                element => {
+                    element.remap_layers(mapping);
+                    return;
+                }
+            }
         }
     }
 
@@ -187,19 +242,6 @@ impl Reference {
         elements
     }
 
-    /// Sends each element in the grid through the channel. Returns `Err(())` if the receiver
-    /// has been dropped.
-    fn send_elements_in_grid(
-        &self,
-        element: &Element,
-        tx: &mpsc::Sender<Element>,
-    ) -> Result<(), ()> {
-        for el in self.get_elements_in_grid(element) {
-            tx.send(el).map_err(|_| ())?;
-        }
-        Ok(())
-    }
-
     /// Like [`flatten`](Self::flatten) but sends elements through a channel as they're produced,
     /// enabling progressive rendering. Returns `Err(())` if the receiver is dropped.
     #[expect(
@@ -212,48 +254,12 @@ impl Reference {
         library: &Library,
         tx: &mpsc::Sender<Element>,
     ) -> Result<(), ()> {
-        let depth = depth.unwrap_or(usize::MAX);
-        if depth == 0 {
-            tx.send(Element::Reference(self)).map_err(|_| ())?;
-            return Ok(());
-        }
-        match &self.instance {
-            Instance::Cell(cell_name) => {
-                if let Some(cell) = library.get_cell(cell_name) {
-                    for element in cell.iter_elements() {
-                        if let Element::Reference(reference) = element {
-                            for grid_el in
-                                self.get_elements_in_grid(&Element::Reference(reference.clone()))
-                            {
-                                if let Element::Reference(grid_ref) = grid_el {
-                                    grid_ref.stream_flatten(Some(depth - 1), library, tx)?;
-                                }
-                            }
-                        } else {
-                            self.send_elements_in_grid(element, tx)?;
-                        }
-                    }
-                }
-            }
-            Instance::Element(element) => match element.as_ref().as_ref() {
-                Element::Path(_)
-                | Element::Polygon(_)
-                | Element::Box(_)
-                | Element::Node(_)
-                | Element::Text(_) => {
-                    self.send_elements_in_grid(element, tx)?;
-                }
-                Element::Reference(reference) => {
-                    for grid_el in self.get_elements_in_grid(&Element::Reference(reference.clone()))
-                    {
-                        if let Element::Reference(grid_ref) = grid_el {
-                            grid_ref.stream_flatten(Some(depth - 1), library, tx)?;
-                        }
-                    }
-                }
-            },
-        }
-        Ok(())
+        self.traverse_filtered_at_depth(
+            depth.unwrap_or(usize::MAX),
+            &FlattenOptions::default(),
+            library,
+            &mut |element| tx.send(element).map_err(|_| ()),
+        )
     }
 
     /// Recursively flattens this reference into concrete elements, resolving cell references
@@ -280,53 +286,112 @@ impl Reference {
         library: &Library,
     ) -> Vec<Element> {
         let mut elements: Vec<Element> = Vec::new();
-        if depth == 0 {
-            return [Element::Reference(self)].to_vec();
-        }
-        match &self.instance {
-            Instance::Cell(cell_name) => {
-                if !options.includes_cell(cell_name) {
-                    return vec![Element::Reference(self)];
-                }
-                if let Some(cell) = library.get_cell(cell_name) {
-                    let flattened_cell_elements =
-                        cell.get_elements_filtered_at_depth(depth - 1, options, library);
-                    for cell_element in flattened_cell_elements {
-                        elements.extend(self.get_elements_in_grid(&cell_element));
-                    }
-                }
-            }
-            Instance::Element(element) => match element.as_ref().as_ref() {
-                Element::Path(_)
-                | Element::Polygon(_)
-                | Element::Box(_)
-                | Element::Node(_)
-                | Element::Text(_) => {
-                    if options.includes_element(element) {
-                        elements.extend(self.get_elements_in_grid(element));
-                    }
-                }
-
-                Element::Reference(reference) => {
-                    let flattened_reference_elements =
-                        reference
-                            .clone()
-                            .flatten_filtered_at_depth(depth - 1, options, library);
-
-                    for reference_element in flattened_reference_elements {
-                        elements.extend(self.get_elements_in_grid(&reference_element));
-                    }
-                }
-            },
-        }
-
+        let result = self.traverse_filtered_at_depth(depth, options, library, &mut |element| {
+            elements.push(element);
+            Ok(())
+        });
+        debug_assert!(result.is_ok(), "vector emitter cannot fail");
         elements
+    }
+
+    fn traverse_filtered_at_depth(
+        self,
+        depth: usize,
+        options: &FlattenOptions,
+        library: &Library,
+        emit: &mut impl FnMut(Element) -> Result<(), ()>,
+    ) -> Result<(), ()> {
+        let mut pending = vec![FlattenAction::Reference(self, depth)];
+        while let Some(action) = pending.pop() {
+            let (reference, depth) = match action {
+                FlattenAction::Reference(reference, depth) => (reference, depth),
+                FlattenAction::Emit(element) => {
+                    emit(element)?;
+                    continue;
+                }
+            };
+            if depth == 0 {
+                emit(Element::Reference(reference))?;
+                continue;
+            }
+
+            let mut next = Vec::new();
+            match reference.instance() {
+                Instance::Cell(cell_name) => {
+                    if !options.includes_cell(cell_name) {
+                        emit(Element::Reference(reference))?;
+                        continue;
+                    }
+                    if let Some(cell) = library.get_cell(cell_name) {
+                        for element in cell.iter_elements() {
+                            for element in reference.get_elements_in_grid(element) {
+                                if let Element::Reference(reference) = element {
+                                    next.push(FlattenAction::Reference(reference, depth - 1));
+                                } else if options.includes_element(&element) {
+                                    next.push(FlattenAction::Emit(element));
+                                }
+                            }
+                        }
+                    }
+                }
+                Instance::Element(element) => match element.as_ref().as_ref() {
+                    Element::Reference(inner) => {
+                        for element in
+                            reference.get_elements_in_grid(&Element::Reference(inner.clone()))
+                        {
+                            if let Element::Reference(reference) = element {
+                                next.push(FlattenAction::Reference(reference, depth - 1));
+                            }
+                        }
+                    }
+                    element if options.includes_element(element) => {
+                        next.extend(
+                            reference
+                                .get_elements_in_grid(element)
+                                .into_iter()
+                                .map(FlattenAction::Emit),
+                        );
+                    }
+                    Element::Path(_)
+                    | Element::Polygon(_)
+                    | Element::Box(_)
+                    | Element::Node(_)
+                    | Element::Text(_) => {}
+                },
+            }
+            pending.extend(next.into_iter().rev());
+        }
+        Ok(())
     }
 }
 
 impl std::fmt::Display for Reference {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "Reference to {} with grid {}", self.instance, self.grid)
+        let mut reference = self;
+        let mut grids = Vec::new();
+        loop {
+            grids.push(reference.grid());
+            write!(f, "Reference to ")?;
+            match reference.instance() {
+                Instance::Cell(cell_name) => {
+                    write!(f, "Cell instance: {cell_name}")?;
+                    break;
+                }
+                Instance::Element(element) => {
+                    write!(f, "Element instance: ")?;
+                    if let Element::Reference(inner) = element.as_ref().as_ref() {
+                        reference = inner;
+                    } else {
+                        write!(f, "{element}")?;
+                        break;
+                    }
+                }
+            }
+        }
+        for grid in grids.into_iter().rev() {
+            write!(f, " with grid {grid}")?;
+        }
+        Ok(())
     }
 }
 
@@ -349,6 +414,79 @@ mod tests {
     use super::*;
     use crate::elements::Polygon;
     use crate::{DataType, Layer};
+    use std::sync::Weak;
+
+    fn deeply_nested_reference(depth: usize) -> Reference {
+        let mut reference = Reference::new("leaf");
+        for _ in 1..depth {
+            reference = Reference::new(reference);
+        }
+        reference
+    }
+
+    #[test]
+    fn deep_unique_inline_chain_drops_iteratively() {
+        let reference = deeply_nested_reference(10_000);
+        assert_eq!(reference.referenced_cell_name(), Some("leaf"));
+        drop(reference);
+    }
+
+    #[test]
+    fn deep_shared_inline_chain_drops_iteratively_for_final_owner() {
+        let reference = deeply_nested_reference(10_000);
+        let shared = reference.clone();
+        drop(reference);
+        drop(shared);
+    }
+
+    #[test]
+    fn deep_inline_chain_with_weak_handles_drops_iteratively() {
+        let reference = deeply_nested_reference(10_000);
+        let mut weak_elements: Vec<Weak<Box<Element>>> = Vec::new();
+        let mut current = &reference;
+        while let Instance::Element(element) = current.instance() {
+            weak_elements.push(Arc::downgrade(element));
+            let Element::Reference(inner) = element.as_ref().as_ref() else {
+                break;
+            };
+            current = inner;
+        }
+        assert!(
+            weak_elements
+                .iter()
+                .all(|element| element.upgrade().is_some())
+        );
+
+        drop(reference);
+
+        assert!(
+            weak_elements
+                .iter()
+                .all(|element| element.upgrade().is_none())
+        );
+    }
+
+    #[test]
+    fn deep_inline_chain_flattens_iteratively() {
+        let polygon = Polygon::new(
+            [
+                Point::default_integer(0, 0),
+                Point::default_integer(10, 0),
+                Point::default_integer(10, 10),
+            ],
+            Layer::new(1),
+            DataType::new(0),
+        );
+        let mut reference = Reference::new(polygon);
+        for _ in 1..10_000 {
+            reference = Reference::new(reference);
+        }
+
+        let flattened = reference.flatten(None, &Library::new("test"));
+
+        assert_eq!(flattened.len(), 1);
+        assert!(matches!(flattened[0], Element::Polygon(_)));
+    }
 
     mod instance {
         use super::*;

--- a/crates/gdsr/src/geometry/bounding_box.rs
+++ b/crates/gdsr/src/geometry/bounding_box.rs
@@ -1,4 +1,4 @@
-use crate::Point;
+use crate::{Point, Unit};
 
 /// Calculate the bounding box of a collection of points.
 ///
@@ -18,16 +18,16 @@ pub fn bounding_box(points: &[Point]) -> (Point, Point) {
     let mut max_y = f64::NEG_INFINITY;
 
     for p in points {
-        let x = p.x().float_value();
-        let y = p.y().float_value();
+        let x = p.x().to_float_unit().scale_to(x_units).float_value();
+        let y = p.y().to_float_unit().scale_to(y_units).float_value();
         min_x = min_x.min(x);
         min_y = min_y.min(y);
         max_x = max_x.max(x);
         max_y = max_y.max(y);
     }
 
-    let min_point = Point::float(min_x, min_y, x_units);
-    let max_point = Point::float(max_x, max_y, y_units);
+    let min_point = Point::new(Unit::float(min_x, x_units), Unit::float(min_y, y_units));
+    let max_point = Point::new(Unit::float(max_x, x_units), Unit::float(max_y, y_units));
     (min_point, max_point)
 }
 
@@ -63,6 +63,44 @@ mod tests {
         let (min, max) = bounding_box(&points);
         assert_eq!(min, Point::integer(5, 3, 1e-9));
         assert_eq!(max, Point::integer(5, 3, 1e-9));
+    }
+
+    #[test]
+    fn bounding_box_preserves_axis_specific_units() {
+        let points = [
+            Point::new(Unit::float(4.0, 1e-9), Unit::float(-2.0, 1e-6)),
+            Point::new(Unit::float(-1.0, 1e-9), Unit::float(3.0, 1e-6)),
+        ];
+
+        let (min, max) = bounding_box(&points);
+
+        assert_eq!(
+            min,
+            Point::new(Unit::float(-1.0, 1e-9), Unit::float(-2.0, 1e-6))
+        );
+        assert_eq!(
+            max,
+            Point::new(Unit::float(4.0, 1e-9), Unit::float(3.0, 1e-6))
+        );
+    }
+
+    #[test]
+    fn bounding_box_preserves_mixed_resolution_integer_coordinates() {
+        let points = [
+            Point::new(Unit::integer(1, 1.0), Unit::integer(1, 1.0)),
+            Point::new(Unit::integer(1, 0.1), Unit::integer(2, 0.1)),
+        ];
+
+        let (min, max) = bounding_box(&points);
+
+        assert_eq!(
+            min,
+            Point::new(Unit::float(0.1, 1.0), Unit::float(0.2, 1.0))
+        );
+        assert_eq!(
+            max,
+            Point::new(Unit::float(1.0, 1.0), Unit::float(1.0, 1.0))
+        );
     }
 
     #[test]

--- a/crates/gdsr/src/hierarchy_bounds.rs
+++ b/crates/gdsr/src/hierarchy_bounds.rs
@@ -1,0 +1,1774 @@
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::fmt;
+
+use crate::{Element, Grid, Instance, Library, Point, Reference};
+
+/// Axis-aligned bounds in physical world units.
+///
+/// Coordinates are absolute physical distances: a point value multiplied by
+/// its stored unit scale. They are independent of any GDS output database unit.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct WorldBounds {
+    /// Minimum physical x coordinate.
+    pub min_x: f64,
+    /// Minimum physical y coordinate.
+    pub min_y: f64,
+    /// Maximum physical x coordinate.
+    pub max_x: f64,
+    /// Maximum physical y coordinate.
+    pub max_y: f64,
+}
+
+impl WorldBounds {
+    /// Creates bounds from minimum and maximum coordinates.
+    pub const fn new(min_x: f64, min_y: f64, max_x: f64, max_y: f64) -> Self {
+        Self {
+            min_x,
+            min_y,
+            max_x,
+            max_y,
+        }
+    }
+
+    /// Returns whether these bounds overlap `other`.
+    pub fn overlaps(&self, other: &Self) -> bool {
+        self.max_x >= other.min_x
+            && self.min_x <= other.max_x
+            && self.max_y >= other.min_y
+            && self.min_y <= other.max_y
+    }
+
+    /// Returns the smallest bounds containing `self` and `other`.
+    #[must_use]
+    pub fn merge(&self, other: &Self) -> Self {
+        Self {
+            min_x: self.min_x.min(other.min_x),
+            min_y: self.min_y.min(other.min_y),
+            max_x: self.max_x.max(other.max_x),
+            max_y: self.max_y.max(other.max_y),
+        }
+    }
+
+    /// Applies one reference grid and returns aggregate bounds for all its members.
+    pub fn transformed_by_grid(&self, grid: &Grid) -> Option<Self> {
+        transform_bounds_by_grid(Some(*self), grid).ok().flatten()
+    }
+
+    fn corners(&self) -> [(f64, f64); 4] {
+        [
+            (self.min_x, self.min_y),
+            (self.max_x, self.min_y),
+            (self.max_x, self.max_y),
+            (self.min_x, self.max_y),
+        ]
+    }
+
+    const fn is_finite(&self) -> bool {
+        self.min_x.is_finite()
+            && self.min_y.is_finite()
+            && self.max_x.is_finite()
+            && self.max_y.is_finite()
+    }
+}
+
+/// Stable location of one top-level reference element.
+///
+/// One location represents the aggregate placement of the whole reference,
+/// including every AREF member. Members are not expanded into separate entries.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ReferenceLocation {
+    /// Name of the cell containing the reference element.
+    pub cell_name: String,
+    /// Stable index of the reference in that cell's element sequence.
+    pub element_index: usize,
+}
+
+/// Non-fatal hierarchy problem found while calculating bounds.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum HierarchyBoundsDiagnostic {
+    /// A reference targets a cell absent from the library.
+    DanglingReference {
+        /// Cell containing the reference element.
+        source_cell: String,
+        /// Index of the reference in the source cell.
+        element_index: usize,
+        /// Missing target cell name.
+        target_cell: String,
+    },
+    /// One strongly connected component containing hierarchy cycles.
+    Cycle {
+        /// Sorted cells in the cyclic component.
+        cells: Vec<String>,
+        /// Cell containing the representative intra-component reference.
+        source_cell: String,
+        /// Index of the representative reference in the source cell.
+        element_index: usize,
+        /// Target of the representative reference.
+        target_cell: String,
+    },
+    /// An element contains non-finite coordinates or transform values.
+    NonFiniteElement {
+        /// Cell containing the invalid top-level element.
+        source_cell: String,
+        /// Index of the invalid element in the source cell.
+        element_index: usize,
+    },
+}
+
+/// Fatal hierarchy-bounds query error.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum HierarchyBoundsError {
+    /// Requested root cell does not exist.
+    UnknownRoot { cell_name: String },
+}
+
+impl fmt::Display for HierarchyBoundsError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnknownRoot { cell_name } => {
+                write!(formatter, "unknown hierarchy root cell '{cell_name}'")
+            }
+        }
+    }
+}
+
+impl std::error::Error for HierarchyBoundsError {}
+
+/// Detached bounds snapshot for the hierarchy reachable from one root cell.
+///
+/// Every query builds a fresh bottom-up memo. Later library mutations require
+/// no invalidation: a later query recomputes from current library contents.
+#[derive(Clone, Debug, PartialEq)]
+pub struct HierarchyBoundsReport {
+    root_cell: String,
+    root_bounds: Option<WorldBounds>,
+    cell_bounds: BTreeMap<String, Option<WorldBounds>>,
+    reference_bounds: BTreeMap<ReferenceLocation, Option<WorldBounds>>,
+    diagnostics: Vec<HierarchyBoundsDiagnostic>,
+}
+
+impl HierarchyBoundsReport {
+    /// Returns the queried root cell name.
+    pub fn root_cell(&self) -> &str {
+        &self.root_cell
+    }
+
+    /// Returns aggregate bounds in the root cell's local coordinate space.
+    pub const fn root_bounds(&self) -> Option<WorldBounds> {
+        self.root_bounds
+    }
+
+    /// Returns local-coordinate bounds for every reachable cell, sorted by name.
+    pub const fn cell_bounds(&self) -> &BTreeMap<String, Option<WorldBounds>> {
+        &self.cell_bounds
+    }
+
+    /// Returns aggregate bounds for every reachable top-level reference element.
+    ///
+    /// Each value uses its containing cell's local coordinate space.
+    pub const fn reference_bounds(&self) -> &BTreeMap<ReferenceLocation, Option<WorldBounds>> {
+        &self.reference_bounds
+    }
+
+    /// Returns non-fatal problems in deterministic canonical order.
+    ///
+    /// Dangling references come first, then cyclic components, then non-finite
+    /// elements. Each group is sorted by its structured fields.
+    pub fn diagnostics(&self) -> &[HierarchyBoundsDiagnostic] {
+        &self.diagnostics
+    }
+}
+
+#[derive(Default)]
+struct BoundsState {
+    cell_bounds: BTreeMap<String, Option<WorldBounds>>,
+    reference_bounds: BTreeMap<ReferenceLocation, Option<WorldBounds>>,
+    non_finite_elements: BTreeSet<(String, usize)>,
+    #[cfg(test)]
+    cell_scan_counts: BTreeMap<String, usize>,
+}
+
+#[derive(Clone)]
+struct GraphEdge {
+    element_index: usize,
+    target_cell: String,
+}
+
+struct ReachableGraph {
+    edges: BTreeMap<String, Vec<GraphEdge>>,
+    dangling_diagnostics: Vec<HierarchyBoundsDiagnostic>,
+}
+
+struct CycleComponent {
+    cells: Vec<String>,
+    source_cell: String,
+    element_index: usize,
+    target_cell: String,
+}
+
+struct SccAnalysis {
+    cyclic_component_by_cell: HashMap<String, usize>,
+    cycles: Vec<CycleComponent>,
+}
+
+struct TraversalFrame {
+    cell_name: String,
+    next_element_index: usize,
+    bounds: Option<WorldBounds>,
+}
+
+impl TraversalFrame {
+    fn new(cell_name: String) -> Self {
+        Self {
+            cell_name,
+            next_element_index: 0,
+            bounds: None,
+        }
+    }
+}
+
+enum TraversalAction {
+    Complete,
+    Direct(BoundsResult),
+    Reference(ReferenceLocation, BoundsResult),
+    Descend(String),
+}
+
+enum ReferenceEvaluation {
+    Ready(BoundsResult),
+    NeedCell(String),
+}
+
+struct ReferenceContext<'a> {
+    source_cell: &'a str,
+    scc_analysis: &'a SccAnalysis,
+}
+
+#[derive(Clone, Copy)]
+struct NonFiniteBounds;
+
+type BoundsResult = Result<Option<WorldBounds>, NonFiniteBounds>;
+
+impl Library {
+    /// Calculates hierarchy-aware bounds with one ephemeral bottom-up memo.
+    ///
+    /// Dangling references and cycles are reported, so valid sibling geometry
+    /// remains. Cyclic cell bounds conservatively cover one finite traversal
+    /// through their strongly connected component. Only an unknown root is fatal.
+    /// Cell traversal uses heap-backed frames rather than the process call stack.
+    pub fn hierarchy_bounds(
+        &self,
+        root_cell: &str,
+    ) -> Result<HierarchyBoundsReport, HierarchyBoundsError> {
+        let (state, diagnostics) = calculate_bounds(self, root_cell)?;
+        let root_bounds = state.cell_bounds.get(root_cell).copied().flatten();
+        Ok(HierarchyBoundsReport {
+            root_cell: root_cell.to_string(),
+            root_bounds,
+            cell_bounds: state.cell_bounds,
+            reference_bounds: state.reference_bounds,
+            diagnostics,
+        })
+    }
+}
+
+fn calculate_bounds(
+    library: &Library,
+    root_cell: &str,
+) -> Result<(BoundsState, Vec<HierarchyBoundsDiagnostic>), HierarchyBoundsError> {
+    if library.get_cell(root_cell).is_none() {
+        return Err(HierarchyBoundsError::UnknownRoot {
+            cell_name: root_cell.to_string(),
+        });
+    }
+
+    let graph = reachable_graph(library, root_cell);
+    let scc_analysis = analyze_sccs(&graph);
+    let mut state = BoundsState::default();
+    calculate_cell_bounds(library, root_cell, &scc_analysis, &mut state)?;
+    for cell_name in graph.edges.keys() {
+        if !state.cell_bounds.contains_key(cell_name) {
+            calculate_cell_bounds(library, cell_name, &scc_analysis, &mut state)?;
+        }
+    }
+    if !scc_analysis.cycles.is_empty() {
+        expand_cyclic_component_bounds(library, &scc_analysis, &mut state)?;
+        let cyclic_cells = &scc_analysis.cyclic_component_by_cell;
+        state
+            .cell_bounds
+            .retain(|cell_name, _| cyclic_cells.contains_key(cell_name));
+        state
+            .reference_bounds
+            .retain(|location, _| cyclic_cells.contains_key(&location.cell_name));
+        state
+            .non_finite_elements
+            .retain(|(cell_name, _)| cyclic_cells.contains_key(cell_name));
+
+        if !state.cell_bounds.contains_key(root_cell) {
+            calculate_cell_bounds(library, root_cell, &scc_analysis, &mut state)?;
+        }
+        for cell_name in graph.edges.keys() {
+            if !state.cell_bounds.contains_key(cell_name) {
+                calculate_cell_bounds(library, cell_name, &scc_analysis, &mut state)?;
+            }
+        }
+    }
+
+    let mut diagnostics = graph.dangling_diagnostics;
+    diagnostics.extend(scc_analysis.cycles.into_iter().map(|cycle| {
+        HierarchyBoundsDiagnostic::Cycle {
+            cells: cycle.cells,
+            source_cell: cycle.source_cell,
+            element_index: cycle.element_index,
+            target_cell: cycle.target_cell,
+        }
+    }));
+    diagnostics.extend(
+        state
+            .non_finite_elements
+            .iter()
+            .map(
+                |(source_cell, element_index)| HierarchyBoundsDiagnostic::NonFiniteElement {
+                    source_cell: source_cell.clone(),
+                    element_index: *element_index,
+                },
+            ),
+    );
+
+    Ok((state, diagnostics))
+}
+
+fn expand_cyclic_component_bounds(
+    library: &Library,
+    scc_analysis: &SccAnalysis,
+    state: &mut BoundsState,
+) -> Result<(), HierarchyBoundsError> {
+    let acyclic_analysis = SccAnalysis {
+        cyclic_component_by_cell: HashMap::new(),
+        cycles: Vec::new(),
+    };
+    for component in cyclic_components_bottom_up(library, scc_analysis) {
+        for cell_name in &component.cells {
+            state.cell_bounds.remove(cell_name);
+        }
+        state
+            .reference_bounds
+            .retain(|location, _| component.cells.binary_search(&location.cell_name).is_err());
+        state
+            .non_finite_elements
+            .retain(|(cell_name, _)| component.cells.binary_search(cell_name).is_err());
+        for cell_name in &component.cells {
+            calculate_cell_bounds(library, cell_name, scc_analysis, state)?;
+        }
+
+        for _ in 1..component.cells.len() {
+            let previous: BTreeMap<_, _> = component
+                .cells
+                .iter()
+                .filter_map(|cell_name| {
+                    state
+                        .cell_bounds
+                        .get(cell_name)
+                        .copied()
+                        .map(|bounds| (cell_name.clone(), bounds))
+                })
+                .collect();
+            let mut expanded = previous.clone();
+
+            for source_cell in &component.cells {
+                let Some(cell) = library.get_cell(source_cell) else {
+                    continue;
+                };
+                for (element_index, element) in cell.elements().iter().enumerate() {
+                    let Element::Reference(reference) = element else {
+                        continue;
+                    };
+                    let Some(target_cell) = terminal_cell_name(reference) else {
+                        continue;
+                    };
+                    if !component
+                        .cells
+                        .iter()
+                        .any(|cell_name| cell_name == target_cell)
+                    {
+                        continue;
+                    }
+                    let evaluation = evaluate_reference(
+                        library,
+                        reference,
+                        &ReferenceContext {
+                            source_cell,
+                            scc_analysis: &acyclic_analysis,
+                        },
+                        state,
+                    );
+                    match evaluation {
+                        ReferenceEvaluation::Ready(Ok(Some(bounds))) => {
+                            let current = expanded.entry(source_cell.clone()).or_default();
+                            merge_bounds(current, bounds);
+                        }
+                        ReferenceEvaluation::Ready(Err(_)) => {
+                            state
+                                .non_finite_elements
+                                .insert((source_cell.clone(), element_index));
+                        }
+                        ReferenceEvaluation::Ready(Ok(None)) | ReferenceEvaluation::NeedCell(_) => {
+                        }
+                    }
+                }
+            }
+
+            for (cell_name, bounds) in expanded {
+                state.cell_bounds.insert(cell_name, bounds);
+            }
+        }
+    }
+
+    for component in &scc_analysis.cycles {
+        for source_cell in &component.cells {
+            let Some(cell) = library.get_cell(source_cell) else {
+                continue;
+            };
+            for (element_index, element) in cell.elements().iter().enumerate() {
+                let Element::Reference(reference) = element else {
+                    continue;
+                };
+                let Some(target_cell) = terminal_cell_name(reference) else {
+                    continue;
+                };
+                if !component
+                    .cells
+                    .iter()
+                    .any(|cell_name| cell_name == target_cell)
+                {
+                    continue;
+                }
+                let location = ReferenceLocation {
+                    cell_name: source_cell.clone(),
+                    element_index,
+                };
+                match evaluate_reference(
+                    library,
+                    reference,
+                    &ReferenceContext {
+                        source_cell,
+                        scc_analysis: &acyclic_analysis,
+                    },
+                    state,
+                ) {
+                    ReferenceEvaluation::Ready(Ok(bounds)) => {
+                        state.reference_bounds.insert(location, bounds);
+                    }
+                    ReferenceEvaluation::Ready(Err(_)) => {
+                        state.reference_bounds.insert(location, None);
+                        state
+                            .non_finite_elements
+                            .insert((source_cell.clone(), element_index));
+                    }
+                    ReferenceEvaluation::NeedCell(_) => {}
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn cyclic_components_bottom_up<'a>(
+    library: &Library,
+    scc_analysis: &'a SccAnalysis,
+) -> Vec<&'a CycleComponent> {
+    let component_name_by_cell: HashMap<&str, &str> = scc_analysis
+        .cycles
+        .iter()
+        .filter_map(|component| {
+            component.cells.first().map(|component_name| {
+                component
+                    .cells
+                    .iter()
+                    .map(move |cell_name| (cell_name.as_str(), component_name.as_str()))
+            })
+        })
+        .flatten()
+        .collect();
+    let component_by_name: HashMap<&str, &CycleComponent> = scc_analysis
+        .cycles
+        .iter()
+        .filter_map(|component| {
+            component
+                .cells
+                .first()
+                .map(|name| (name.as_str(), component))
+        })
+        .collect();
+    let mut adjacency: BTreeMap<String, Vec<String>> = component_by_name
+        .keys()
+        .map(|name| ((*name).to_string(), Vec::new()))
+        .collect();
+
+    for component in &scc_analysis.cycles {
+        let Some(component_name) = component.cells.first() else {
+            continue;
+        };
+        let Some(dependencies) = adjacency.get_mut(component_name) else {
+            continue;
+        };
+        for cell_name in &component.cells {
+            let Some(cell) = library.get_cell(cell_name) else {
+                continue;
+            };
+            for reference in cell.elements().iter().filter_map(|element| {
+                if let Element::Reference(reference) = element {
+                    Some(reference)
+                } else {
+                    None
+                }
+            }) {
+                let Some(target_cell) = terminal_cell_name(reference) else {
+                    continue;
+                };
+                let Some(target_component) = component_name_by_cell.get(target_cell) else {
+                    continue;
+                };
+                if *target_component != component_name {
+                    dependencies.push((*target_component).to_string());
+                }
+            }
+        }
+        dependencies.sort();
+        dependencies.dedup();
+    }
+
+    iterative_finish_order(&adjacency)
+        .into_iter()
+        .filter_map(|name| component_by_name.get(name.as_str()).copied())
+        .collect()
+}
+
+fn reachable_graph(library: &Library, root_cell: &str) -> ReachableGraph {
+    let mut edges = BTreeMap::new();
+    let mut dangling = Vec::new();
+    let mut pending = vec![root_cell.to_string()];
+    let mut visited = HashSet::new();
+
+    while let Some(cell_name) = pending.pop() {
+        if !visited.insert(cell_name.clone()) {
+            continue;
+        }
+        let Some(cell) = library.get_cell(&cell_name) else {
+            continue;
+        };
+        let mut cell_edges = Vec::new();
+        for (element_index, element) in cell.elements().iter().enumerate() {
+            let Element::Reference(reference) = element else {
+                continue;
+            };
+            let Some(target_cell) = terminal_cell_name(reference) else {
+                continue;
+            };
+            if library.get_cell(target_cell).is_some() {
+                cell_edges.push(GraphEdge {
+                    element_index,
+                    target_cell: target_cell.to_string(),
+                });
+                pending.push(target_cell.to_string());
+            } else {
+                dangling.push(HierarchyBoundsDiagnostic::DanglingReference {
+                    source_cell: cell_name.clone(),
+                    element_index,
+                    target_cell: target_cell.to_string(),
+                });
+            }
+        }
+        edges.insert(cell_name, cell_edges);
+    }
+
+    dangling.sort_by(|left, right| diagnostic_key(left).cmp(&diagnostic_key(right)));
+    ReachableGraph {
+        edges,
+        dangling_diagnostics: dangling,
+    }
+}
+
+fn terminal_cell_name(reference: &Reference) -> Option<&str> {
+    let mut current = reference;
+    loop {
+        match current.instance() {
+            Instance::Cell(cell_name) => return Some(cell_name),
+            Instance::Element(element) => {
+                if let Element::Reference(reference) = element.as_ref().as_ref() {
+                    current = reference;
+                } else {
+                    return None;
+                }
+            }
+        }
+    }
+}
+
+fn diagnostic_key(diagnostic: &HierarchyBoundsDiagnostic) -> (&str, usize, &str) {
+    match diagnostic {
+        HierarchyBoundsDiagnostic::DanglingReference {
+            source_cell,
+            element_index,
+            target_cell,
+        }
+        | HierarchyBoundsDiagnostic::Cycle {
+            source_cell,
+            element_index,
+            target_cell,
+            ..
+        } => (source_cell, *element_index, target_cell),
+        HierarchyBoundsDiagnostic::NonFiniteElement {
+            source_cell,
+            element_index,
+        } => (source_cell, *element_index, ""),
+    }
+}
+
+fn analyze_sccs(graph: &ReachableGraph) -> SccAnalysis {
+    let mut adjacency: BTreeMap<String, Vec<String>> = graph
+        .edges
+        .keys()
+        .map(|cell_name| (cell_name.clone(), Vec::new()))
+        .collect();
+    let mut reverse = adjacency.clone();
+    for (source_cell, edges) in &graph.edges {
+        if let Some(targets) = adjacency.get_mut(source_cell) {
+            targets.extend(edges.iter().map(|edge| edge.target_cell.clone()));
+            targets.sort();
+            targets.dedup();
+        }
+        for edge in edges {
+            if let Some(sources) = reverse.get_mut(&edge.target_cell) {
+                sources.push(source_cell.clone());
+            }
+        }
+    }
+    for sources in reverse.values_mut() {
+        sources.sort();
+        sources.dedup();
+    }
+
+    let finish_order = iterative_finish_order(&adjacency);
+    let mut assigned = HashSet::new();
+    let mut components = Vec::new();
+    for start in finish_order.into_iter().rev() {
+        if !assigned.insert(start.clone()) {
+            continue;
+        }
+        let mut members = Vec::new();
+        let mut pending = vec![start];
+        while let Some(cell_name) = pending.pop() {
+            members.push(cell_name.clone());
+            if let Some(neighbors) = reverse.get(&cell_name) {
+                for neighbor in neighbors.iter().rev() {
+                    if assigned.insert(neighbor.clone()) {
+                        pending.push(neighbor.clone());
+                    }
+                }
+            }
+        }
+        members.sort();
+        components.push(members);
+    }
+
+    let component_by_cell: HashMap<String, usize> = components
+        .iter()
+        .enumerate()
+        .flat_map(|(component_index, cells)| {
+            cells
+                .iter()
+                .cloned()
+                .map(move |cell_name| (cell_name, component_index))
+        })
+        .collect();
+    let mut cyclic_component_by_cell = HashMap::new();
+    let mut cycles = Vec::new();
+    for (component_index, cells) in components.into_iter().enumerate() {
+        let self_edge = cells.first().is_some_and(|cell_name| {
+            graph
+                .edges
+                .get(cell_name)
+                .is_some_and(|edges| edges.iter().any(|edge| edge.target_cell == *cell_name))
+        });
+        if cells.len() == 1 && !self_edge {
+            continue;
+        }
+        for cell_name in &cells {
+            cyclic_component_by_cell.insert(cell_name.clone(), component_index);
+        }
+        let representative = cells
+            .iter()
+            .flat_map(|source_cell| {
+                graph
+                    .edges
+                    .get(source_cell)
+                    .into_iter()
+                    .flatten()
+                    .filter(|edge| {
+                        component_by_cell.get(&edge.target_cell) == Some(&component_index)
+                    })
+                    .map(|edge| {
+                        (
+                            source_cell.clone(),
+                            edge.element_index,
+                            edge.target_cell.clone(),
+                        )
+                    })
+            })
+            .min();
+        if let Some((source_cell, element_index, target_cell)) = representative {
+            cycles.push(CycleComponent {
+                cells,
+                source_cell,
+                element_index,
+                target_cell,
+            });
+        }
+    }
+    cycles.sort_by(|left, right| {
+        left.cells.cmp(&right.cells).then_with(|| {
+            (&left.source_cell, left.element_index, &left.target_cell).cmp(&(
+                &right.source_cell,
+                right.element_index,
+                &right.target_cell,
+            ))
+        })
+    });
+
+    SccAnalysis {
+        cyclic_component_by_cell,
+        cycles,
+    }
+}
+
+fn iterative_finish_order(adjacency: &BTreeMap<String, Vec<String>>) -> Vec<String> {
+    let mut visited = HashSet::new();
+    let mut finished = Vec::new();
+    for start in adjacency.keys() {
+        if !visited.insert(start.clone()) {
+            continue;
+        }
+        let mut stack = vec![(start.clone(), 0)];
+        while let Some((cell_name, next_neighbor)) = stack.last_mut() {
+            let neighbors = adjacency.get(cell_name).map_or(&[][..], Vec::as_slice);
+            if let Some(neighbor) = neighbors.get(*next_neighbor) {
+                *next_neighbor += 1;
+                if visited.insert(neighbor.clone()) {
+                    stack.push((neighbor.clone(), 0));
+                }
+            } else if let Some((cell_name, _)) = stack.pop() {
+                finished.push(cell_name);
+            }
+        }
+    }
+    finished
+}
+
+impl SccAnalysis {
+    fn skips_edge(&self, source_cell: &str, target_cell: &str) -> bool {
+        self.cyclic_component_by_cell.get(source_cell)
+            == self.cyclic_component_by_cell.get(target_cell)
+            && self.cyclic_component_by_cell.contains_key(source_cell)
+    }
+}
+
+fn calculate_cell_bounds(
+    library: &Library,
+    root_cell: &str,
+    scc_analysis: &SccAnalysis,
+    state: &mut BoundsState,
+) -> Result<(), HierarchyBoundsError> {
+    let mut frames = vec![TraversalFrame::new(root_cell.to_string())];
+    record_cell_scan(state, root_cell);
+
+    while let Some(frame) = frames.last() {
+        let cell = library.get_cell(&frame.cell_name).ok_or_else(|| {
+            HierarchyBoundsError::UnknownRoot {
+                cell_name: frame.cell_name.clone(),
+            }
+        })?;
+        let action = if let Some(element) = cell.elements().get(frame.next_element_index) {
+            match element {
+                Element::Reference(reference) => {
+                    let location = ReferenceLocation {
+                        cell_name: frame.cell_name.clone(),
+                        element_index: frame.next_element_index,
+                    };
+                    match evaluate_reference(
+                        library,
+                        reference,
+                        &ReferenceContext {
+                            source_cell: &frame.cell_name,
+                            scc_analysis,
+                        },
+                        state,
+                    ) {
+                        ReferenceEvaluation::Ready(bounds) => {
+                            TraversalAction::Reference(location, bounds)
+                        }
+                        ReferenceEvaluation::NeedCell(cell_name) => {
+                            TraversalAction::Descend(cell_name)
+                        }
+                    }
+                }
+                _ => TraversalAction::Direct(direct_element_bounds(element)),
+            }
+        } else {
+            TraversalAction::Complete
+        };
+
+        match action {
+            TraversalAction::Complete => {
+                if let Some(frame) = frames.pop() {
+                    state.cell_bounds.insert(frame.cell_name, frame.bounds);
+                }
+            }
+            TraversalAction::Direct(Ok(bounds)) => {
+                if let Some(frame) = frames.last_mut() {
+                    if let Some(bounds) = bounds {
+                        merge_bounds(&mut frame.bounds, bounds);
+                    }
+                    frame.next_element_index += 1;
+                }
+            }
+            TraversalAction::Direct(Err(_)) => {
+                if let Some(frame) = frames.last_mut() {
+                    state
+                        .non_finite_elements
+                        .insert((frame.cell_name.clone(), frame.next_element_index));
+                    frame.next_element_index += 1;
+                }
+            }
+            TraversalAction::Reference(location, Ok(bounds)) => {
+                state.reference_bounds.insert(location, bounds);
+                if let Some(frame) = frames.last_mut() {
+                    if let Some(bounds) = bounds {
+                        merge_bounds(&mut frame.bounds, bounds);
+                    }
+                    frame.next_element_index += 1;
+                }
+            }
+            TraversalAction::Reference(location, Err(_)) => {
+                state.reference_bounds.insert(location.clone(), None);
+                state
+                    .non_finite_elements
+                    .insert((location.cell_name, location.element_index));
+                if let Some(frame) = frames.last_mut() {
+                    frame.next_element_index += 1;
+                }
+            }
+            TraversalAction::Descend(cell_name) => {
+                record_cell_scan(state, &cell_name);
+                frames.push(TraversalFrame::new(cell_name));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn evaluate_reference(
+    library: &Library,
+    reference: &Reference,
+    context: &ReferenceContext<'_>,
+    state: &BoundsState,
+) -> ReferenceEvaluation {
+    match reference.instance() {
+        Instance::Cell(target_cell) => {
+            match evaluate_cell_source(library, target_cell, context, state) {
+                ReferenceEvaluation::Ready(bounds) => {
+                    ReferenceEvaluation::Ready(transform_bounds_result(bounds, reference.grid()))
+                }
+                evaluation @ ReferenceEvaluation::NeedCell(_) => evaluation,
+            }
+        }
+        Instance::Element(element) => match element.as_ref().as_ref() {
+            Element::Reference(nested) => {
+                evaluate_inline_reference_chain(library, reference.grid(), nested, context, state)
+            }
+            element => ReferenceEvaluation::Ready(transform_bounds_result(
+                direct_element_bounds(element),
+                reference.grid(),
+            )),
+        },
+    }
+}
+
+fn evaluate_inline_reference_chain(
+    library: &Library,
+    outer_grid: &Grid,
+    reference: &Reference,
+    context: &ReferenceContext<'_>,
+    state: &BoundsState,
+) -> ReferenceEvaluation {
+    let mut current = reference;
+    let mut grids = vec![outer_grid];
+    let source_bounds = loop {
+        grids.push(current.grid());
+        match current.instance() {
+            Instance::Cell(target_cell) => {
+                match evaluate_cell_source(library, target_cell, context, state) {
+                    ReferenceEvaluation::Ready(bounds) => break bounds,
+                    evaluation @ ReferenceEvaluation::NeedCell(_) => return evaluation,
+                }
+            }
+            Instance::Element(element) => match element.as_ref().as_ref() {
+                Element::Reference(reference) => current = reference,
+                element => break direct_element_bounds(element),
+            },
+        }
+    };
+
+    let mut bounds = source_bounds;
+    for grid in grids.into_iter().rev() {
+        bounds = transform_bounds_result(bounds, grid);
+    }
+    ReferenceEvaluation::Ready(bounds)
+}
+
+fn evaluate_cell_source(
+    library: &Library,
+    target_cell: &str,
+    context: &ReferenceContext<'_>,
+    state: &BoundsState,
+) -> ReferenceEvaluation {
+    if context
+        .scc_analysis
+        .skips_edge(context.source_cell, target_cell)
+    {
+        return ReferenceEvaluation::Ready(Ok(None));
+    }
+    if let Some(bounds) = state.cell_bounds.get(target_cell) {
+        return ReferenceEvaluation::Ready(Ok(*bounds));
+    }
+    if library.get_cell(target_cell).is_none() {
+        return ReferenceEvaluation::Ready(Ok(None));
+    }
+    ReferenceEvaluation::NeedCell(target_cell.to_string())
+}
+
+fn record_cell_scan(state: &mut BoundsState, cell_name: &str) {
+    #[cfg(test)]
+    state
+        .cell_scan_counts
+        .entry(cell_name.to_string())
+        .and_modify(|count| *count += 1)
+        .or_insert(1);
+    #[cfg(not(test))]
+    let _ = (state, cell_name);
+}
+
+fn transform_bounds_result(bounds: BoundsResult, grid: &Grid) -> BoundsResult {
+    transform_bounds_by_grid(bounds?, grid)
+}
+
+fn transform_bounds_by_grid(bounds: Option<WorldBounds>, grid: &Grid) -> BoundsResult {
+    let angle = grid.angle().value();
+    let magnification = grid.magnification();
+    let origin = grid.origin();
+    let origin_x = origin.x().absolute_value();
+    let origin_y = origin.y().absolute_value();
+    let spacing_x = grid.spacing_x().unwrap_or_default();
+    let spacing_y = grid.spacing_y().unwrap_or_default();
+    let spacing_x = (
+        spacing_x.x().absolute_value(),
+        spacing_x.y().absolute_value(),
+    );
+    let spacing_y = (
+        spacing_y.x().absolute_value(),
+        spacing_y.y().absolute_value(),
+    );
+    if ![
+        angle,
+        magnification,
+        origin_x,
+        origin_y,
+        spacing_x.0,
+        spacing_x.1,
+        spacing_y.0,
+        spacing_y.1,
+    ]
+    .into_iter()
+    .all(f64::is_finite)
+    {
+        return Err(NonFiniteBounds);
+    }
+    if grid.columns() == 0 || grid.rows() == 0 {
+        return Ok(None);
+    }
+    let Some(bounds) = bounds else {
+        return Ok(None);
+    };
+    if !bounds.is_finite() {
+        return Err(NonFiniteBounds);
+    }
+
+    let (sin_angle, cos_angle) = angle.sin_cos();
+    let mut result = None;
+    for column in [0, grid.columns() - 1] {
+        for row in [0, grid.rows() - 1] {
+            let offset_x = spacing_x.0 * f64::from(column) + spacing_y.0 * f64::from(row);
+            let offset_y = spacing_x.1 * f64::from(column) + spacing_y.1 * f64::from(row);
+            let rotated_offset_x = offset_x * cos_angle - offset_y * sin_angle;
+            let rotated_offset_y = offset_x * sin_angle + offset_y * cos_angle;
+
+            for (mut x, mut y) in bounds.corners() {
+                if grid.x_reflection() {
+                    y = -y;
+                }
+                (x, y) = (
+                    (x * cos_angle - y * sin_angle) * magnification,
+                    (x * sin_angle + y * cos_angle) * magnification,
+                );
+                let x = x + origin_x + rotated_offset_x;
+                let y = y + origin_y + rotated_offset_y;
+                if !x.is_finite() || !y.is_finite() {
+                    return Err(NonFiniteBounds);
+                }
+                merge_point(&mut result, x, y);
+            }
+        }
+    }
+    Ok(result)
+}
+
+fn direct_element_bounds(element: &Element) -> BoundsResult {
+    match element {
+        Element::Polygon(polygon) => point_bounds(polygon.points().iter()),
+        Element::Box(gds_box) => point_bounds(gds_box.points().iter()),
+        Element::Node(node) => point_bounds(node.points().iter()),
+        Element::Path(path) => path_bounds(path),
+        Element::Text(text) => point_bounds(std::iter::once(text.origin())),
+        Element::Reference(_) => Ok(None),
+    }
+}
+
+fn point_bounds<'a>(points: impl IntoIterator<Item = &'a Point>) -> BoundsResult {
+    let mut bounds = None;
+    for point in points {
+        let x = point.x().absolute_value();
+        let y = point.y().absolute_value();
+        if !x.is_finite() || !y.is_finite() {
+            return Err(NonFiniteBounds);
+        }
+        merge_point(&mut bounds, x, y);
+    }
+    Ok(bounds)
+}
+
+fn path_bounds(path: &crate::Path) -> BoundsResult {
+    let mut bounds = point_bounds(path.points().iter())?;
+    let half_width = path
+        .width()
+        .map_or(0.0, |width| width.absolute_value().abs() / 2.0);
+    let begin_extension = path
+        .begin_extension()
+        .map_or(0.0, |extension| extension.absolute_value().max(0.0));
+    let end_extension = path
+        .end_extension()
+        .map_or(0.0, |extension| extension.absolute_value().max(0.0));
+    let padding = half_width + begin_extension.max(end_extension);
+    if !padding.is_finite() {
+        return Err(NonFiniteBounds);
+    }
+    if let Some(bounds) = &mut bounds {
+        bounds.min_x -= padding;
+        bounds.min_y -= padding;
+        bounds.max_x += padding;
+        bounds.max_y += padding;
+        if !bounds.is_finite() {
+            return Err(NonFiniteBounds);
+        }
+    }
+    Ok(bounds)
+}
+
+fn merge_bounds(result: &mut Option<WorldBounds>, bounds: WorldBounds) {
+    *result = Some(match result {
+        Some(current) => current.merge(&bounds),
+        None => bounds,
+    });
+}
+
+fn merge_point(result: &mut Option<WorldBounds>, x: f64, y: f64) {
+    merge_bounds(result, WorldBounds::new(x, y, x, y));
+}
+
+#[cfg(test)]
+mod tests {
+    use std::f64::consts::FRAC_PI_2;
+
+    use crate::{
+        Cell, DataType, GdsBox, HorizontalPresentation, Layer, Node, Path, Point, Polygon, Radians,
+        Text, Unit, VerticalPresentation,
+    };
+
+    use super::*;
+
+    fn point(x: f64, y: f64) -> Point {
+        Point::float(x, y, 1.0)
+    }
+
+    fn rectangle(min_x: f64, min_y: f64, max_x: f64, max_y: f64) -> Polygon {
+        Polygon::new(
+            [
+                point(min_x, min_y),
+                point(max_x, min_y),
+                point(max_x, max_y),
+                point(min_x, max_y),
+            ],
+            Layer::new(1),
+            DataType::new(0),
+        )
+    }
+
+    fn assert_bounds(actual: Option<WorldBounds>, expected: (f64, f64, f64, f64)) {
+        let actual = actual.expect("bounds should exist");
+        let tolerance = 1e-12;
+        assert!((actual.min_x - expected.0).abs() < tolerance, "{actual:?}");
+        assert!((actual.min_y - expected.1).abs() < tolerance, "{actual:?}");
+        assert!((actual.max_x - expected.2).abs() < tolerance, "{actual:?}");
+        assert!((actual.max_y - expected.3).abs() < tolerance, "{actual:?}");
+    }
+
+    fn assert_element_bounds(element: impl Into<Element>, expected: (f64, f64, f64, f64)) {
+        let mut cell = Cell::new("element");
+        cell.add(element);
+        let mut library = Library::new("bounds");
+        library.add_cell(cell);
+        let report = library
+            .hierarchy_bounds("element")
+            .expect("direct element should resolve");
+        assert_bounds(report.root_bounds(), expected);
+    }
+
+    #[test]
+    fn direct_and_empty_cells_have_explicit_bounds() {
+        let mut direct = Cell::new("direct");
+        direct.add(rectangle(-2.0, 3.0, 5.0, 8.0));
+        let mut library = Library::new("bounds");
+        library.add_cell(Cell::new("empty"));
+        library.add_cell(direct);
+
+        let direct_report = library
+            .hierarchy_bounds("direct")
+            .expect("direct cell should resolve");
+        assert_bounds(direct_report.root_bounds(), (-2.0, 3.0, 5.0, 8.0));
+
+        let empty_report = library
+            .hierarchy_bounds("empty")
+            .expect("empty cell should resolve");
+        assert_eq!(empty_report.root_bounds(), None);
+        assert_eq!(empty_report.cell_bounds().get("empty"), Some(&None));
+    }
+
+    #[test]
+    fn direct_path_bounds_include_width_and_extensions() {
+        let path = Path::new(
+            [point(10.0, 20.0), point(30.0, 40.0)],
+            Layer::new(1),
+            DataType::new(0),
+            None,
+            Some(Unit::float(4.0, 1.0)),
+            Some(Unit::float(3.0, 1.0)),
+            Some(Unit::float(1.0, 1.0)),
+        );
+        let mut cell = Cell::new("path");
+        cell.add(path);
+        let mut library = Library::new("bounds");
+        library.add_cell(cell);
+
+        let report = library
+            .hierarchy_bounds("path")
+            .expect("path cell should resolve");
+        assert_bounds(report.root_bounds(), (5.0, 15.0, 35.0, 45.0));
+    }
+
+    #[test]
+    fn direct_elements_compare_extrema_in_physical_units() {
+        let low = Point::new(Unit::float(-2.0, 1.0), Unit::float(-7_000.0, 0.001));
+        let high = Point::new(Unit::float(5_000.0, 0.001), Unit::float(3.0, 1.0));
+
+        assert_element_bounds(
+            Polygon::new(
+                [low, high, point(0.0, 0.0)],
+                Layer::new(1),
+                DataType::new(0),
+            ),
+            (-2.0, -7.0, 5.0, 3.0),
+        );
+        assert_element_bounds(
+            GdsBox::new(low, high, Layer::new(1), DataType::new(0)),
+            (-2.0, -7.0, 5.0, 3.0),
+        );
+        assert_element_bounds(
+            Node::new(vec![low, high], Layer::new(1), DataType::new(0)),
+            (-2.0, -7.0, 5.0, 3.0),
+        );
+        assert_element_bounds(
+            Path::new(
+                [low, high],
+                Layer::new(1),
+                DataType::new(0),
+                None,
+                None,
+                None,
+                None,
+            ),
+            (-2.0, -7.0, 5.0, 3.0),
+        );
+        assert_element_bounds(
+            Text::new(
+                "mixed",
+                low,
+                Layer::new(1),
+                DataType::new(0),
+                1.0,
+                Radians::new(0.0),
+                false,
+                VerticalPresentation::Middle,
+                HorizontalPresentation::Centre,
+            ),
+            (-2.0, -7.0, -2.0, -7.0),
+        );
+    }
+
+    #[test]
+    fn negative_path_values_never_shrink_bounds() {
+        let path = Path::new(
+            [point(0.0, 0.0), point(10.0, 0.0)],
+            Layer::new(1),
+            DataType::new(0),
+            None,
+            Some(Unit::float(-4.0, 0.5)),
+            Some(Unit::float(-100.0, 1.0)),
+            Some(Unit::float(2.0, 0.5)),
+        );
+
+        assert_element_bounds(path, (-2.0, -2.0, 12.0, 2.0));
+    }
+
+    #[test]
+    fn nested_reference_applies_all_transform_components() {
+        let mut leaf = Cell::new("leaf");
+        leaf.add(rectangle(0.0, 0.0, 2.0, 1.0));
+        let mut middle = Cell::new("middle");
+        middle.add(
+            Reference::new("leaf").with_grid(
+                Grid::default()
+                    .with_origin(point(10.0, 20.0))
+                    .with_angle(Radians::new(FRAC_PI_2))
+                    .with_magnification(2.0)
+                    .with_x_reflection(true),
+            ),
+        );
+        let mut top = Cell::new("top");
+        top.add(Reference::new("middle").with_grid(Grid::default().with_origin(point(-5.0, 3.0))));
+        let mut library = Library::new("bounds");
+        library.add_cell(leaf);
+        library.add_cell(middle);
+        library.add_cell(top);
+
+        let report = library
+            .hierarchy_bounds("top")
+            .expect("hierarchy should resolve");
+        assert_bounds(report.root_bounds(), (5.0, 23.0, 7.0, 27.0));
+    }
+
+    #[test]
+    fn inline_reference_chain_resolves_named_cell_without_extra_entries() {
+        let mut leaf = Cell::new("leaf");
+        leaf.add(rectangle(0.0, 0.0, 1.0, 1.0));
+        let nested = Reference::new("leaf").with_grid(Grid::default().with_origin(point(2.0, 0.0)));
+        let mut top = Cell::new("top");
+        top.add(Reference::new(nested).with_grid(Grid::default().with_origin(point(3.0, 0.0))));
+        let mut library = Library::new("bounds");
+        library.add_cell(leaf);
+        library.add_cell(top);
+
+        let report = library
+            .hierarchy_bounds("top")
+            .expect("inline hierarchy should resolve");
+        assert_bounds(report.root_bounds(), (5.0, 0.0, 6.0, 1.0));
+        assert_eq!(report.reference_bounds().len(), 1);
+    }
+
+    #[test]
+    fn rotated_bounds_use_all_four_source_corners() {
+        let bounds = WorldBounds::new(0.0, 0.0, 2.0, 1.0);
+        let transformed = bounds.transformed_by_grid(
+            &Grid::default().with_angle(Radians::new(std::f64::consts::FRAC_PI_4)),
+        );
+        let sqrt_two = 2.0_f64.sqrt();
+        assert_bounds(
+            transformed,
+            (-sqrt_two / 2.0, 0.0, sqrt_two, 3.0 * sqrt_two / 2.0),
+        );
+    }
+
+    #[test]
+    fn skew_and_negative_array_spacing_use_extreme_members() {
+        let mut leaf = Cell::new("leaf");
+        leaf.add(rectangle(0.0, 0.0, 2.0, 1.0));
+        let mut top = Cell::new("top");
+        top.add(
+            Reference::new("leaf").with_grid(
+                Grid::default()
+                    .with_columns(3)
+                    .with_rows(2)
+                    .with_spacing_x(Some(point(-4.0, 1.0)))
+                    .with_spacing_y(Some(point(2.0, -5.0))),
+            ),
+        );
+        let mut library = Library::new("bounds");
+        library.add_cell(leaf);
+        library.add_cell(top);
+
+        let report = library
+            .hierarchy_bounds("top")
+            .expect("hierarchy should resolve");
+        assert_bounds(report.root_bounds(), (-8.0, -5.0, 4.0, 3.0));
+        assert_eq!(report.reference_bounds().len(), 1);
+        assert_bounds(
+            report.reference_bounds().values().next().copied().flatten(),
+            (-8.0, -5.0, 4.0, 3.0),
+        );
+    }
+
+    #[test]
+    fn large_aref_stores_one_aggregate_reference_bound() {
+        let mut leaf = Cell::new("leaf");
+        leaf.add(rectangle(0.0, 0.0, 1.0, 1.0));
+        let mut top = Cell::new("top");
+        top.add(
+            Reference::new("leaf").with_grid(
+                Grid::default()
+                    .with_columns(1_000_000)
+                    .with_rows(1_000_000)
+                    .with_spacing_x(Some(point(2.0, 0.0)))
+                    .with_spacing_y(Some(point(0.0, -3.0))),
+            ),
+        );
+        let mut library = Library::new("bounds");
+        library.add_cell(leaf);
+        library.add_cell(top);
+
+        let report = library
+            .hierarchy_bounds("top")
+            .expect("hierarchy should resolve");
+        assert_eq!(report.reference_bounds().len(), 1);
+        assert_bounds(report.root_bounds(), (0.0, -2_999_997.0, 1_999_999.0, 1.0));
+    }
+
+    #[test]
+    fn repeated_child_is_reported_once_and_each_reference_has_bounds() {
+        let mut leaf = Cell::new("leaf");
+        leaf.add(rectangle(0.0, 0.0, 1.0, 1.0));
+        let mut top = Cell::new("top");
+        for index in 0..100 {
+            top.add(
+                Reference::new("leaf")
+                    .with_grid(Grid::default().with_origin(point(f64::from(index), 0.0))),
+            );
+        }
+        let mut library = Library::new("bounds");
+        library.add_cell(leaf);
+        library.add_cell(top);
+
+        let report = library
+            .hierarchy_bounds("top")
+            .expect("hierarchy should resolve");
+        assert_eq!(report.cell_bounds().len(), 2);
+        assert_eq!(report.reference_bounds().len(), 100);
+        assert_bounds(report.root_bounds(), (0.0, 0.0, 100.0, 1.0));
+
+        let (state, _) = calculate_bounds(&library, "top").expect("hierarchy should resolve");
+        assert_eq!(state.cell_scan_counts.get("leaf"), Some(&1));
+        assert_eq!(state.cell_scan_counts.get("top"), Some(&1));
+    }
+
+    #[test]
+    fn deep_hierarchy_uses_heap_backed_traversal() {
+        const DEPTH: usize = 10_000;
+
+        let mut library = Library::new("bounds");
+        for index in 0..DEPTH {
+            let cell_name = format!("cell_{index:05}");
+            let mut cell = Cell::new(&cell_name);
+            if index + 1 == DEPTH {
+                cell.add(rectangle(0.0, 0.0, 1.0, 1.0));
+                cell.add(Reference::new("missing"));
+            } else {
+                cell.add(Reference::new(format!("cell_{:05}", index + 1)));
+            }
+            library.add_cell(cell);
+        }
+
+        let report = library
+            .hierarchy_bounds("cell_00000")
+            .expect("deep hierarchy should resolve");
+        assert_bounds(report.root_bounds(), (0.0, 0.0, 1.0, 1.0));
+        assert_eq!(report.cell_bounds().len(), DEPTH);
+        assert_eq!(
+            report.diagnostics(),
+            &[HierarchyBoundsDiagnostic::DanglingReference {
+                source_cell: "cell_09999".to_string(),
+                element_index: 1,
+                target_cell: "missing".to_string(),
+            }],
+        );
+    }
+
+    #[test]
+    fn dangling_reference_keeps_valid_sibling_geometry() {
+        let mut top = Cell::new("top");
+        top.add(rectangle(1.0, 2.0, 3.0, 4.0));
+        top.add(Reference::new("missing"));
+        let mut library = Library::new("bounds");
+        library.add_cell(top);
+
+        let report = library
+            .hierarchy_bounds("top")
+            .expect("known root should produce a partial report");
+        assert_bounds(report.root_bounds(), (1.0, 2.0, 3.0, 4.0));
+        insta::assert_debug_snapshot!(report.diagnostics(), @r#"
+        [
+            DanglingReference {
+                source_cell: "top",
+                element_index: 1,
+                target_cell: "missing",
+            },
+        ]
+        "#);
+    }
+
+    #[test]
+    fn diagnostic_order_is_canonical_across_cell_storage_order() {
+        let mut child_a = Cell::new("a");
+        child_a.add(Reference::new("missing_a"));
+        let mut child_b = Cell::new("b");
+        child_b.add(Reference::new("missing_b"));
+        let mut top = Cell::new("top");
+        top.add(Reference::new("b"));
+        top.add(Reference::new("a"));
+        let mut library = Library::new("bounds");
+        library.add_cell(child_a);
+        library.add_cell(top);
+        library.add_cell(child_b);
+
+        let report = library
+            .hierarchy_bounds("top")
+            .expect("known root should produce a partial report");
+        let targets: Vec<&str> = report
+            .diagnostics()
+            .iter()
+            .filter_map(|diagnostic| {
+                if let HierarchyBoundsDiagnostic::DanglingReference { target_cell, .. } = diagnostic
+                {
+                    Some(target_cell.as_str())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        assert_eq!(targets, ["missing_a", "missing_b"]);
+    }
+
+    #[test]
+    fn self_cycle_keeps_valid_geometry_and_reports_component() {
+        let mut cell = Cell::new("self");
+        cell.add(rectangle(0.0, 0.0, 2.0, 2.0));
+        cell.add(Reference::new("self"));
+        let mut library = Library::new("bounds");
+        library.add_cell(cell);
+
+        let report = library
+            .hierarchy_bounds("self")
+            .expect("known root should produce a partial report");
+        assert_bounds(report.root_bounds(), (0.0, 0.0, 2.0, 2.0));
+        insta::assert_debug_snapshot!(report.diagnostics(), @r#"
+        [
+            Cycle {
+                cells: [
+                    "self",
+                ],
+                source_cell: "self",
+                element_index: 1,
+                target_cell: "self",
+            },
+        ]
+        "#);
+    }
+
+    #[test]
+    fn mutual_cycle_is_deterministic() {
+        let mut a = Cell::new("a");
+        a.add(Reference::new("b"));
+        let mut b = Cell::new("b");
+        b.add(Reference::new("a"));
+        let mut library = Library::new("bounds");
+        library.add_cell(b);
+        library.add_cell(a);
+
+        let report = library
+            .hierarchy_bounds("a")
+            .expect("known root should produce a partial report");
+        assert_eq!(report.root_bounds(), None);
+        insta::assert_debug_snapshot!(report.diagnostics(), @r#"
+        [
+            Cycle {
+                cells: [
+                    "a",
+                    "b",
+                ],
+                source_cell: "a",
+                element_index: 0,
+                target_cell: "b",
+            },
+        ]
+        "#);
+    }
+
+    #[test]
+    fn cyclic_component_bounds_are_root_and_sibling_order_independent() {
+        fn library(reverse_top_references: bool) -> Library {
+            let mut a = Cell::new("a");
+            a.add(rectangle(0.0, 0.0, 1.0, 1.0));
+            a.add(Reference::new(Reference::new("c")));
+            let mut c = Cell::new("c");
+            c.add(rectangle(10.0, 20.0, 11.0, 21.0));
+            c.add(Reference::new("a"));
+            let mut top = Cell::new("top");
+            let references = if reverse_top_references {
+                ["c", "a"]
+            } else {
+                ["a", "c"]
+            };
+            for target in references {
+                top.add(Reference::new(target));
+            }
+            let mut library = Library::new("bounds");
+            library.add_cell(c);
+            library.add_cell(top);
+            library.add_cell(a);
+            library
+        }
+
+        let ordered_library = library(false);
+        let from_a = ordered_library
+            .hierarchy_bounds("a")
+            .expect("cyclic component should produce partial bounds");
+        let from_c = ordered_library
+            .hierarchy_bounds("c")
+            .expect("cyclic component should produce partial bounds");
+        let from_top = ordered_library
+            .hierarchy_bounds("top")
+            .expect("parent should produce partial bounds");
+        let reversed_top = library(true)
+            .hierarchy_bounds("top")
+            .expect("reordered parent should produce partial bounds");
+
+        for report in [&from_a, &from_c, &from_top, &reversed_top] {
+            assert_bounds(
+                report.cell_bounds().get("a").copied().flatten(),
+                (0.0, 0.0, 11.0, 21.0),
+            );
+            assert_bounds(
+                report.cell_bounds().get("c").copied().flatten(),
+                (0.0, 0.0, 11.0, 21.0),
+            );
+            assert_eq!(
+                report.reference_bounds().get(&ReferenceLocation {
+                    cell_name: "a".to_string(),
+                    element_index: 1,
+                }),
+                Some(&Some(WorldBounds::new(0.0, 0.0, 11.0, 21.0))),
+            );
+            assert_eq!(
+                report.reference_bounds().get(&ReferenceLocation {
+                    cell_name: "c".to_string(),
+                    element_index: 1,
+                }),
+                Some(&Some(WorldBounds::new(0.0, 0.0, 11.0, 21.0))),
+            );
+            assert_eq!(report.diagnostics(), from_a.diagnostics());
+        }
+    }
+
+    #[test]
+    fn parent_bounds_cover_geometry_reached_before_cycle_cutoff() {
+        let mut a = Cell::new("a");
+        a.add(rectangle(0.0, 0.0, 1.0, 1.0));
+        a.add(Reference::new("b"));
+        let mut b = Cell::new("b");
+        b.add(rectangle(100.0, 0.0, 101.0, 1.0));
+        b.add(Reference::new("a"));
+        let mut top = Cell::new("top");
+        top.add(Reference::new("a"));
+        let mut library = Library::new("bounds");
+        library.add_cell(top);
+        library.add_cell(b);
+        library.add_cell(a);
+
+        let report = library
+            .hierarchy_bounds("top")
+            .expect("known root should produce conservative cyclic bounds");
+
+        for cell_name in ["top", "a", "b"] {
+            assert_bounds(
+                report.cell_bounds().get(cell_name).copied().flatten(),
+                (0.0, 0.0, 101.0, 1.0),
+            );
+        }
+        for cell_name in ["a", "b"] {
+            assert_eq!(
+                report.reference_bounds().get(&ReferenceLocation {
+                    cell_name: cell_name.to_string(),
+                    element_index: 1,
+                }),
+                Some(&Some(WorldBounds::new(0.0, 0.0, 101.0, 1.0))),
+            );
+        }
+        insta::assert_debug_snapshot!(report.diagnostics(), @r#"
+        [
+            Cycle {
+                cells: [
+                    "a",
+                    "b",
+                ],
+                source_cell: "a",
+                element_index: 1,
+                target_cell: "b",
+            },
+        ]
+        "#);
+    }
+
+    #[test]
+    fn dependent_cyclic_components_expand_bottom_up() {
+        let mut a1 = Cell::new("a1");
+        a1.add(Reference::new("a2"));
+        a1.add(Reference::new("b1"));
+        let mut a2 = Cell::new("a2");
+        a2.add(Reference::new("a1"));
+        let mut b1 = Cell::new("b1");
+        b1.add(Reference::new("b2"));
+        let mut b2 = Cell::new("b2");
+        b2.add(rectangle(100.0, 0.0, 101.0, 1.0));
+        b2.add(Reference::new("b1"));
+        let mut top = Cell::new("top");
+        top.add(Reference::new("a1"));
+        let mut library = Library::new("bounds");
+        for cell in [top, b2, b1, a2, a1] {
+            library.add_cell(cell);
+        }
+
+        let report = library
+            .hierarchy_bounds("top")
+            .expect("known root should produce conservative cyclic bounds");
+
+        assert_bounds(report.root_bounds(), (100.0, 0.0, 101.0, 1.0));
+    }
+
+    #[test]
+    fn non_finite_elements_are_reported_and_never_returned() {
+        let mut top = Cell::new("top");
+        top.add(Polygon::new(
+            [
+                Point::float(f64::NAN, 0.0, 1.0),
+                point(1.0, 1.0),
+                point(2.0, 0.0),
+            ],
+            Layer::new(1),
+            DataType::new(0),
+        ));
+        top.add(rectangle(10.0, 20.0, 30.0, 40.0));
+        top.add(
+            Reference::new(rectangle(0.0, 0.0, 1.0, 1.0))
+                .with_grid(Grid::default().with_magnification(f64::INFINITY)),
+        );
+        let mut library = Library::new("bounds");
+        library.add_cell(top);
+
+        let report = library
+            .hierarchy_bounds("top")
+            .expect("invalid elements should be non-fatal");
+        assert_bounds(report.root_bounds(), (10.0, 20.0, 30.0, 40.0));
+        insta::assert_debug_snapshot!(report.diagnostics(), @r#"
+        [
+            NonFiniteElement {
+                source_cell: "top",
+                element_index: 0,
+            },
+            NonFiniteElement {
+                source_cell: "top",
+                element_index: 2,
+            },
+        ]
+        "#);
+        assert!(
+            WorldBounds::new(f64::NAN, 0.0, 1.0, 1.0)
+                .transformed_by_grid(&Grid::default())
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn ten_thousand_nested_inline_references_use_heap_traversal() {
+        const DEPTH: usize = 10_000;
+
+        let mut leaf = Cell::new("leaf");
+        leaf.add(rectangle(0.0, 0.0, 1.0, 1.0));
+        let mut reference = Reference::new("leaf");
+        for _ in 1..DEPTH {
+            reference = Reference::new(reference);
+        }
+        let mut top = Cell::new("top");
+        top.add(reference);
+        let mut library = Library::new("bounds");
+        library.add_cell(leaf);
+        library.add_cell(top);
+
+        let report = library
+            .hierarchy_bounds("top")
+            .expect("deep inline hierarchy should resolve");
+        assert_bounds(report.root_bounds(), (0.0, 0.0, 1.0, 1.0));
+        assert_eq!(report.reference_bounds().len(), 1);
+    }
+
+    #[test]
+    fn unknown_root_is_structured() {
+        let library = Library::new("bounds");
+        insta::assert_debug_snapshot!(library.hierarchy_bounds("missing"), @r#"
+        Err(
+            UnknownRoot {
+                cell_name: "missing",
+            },
+        )
+        "#);
+    }
+
+    #[test]
+    fn later_call_recomputes_after_mutation() {
+        let mut cell = Cell::new("top");
+        cell.add(rectangle(0.0, 0.0, 1.0, 1.0));
+        let mut library = Library::new("bounds");
+        library.add_cell(cell);
+
+        let before = library
+            .hierarchy_bounds("top")
+            .expect("first query should resolve");
+        assert_bounds(before.root_bounds(), (0.0, 0.0, 1.0, 1.0));
+
+        library
+            .get_cell_mut("top")
+            .expect("cell should exist")
+            .add(rectangle(10.0, 20.0, 30.0, 40.0));
+        let after = library
+            .hierarchy_bounds("top")
+            .expect("second query should resolve");
+        assert_bounds(after.root_bounds(), (0.0, 0.0, 30.0, 40.0));
+    }
+}

--- a/crates/gdsr/src/lib.rs
+++ b/crates/gdsr/src/lib.rs
@@ -9,6 +9,7 @@ mod error;
 mod flatten;
 mod geometry;
 mod grid;
+mod hierarchy_bounds;
 pub(crate) mod io;
 mod library;
 mod point;
@@ -33,6 +34,10 @@ pub use elements::{
 pub use error::GdsError;
 pub use flatten::FlattenOptions;
 pub use grid::Grid;
+pub use hierarchy_bounds::{
+    HierarchyBoundsDiagnostic, HierarchyBoundsError, HierarchyBoundsReport, ReferenceLocation,
+    WorldBounds,
+};
 pub use io::write::svg::cell_to_svg;
 pub use io::write::{
     GdsConversionReport, GdsFileWriter, GdsQuantization, GdsRoundingPolicy, GdsStreamWriter,

--- a/docs/hierarchy-bounds.md
+++ b/docs/hierarchy-bounds.md
@@ -1,0 +1,41 @@
+# Hierarchy bounds
+
+Use `Library::hierarchy_bounds` to calculate axis-aligned bounds for a cell and
+the hierarchy reachable from it:
+
+```rs
+let report = library.hierarchy_bounds("top")?;
+
+if let Some(bounds) = report.root_bounds() {
+    println!(
+        "({}, {}) to ({}, {})",
+        bounds.min_x, bounds.min_y, bounds.max_x, bounds.max_y
+    );
+}
+```
+
+Coordinates are physical world values. Cell bounds use each cell's local
+coordinate space. Reference bounds use the local coordinate space of the cell
+containing that reference.
+
+The report includes bounds for every reachable cell and one aggregate bound for
+each reference element. An array reference has one entry covering its whole
+grid; it is not expanded into individual members. Empty cells and references
+without geometry have `None` bounds.
+
+Dangling references and hierarchy cycles do not fail the query. Recursive
+traversal stops at repeated cells. Bounds for cyclic cells conservatively cover
+one finite traversal through the strongly connected component and remain
+independent of the requested root and traversal order. One cycle diagnostic
+lists the sorted component cells and a representative cycle edge. Valid sibling
+geometry remains in the result.
+
+Elements with non-finite coordinates or reference transforms are also omitted
+and diagnosed, so a report never contains `NaN` or infinite bounds. Path widths
+use their physical magnitude. Positive path extensions conservatively expand
+the axis-aligned bounds; negative extensions never shrink them.
+
+Requesting an unknown root is the only fatal error.
+
+Each call creates a detached snapshot with a query-local memo. Call the method
+again after mutating the library; no cache invalidation is required.

--- a/zensical.toml
+++ b/zensical.toml
@@ -12,7 +12,8 @@ dev_addr = "localhost:3000"
 
 nav = [
     { "Home" = "index.md" },
-    { "Units" = "units.md" }
+    { "Units" = "units.md" },
+    { "Hierarchy bounds" = "hierarchy-bounds.md" }
 ]
 
 [project.theme]


### PR DESCRIPTION
## Summary

Add an authoritative hierarchy-aware bounds report with cached child bounds, transformed instance bounds, deterministic diagnostics, and explicit empty/cyclic results. The viewer now consumes the core bounds logic and all deep hierarchy paths use heap-backed traversal. Closes #316.

## Test Plan

Full workspace tests, strict Clippy, warning-denied rustdoc, docs build, and pre-commit hooks.