### PR TITLE
Clarify README and docs-only CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,8 @@ jobs:
 
     needs: determine_changes
 
+    if: ${{ (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
+
     permissions:
       id-token: write
 
@@ -299,12 +301,12 @@ jobs:
           require_success "determine changes" "$DETERMINE_CHANGES_RESULT"
           require_success "pre commit" "$PRE_COMMIT_RESULT"
           require_success "Build docs" "$BUILD_DOCS_RESULT"
-          require_success "coverage" "$COVERAGE_RESULT"
 
           if [ "$CODE_CHANGED" != "true" ] && [ "$CODE_CHANGED" != "false" ]; then
             echo "::error::determine changes produced unexpected code output '$CODE_CHANGED'"
             exit 1
           fi
 
+          require_code_validation "coverage" "$COVERAGE_RESULT"
           require_code_validation "cargo test" "$CARGO_TEST_RESULT"
           require_code_validation "benchmarks" "$BENCHMARKS_RESULT"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@ GDSII manipulation, written in Rust.
 </div>
 
 > [!WARNING]
-> This is a work in progress and is not yet ready for production use.
+> This is a work in progress and is not yet ready for production use.\
+> Most of the work on this project is done by AI.
+
+GDSR is both a GDSII viewer and a Rust crate for reading and writing GDSII files.
 
 ## Installation
 


### PR DESCRIPTION
## Summary

Clarify that most project work is done by AI and describe GDSR as both a GDSII viewer and Rust crate. Skip coverage for documentation-only changes while allowing that expected skip through the CI gate.

## Test Plan

`pinact run .github/workflows/ci.yml` and `uvx prek run -a`